### PR TITLE
Add AgentContext for context propagation through agent hierarchy

### DIFF
--- a/docs/agent_context.md
+++ b/docs/agent_context.md
@@ -1,0 +1,170 @@
+# AgentContext and State.metadata — Usage Guide
+
+Sagents provides two mechanisms for attaching data to agents. They serve
+different purposes and should not be confused. This guide explains when to use
+each, and how to update your code.
+
+## Quick decision
+
+Ask yourself: **does this value need to survive after the process dies?**
+
+- **Yes** → use `State.metadata` (persisted to the database, restored on
+  restart)
+- **No** → use `AgentContext` (lives in the process dictionary, propagated to
+  sub-agents automatically)
+
+## When to use AgentContext
+
+Use `AgentContext` for ambient, application-level values that every agent and
+tool in the hierarchy needs to read but that have no reason to be stored in the
+database. These values originate at the application boundary (your LiveView,
+controller, or background job) and flow downward through the entire agent tree.
+
+**Examples**: `tenant_id`, `user_id`, `trace_id`, OpenTelemetry span context,
+feature flags, session tokens.
+
+### How to pass it
+
+Pass `:agent_context` when starting your agent supervisor:
+
+```elixir
+AgentSupervisor.start_link(
+  agent: agent,
+  agent_context: %{tenant_id: tenant_id, user_id: current_user.id}
+)
+```
+
+### How to read it (in tools)
+
+```elixir
+defp my_tool_function(_args, _context) do
+  tenant_id = AgentContext.fetch(:tenant_id)
+  MyApp.Repo.all(from r in Record, where: r.tenant_id == ^tenant_id)
+end
+```
+
+### How to read it (in middleware)
+
+```elixir
+def before_model(state, _config) do
+  user_id = AgentContext.fetch(:user_id)
+  Logger.metadata(user_id: user_id)
+  {:ok, state}
+end
+```
+
+### Writing to AgentContext at runtime
+
+If middleware or tools need to add derived values during execution:
+
+```elixir
+AgentContext.put(:request_id, "req-123")
+AgentContext.merge(%{correlation_id: "corr-456", region: "us-east-1"})
+```
+
+These writes only affect the current process's dictionary and are not persisted.
+
+## When to use State.metadata
+
+Use `State.metadata` for values that are part of the conversation's persistent
+state. These are serialized to JSONB via `StateSerializer` and survive process
+restarts, Horde redistribution, and conversation restoration.
+
+**Examples**: generated conversation title, middleware working state (e.g., "has
+this middleware already run its one-time setup?"), user preferences set during
+the conversation.
+
+### How to read/write it (in middleware)
+
+```elixir
+def before_model(state, _config) do
+  case State.get_metadata(state, "conversation_title") do
+    nil ->
+      # First time — trigger title generation
+      {:ok, State.put_metadata(state, "title_triggered", true)}
+    _title ->
+      {:ok, state}
+  end
+end
+```
+
+### Important constraints
+
+- **Use string keys** for metadata values. They are serialized to JSONB, which
+  requires string keys. Atom keys will work at runtime but may cause issues on
+  deserialization.
+- **Never store non-serializable values** (PIDs, references, functions) in
+  metadata. They will be lost on serialization. Use `AgentContext` with restore
+  functions for such values.
+
+## Migrating existing code
+
+### If you were storing tenant_id / user_id in State.metadata
+
+**Before** (works but wrong store):
+
+```elixir
+# At agent start
+state = State.new!(%{metadata: %{"tenant_id" => tenant_id}})
+
+# In a tool
+tenant_id = context[:state].metadata["tenant_id"]
+```
+
+**After** (recommended):
+
+```elixir
+# At agent start
+AgentSupervisor.start_link(
+  agent: agent,
+  agent_context: %{tenant_id: tenant_id}
+)
+
+# In a tool
+tenant_id = AgentContext.fetch(:tenant_id)
+```
+
+Why: tenant_id doesn't need to be persisted to the database, and `AgentContext`
+propagates automatically to sub-agents without threading the state struct
+through every function.
+
+### If you were passing context through custom_context manually
+
+**Before** (manual threading):
+
+```elixir
+# Building chain with manual context
+custom_context = %{tenant_id: tenant_id, trace_id: trace_id}
+chain = LLMChain.new!(%{...}) |> LLMChain.update_custom_context(custom_context)
+```
+
+**After** (automatic propagation):
+
+```elixir
+# Set once at the boundary
+AgentSupervisor.start_link(
+  agent: agent,
+  agent_context: %{tenant_id: tenant_id, trace_id: trace_id}
+)
+
+# Available everywhere — tools, middleware, sub-agents
+AgentContext.fetch(:tenant_id)
+```
+
+### If you have middleware using on_fork_context for OTel or Logger
+
+No changes needed. `on_fork_context/2` continues to work as before. The new
+`put/2` and `merge/1` functions are additive — existing
+`init/get/fetch/fork/fork_with_middleware` APIs are unchanged.
+
+## Summary table
+
+|                               | `AgentContext`                              | `State.metadata`                             |
+| ----------------------------- | ------------------------------------------- | -------------------------------------------- |
+| **Storage**                   | Process dictionary                          | Ecto field on `State`                        |
+| **Persisted to DB?**          | No                                          | Yes (serialized to JSONB)                    |
+| **Survives restart?**         | No                                          | Yes                                          |
+| **Propagated to sub-agents?** | Yes (automatic via fork)                    | Yes (inherited from parent)                  |
+| **Access pattern**            | `AgentContext.fetch(:key)`                  | `State.get_metadata(state, key)`             |
+| **Requires state param?**     | No                                          | Yes                                          |
+| **Use for**                   | tenant_id, trace_id, user_id, feature flags | conversation_title, middleware working state |

--- a/lib/sagents.ex
+++ b/lib/sagents.ex
@@ -8,6 +8,7 @@ defmodule Sagents do
   - **TODO Management**: Task planning and progress tracking
   - **Virtual Filesystem**: File operations for agent workflows
   - **Task Delegation**: Hierarchical sub-agents for complex tasks
+  - **Context Propagation**: Pass tenant IDs, trace IDs, and feature flags through agent hierarchies via `Sagents.AgentContext`
   - **Context Management**: Automatic summarization and optimization
   - **Observability**: Custom telemetry and tracing via middleware callbacks (see [Observability Guide](docs/observability.md))
 

--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -243,11 +243,11 @@ defmodule Sagents.Agent do
         false ->
           # Append user middleware to defaults (inject agent_id, model, and filesystem_scope)
           build_default_middleware(model, agent_id, opts) ++
-            inject_agent_context(user_middleware, agent_id, model, filesystem_scope)
+            inject_middleware_init_params(user_middleware, agent_id, model, filesystem_scope)
 
         true ->
           # Use only user-provided middleware (inject agent_id, model, and filesystem_scope)
-          inject_agent_context(user_middleware, agent_id, model, filesystem_scope)
+          inject_middleware_init_params(user_middleware, agent_id, model, filesystem_scope)
       end
 
     # Initialize middleware
@@ -260,8 +260,9 @@ defmodule Sagents.Agent do
     end
   end
 
-  # Inject agent_id, model, and filesystem_scope into user middleware configurations
-  defp inject_agent_context(middleware_list, agent_id, model, filesystem_scope) do
+  # Inject agent_id, model, and filesystem_scope into user middleware configurations.
+  # Named to avoid confusion with AgentContext (which is process-scoped runtime context).
+  defp inject_middleware_init_params(middleware_list, agent_id, model, filesystem_scope) do
     base_context =
       if filesystem_scope do
         [agent_id: agent_id, model: model, filesystem_scope: filesystem_scope]

--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -42,6 +42,7 @@ defmodule Sagents.Agent do
   require Logger
 
   alias __MODULE__
+  alias Sagents.AgentContext
   alias Sagents.Middleware
   alias Sagents.State
   alias LangChain.LangChainError
@@ -912,7 +913,9 @@ defmodule Sagents.Agent do
         state: state,
         # Make parent agent's middleware and tools available to tools (e.g., SubAgent middleware)
         parent_middleware: agent.middleware,
-        parent_tools: agent.tools
+        parent_tools: agent.tools,
+        # Snapshot of the process-local agent context for tool access
+        agent_context: AgentContext.get()
       }
     }
 

--- a/lib/sagents/agent_context.ex
+++ b/lib/sagents/agent_context.ex
@@ -16,7 +16,9 @@ defmodule Sagents.AgentContext do
   1. **Your application** passes `:agent_context` when starting an agent
   2. **AgentSupervisor** forwards the context to its child AgentServer
   3. **AgentServer.init/1** calls `AgentContext.init/1` to store it in the process dictionary
-  4. **Agent.execute/3** runs in a `Task.async`, which inherits the caller's process dictionary,
+  4. **Agent.execute/3** runs in a `Task.async`. Since `Task.async` does NOT
+     inherit the caller's process dictionary, AgentServer explicitly forks the
+     context via `fork_with_middleware/1` and calls `init/1` in the task,
      so tools and callbacks can read context via `AgentContext.get/0`
   5. **SubAgent middleware** calls `AgentContext.fork_with_middleware/1` to snapshot
      context before spawning a child SubAgentServer. Each middleware's

--- a/lib/sagents/agent_context.ex
+++ b/lib/sagents/agent_context.ex
@@ -1,0 +1,86 @@
+defmodule Sagents.AgentContext do
+  @moduledoc """
+  Process-local context propagation for agent hierarchies.
+
+  Provides a mechanism to propagate application-level context (e.g., OpenTelemetry
+  trace IDs, tenant IDs, feature flags) through the agent execution tree.
+
+  Context is stored in the process dictionary for zero-cost reads within a process.
+  At process boundaries (e.g., spawning sub-agents), use `fork/1` to snapshot the
+  context for explicit passing to the child process.
+
+  ## Usage
+
+      # At the application boundary (e.g., LiveView or API controller)
+      AgentSupervisor.start_link(
+        agent: agent,
+        agent_context: %{trace_id: "abc123", tenant_id: 42}
+      )
+
+      # Inside a tool function (reads from chain's custom_context or PD)
+      ctx = AgentContext.get()
+      trace_id = AgentContext.fetch(:trace_id)
+
+      # When spawning a sub-agent (cross-process boundary)
+      child_context = AgentContext.fork(fn ctx -> Map.put(ctx, :parent_span_id, current_span()) end)
+      SubAgentServer.start_link(subagent: subagent, agent_context: child_context)
+  """
+
+  @key {Sagents, :agent_context}
+
+  @doc """
+  Initialize the agent context for the current process.
+
+  Sets the context map in the process dictionary. Should be called once
+  during process initialization (e.g., in `GenServer.init/1`).
+
+  Returns `:ok`.
+  """
+  @spec init(map()) :: :ok
+  def init(context) when is_map(context) do
+    Process.put(@key, context)
+    :ok
+  end
+
+  @doc """
+  Read the full context map for the current process.
+
+  Returns an empty map if no context has been initialized.
+  """
+  @spec get() :: map()
+  def get do
+    Process.get(@key, %{})
+  end
+
+  @doc """
+  Fetch a single key from the context, returning a default if not found.
+  """
+  @spec fetch(atom() | term(), term()) :: term()
+  def fetch(key, default \\ nil) do
+    Map.get(get(), key, default)
+  end
+
+  @doc """
+  Create a copy of the current context suitable for passing to a child process.
+
+  An optional transform function can modify the context before it is handed off.
+  This is useful for adding child-specific metadata (e.g., a `parent_span_id`).
+
+  ## Examples
+
+      # Simple copy
+      child_ctx = AgentContext.fork()
+
+      # With transform
+      child_ctx = AgentContext.fork(fn ctx -> Map.put(ctx, :parent_span_id, span_id) end)
+  """
+  @spec fork((map() -> map()) | nil) :: map()
+  def fork(transform \\ nil) do
+    ctx = get()
+
+    case transform do
+      nil -> ctx
+      fun when is_function(fun, 1) -> fun.(ctx)
+    end
+  end
+end

--- a/lib/sagents/agent_context.ex
+++ b/lib/sagents/agent_context.ex
@@ -80,7 +80,7 @@ defmodule Sagents.AgentContext do
   | **Storage** | Process dictionary | Ecto field on `State` |
   | **Persisted to DB?** | No | Yes (serialized to JSONB) |
   | **Survives restart?** | No | Yes |
-  | **Propagated to sub-agents?** | Yes (automatic) | No (intentional isolation) |
+  | **Propagated to sub-agents?** | Yes (automatic via fork) | Yes (inherited from parent) |
   | **Access pattern** | `AgentContext.fetch(:key)` | `State.get_metadata(state, key)` |
   | **Requires state param?** | No | Yes |
   | **Use for** | tenant_id, trace_id, user_id, feature flags | conversation_title, middleware working state |

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -317,6 +317,9 @@ defmodule Sagents.AgentServer do
   - `:conversation_id` - Optional conversation identifier for message persistence (default: nil)
   - `:agent_persistence` - Module implementing `Sagents.AgentPersistence` for state snapshots (default: nil)
   - `:display_message_persistence` - Module implementing `Sagents.DisplayMessagePersistence` for display messages (default: nil)
+  - `:agent_context` - Application-level context map propagated through the agent hierarchy (default: `%{}`).
+    Accessible via `AgentContext.get()` in the agent process and all sub-agent processes.
+    See `Sagents.AgentContext` for details.
 
   ## Examples
 
@@ -357,6 +360,12 @@ defmodule Sagents.AgentServer do
         agent: agent,
         pubsub: {Phoenix.PubSub, :my_app_pubsub},
         debug_pubsub: {Phoenix.PubSub, :my_debug_pubsub}
+      )
+
+      # With application context (propagated to sub-agents)
+      {:ok, pid} = AgentServer.start_link(
+        agent: agent,
+        agent_context: %{tenant_id: 42, trace_id: "abc123"}
       )
   """
   def start_link(opts) do

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -210,6 +210,7 @@ defmodule Sagents.AgentServer do
   require Logger
 
   alias Sagents.Agent
+  alias Sagents.AgentContext
   alias Sagents.State
   alias Sagents.AgentSupervisor
   alias Sagents.Middleware
@@ -256,7 +257,11 @@ defmodule Sagents.AgentServer do
       :presence_module,
       # Whether this server was restored from persisted state (vs fresh start)
       # Used to broadcast :node_transferred event on startup after Horde migration
-      restored: false
+      restored: false,
+      # Application-level context map propagated through the agent hierarchy.
+      # Set via :agent_context option; accessible via AgentContext.get() in
+      # the process and its Task.async children.
+      agent_context: %{}
     ]
 
     @type t :: %__MODULE__{
@@ -287,7 +292,8 @@ defmodule Sagents.AgentServer do
             agent_persistence: module() | nil,
             display_message_persistence: module() | nil,
             presence_module: module() | nil,
-            restored: boolean()
+            restored: boolean(),
+            agent_context: map()
           }
   end
 
@@ -1289,6 +1295,10 @@ defmodule Sagents.AgentServer do
     # When set, agent will track presence on "agent_server:presence" topic
     presence_module = Keyword.get(opts, :presence_module)
 
+    # Application-level context for propagation through agent hierarchy
+    agent_context = Keyword.get(opts, :agent_context, %{})
+    AgentContext.init(agent_context)
+
     server_state = %ServerState{
       agent: updated_agent,
       state: state,
@@ -1309,7 +1319,8 @@ defmodule Sagents.AgentServer do
       agent_persistence: agent_persistence,
       display_message_persistence: display_message_persistence,
       presence_module: presence_module,
-      restored: Keyword.get(opts, :restored, false)
+      restored: Keyword.get(opts, :restored, false),
+      agent_context: agent_context
     }
 
     # Start the inactivity timer

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -1410,14 +1410,18 @@ defmodule Sagents.AgentServer do
     # Reset inactivity timer on execution start
     new_state = reset_inactivity_timer(new_state)
 
+    # Fork context through middleware so process-local state (e.g. OTel spans)
+    # is propagated into the Task.async process. Task.async does NOT inherit
+    # the caller's process dictionary.
+    forked_ctx = AgentContext.fork_with_middleware(new_state.agent.middleware)
+
     # Start async execution
     task =
       Task.async(fn ->
+        AgentContext.init(forked_ctx)
         execute_agent(new_state, pubsub_callbacks)
       end)
 
-    # Store task reference if needed, or just let it run
-    # For now, we'll handle the result in handle_info
     {:reply, :ok, Map.put(new_state, :task, task)}
   end
 
@@ -1470,9 +1474,13 @@ defmodule Sagents.AgentServer do
     # Reset inactivity timer on resume
     new_state = reset_inactivity_timer(new_state)
 
+    # Fork context through middleware (same as execute handler)
+    forked_ctx = AgentContext.fork_with_middleware(new_state.agent.middleware)
+
     # Resume execution async (callbacks are built in resume_agent)
     task =
       Task.async(fn ->
+        AgentContext.init(forked_ctx)
         resume_agent(new_state, decisions)
       end)
 

--- a/lib/sagents/agent_supervisor.ex
+++ b/lib/sagents/agent_supervisor.ex
@@ -28,6 +28,8 @@ defmodule Sagents.AgentSupervisor do
   - `:conversation_id` - Optional conversation identifier for message persistence (optional, default: nil)
   - `:agent_persistence` - Module implementing `Sagents.AgentPersistence` (optional, default: nil)
   - `:display_message_persistence` - Module implementing `Sagents.DisplayMessagePersistence` (optional, default: nil)
+  - `:agent_context` - Application-level context map propagated through the agent hierarchy (optional, default: `%{}`).
+    See `Sagents.AgentContext` for details.
 
   ## Examples
 
@@ -146,6 +148,8 @@ defmodule Sagents.AgentSupervisor do
   - `:conversation_id` - Optional conversation identifier for message persistence (optional, default: nil)
   - `:agent_persistence` - Module implementing `Sagents.AgentPersistence` (optional, default: nil)
   - `:display_message_persistence` - Module implementing `Sagents.DisplayMessagePersistence` (optional, default: nil)
+  - `:agent_context` - Application-level context map propagated through the agent hierarchy (optional, default: `%{}`).
+    See `Sagents.AgentContext` for details.
 
   ## Examples
 
@@ -176,6 +180,12 @@ defmodule Sagents.AgentSupervisor do
         agent: agent,
         pubsub: {Phoenix.PubSub, :my_app_pubsub},
         debug_pubsub: {Phoenix.PubSub, :my_debug_pubsub}
+      )
+
+      # With application context (propagated to sub-agents)
+      {:ok, sup_pid} = AgentSupervisor.start_link(
+        agent: agent,
+        agent_context: %{tenant_id: 42, trace_id: "abc123"}
       )
   """
   @spec start_link(keyword()) :: Supervisor.on_start()

--- a/lib/sagents/agent_supervisor.ex
+++ b/lib/sagents/agent_supervisor.ex
@@ -311,6 +311,7 @@ defmodule Sagents.AgentSupervisor do
     agent_persistence = Keyword.get(config, :agent_persistence)
     display_message_persistence = Keyword.get(config, :display_message_persistence)
     presence_module = Keyword.get(config, :presence_module)
+    agent_context = Keyword.get(config, :agent_context)
 
     # Build AgentServer options
     agent_server_opts = [
@@ -366,6 +367,12 @@ defmodule Sagents.AgentSupervisor do
     agent_server_opts =
       if presence_module,
         do: Keyword.put(agent_server_opts, :presence_module, presence_module),
+        else: agent_server_opts
+
+    # Add agent_context if provided
+    agent_server_opts =
+      if agent_context,
+        do: Keyword.put(agent_server_opts, :agent_context, agent_context),
         else: agent_server_opts
 
     # Build child specifications

--- a/lib/sagents/middleware.ex
+++ b/lib/sagents/middleware.ex
@@ -66,6 +66,26 @@ defmodule Sagents.Middleware do
 
   - Module name: `MyMiddleware`
   - Tuple with options: `{MyMiddleware, [enabled: true]}`
+
+  ## Choosing Between AgentContext and State.metadata
+
+  When writing middleware, you will often need to store and retrieve data.
+  Choose the right store based on the persistence test:
+
+  - **Use `AgentContext`** for process-local state that middleware needs to
+    propagate to child processes. Implement `on_fork_context/2` to inject
+    values and register restore functions.
+
+    Example: An OpenTelemetry middleware storing span context.
+
+  - **Use `State.metadata`** for data that must survive serialization and
+    be available after conversation restoration.
+
+    Example: ConversationTitle storing the generated title.
+
+  Never store non-serializable values (PIDs, references, functions) in
+  `State.metadata` — they will be lost on serialization. Use `AgentContext`
+  with restore functions for such values.
   """
   alias Sagents.State
   alias Sagents.MiddlewareEntry

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -440,7 +440,8 @@ defmodule Sagents.Middleware.SubAgent do
                 instructions: instructions,
                 compiled_agent: compiled.agent,
                 initial_messages: compiled.initial_messages || [],
-                until_tool: until_tool
+                until_tool: until_tool,
+                parent_state: context[:state]
               )
 
             agent ->
@@ -449,7 +450,8 @@ defmodule Sagents.Middleware.SubAgent do
                 parent_agent_id: config.agent_id,
                 instructions: instructions,
                 agent_config: agent,
-                until_tool: until_tool
+                until_tool: until_tool,
+                parent_state: context[:state]
               )
           end
 
@@ -537,7 +539,8 @@ defmodule Sagents.Middleware.SubAgent do
           SubAgent.new_from_config(
             parent_agent_id: config.agent_id,
             instructions: instructions,
-            agent_config: agent_config
+            agent_config: agent_config,
+            parent_state: context[:state]
           )
 
         # Fork agent context for the child process, giving middleware a chance

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -416,6 +416,14 @@ defmodule Sagents.Middleware.SubAgent do
           | {:interrupt, map()}
           | {:error, String.t()}
   def start_subagent(instructions, subagent_type, args, context, config) do
+    # Restore AgentContext from the snapshot taken at build_chain time.
+    # Needed because async: true tools run in Task.async (LangChain),
+    # which does not inherit the caller's process dictionary. Without this,
+    # fork_with_middleware below starts from an empty context.
+    if agent_ctx = context[:agent_context] do
+      AgentContext.init(agent_ctx)
+    end
+
     Logger.debug("Starting SubAgent: #{subagent_type}")
 
     # Get agent from lookup map

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -140,6 +140,7 @@ defmodule Sagents.Middleware.SubAgent do
 
   require Logger
 
+  alias Sagents.AgentContext
   alias Sagents.SubAgent
   alias Sagents.SubAgentServer
   alias Sagents.SubAgentsDynamicSupervisor
@@ -456,11 +457,15 @@ defmodule Sagents.Middleware.SubAgent do
         # Uses existing Sagents.Registry for process lookup
         supervisor_name = SubAgentsDynamicSupervisor.get_name(config.agent_id)
 
+        # Fork agent context for the child process
+        child_context = AgentContext.fork()
+
         # Spawn SubAgentServer under supervision
         # SubAgentServer will register itself in Sagents.Registry
         child_spec = %{
           id: subagent.id,
-          start: {SubAgentServer, :start_link, [[subagent: subagent]]},
+          start:
+            {SubAgentServer, :start_link, [[subagent: subagent, agent_context: child_context]]},
           # Don't restart on crash
           restart: :temporary
         }
@@ -533,12 +538,16 @@ defmodule Sagents.Middleware.SubAgent do
             agent_config: agent_config
           )
 
+        # Fork agent context for the child process
+        child_context = AgentContext.fork()
+
         # Get supervisor and start SubAgent (same as pre-configured)
         supervisor_name = SubAgentsDynamicSupervisor.get_name(config.agent_id)
 
         child_spec = %{
           id: subagent.id,
-          start: {SubAgentServer, :start_link, [[subagent: subagent]]},
+          start:
+            {SubAgentServer, :start_link, [[subagent: subagent, agent_context: child_context]]},
           restart: :temporary
         }
 

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -457,8 +457,10 @@ defmodule Sagents.Middleware.SubAgent do
         # Uses existing Sagents.Registry for process lookup
         supervisor_name = SubAgentsDynamicSupervisor.get_name(config.agent_id)
 
-        # Fork agent context for the child process
-        child_context = AgentContext.fork()
+        # Fork agent context for the child process, giving middleware a chance
+        # to inject process-local state (e.g., tracing context)
+        parent_middleware = Map.get(context, :parent_middleware, [])
+        child_context = AgentContext.fork_with_middleware(parent_middleware)
 
         # Spawn SubAgentServer under supervision
         # SubAgentServer will register itself in Sagents.Registry
@@ -538,8 +540,9 @@ defmodule Sagents.Middleware.SubAgent do
             agent_config: agent_config
           )
 
-        # Fork agent context for the child process
-        child_context = AgentContext.fork()
+        # Fork agent context for the child process, giving middleware a chance
+        # to inject process-local state (e.g., tracing context)
+        child_context = AgentContext.fork_with_middleware(parent_middleware)
 
         # Get supervisor and start SubAgent (same as pre-configured)
         supervisor_name = SubAgentsDynamicSupervisor.get_name(config.agent_id)

--- a/lib/sagents/state.ex
+++ b/lib/sagents/state.ex
@@ -232,14 +232,23 @@ defmodule Sagents.State do
   end
 
   @doc """
-  Set metadata value.
+  Set a metadata value.
+
+  Metadata is persistent, conversation-scoped key-value data that is
+  serialized to the database via `StateSerializer` and survives process
+  restarts and Horde redistribution.
+
+  For ephemeral, process-scoped context that propagates to sub-agents
+  (tenant IDs, trace IDs, feature flags), see `Sagents.AgentContext` instead.
   """
   def put_metadata(%State{} = state, key, value) do
     %{state | metadata: Map.put(state.metadata, key, value)}
   end
 
   @doc """
-  Get metadata value.
+  Get a metadata value.
+
+  See `put_metadata/3` for guidance on when to use metadata vs `Sagents.AgentContext`.
   """
   def get_metadata(%State{} = state, key, default \\ nil) do
     Map.get(state.metadata, key, default)

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -105,6 +105,7 @@ defmodule Sagents.SubAgent do
   require Logger
 
   alias __MODULE__
+  alias Sagents.AgentContext
   alias Sagents.AgentUtils
   alias Sagents.State
   alias LangChain.Chains.LLMChain
@@ -197,7 +198,8 @@ defmodule Sagents.SubAgent do
     # Tools in SubAgent will access/modify SubAgent's state, not parent's
     custom_context = %{
       state: subagent_state,
-      parent_middleware: agent_config.middleware
+      parent_middleware: agent_config.middleware,
+      agent_context: AgentContext.get()
     }
 
     chain =
@@ -271,7 +273,8 @@ defmodule Sagents.SubAgent do
     # Tools in SubAgent will access/modify SubAgent's state, not parent's
     custom_context = %{
       state: subagent_state,
-      parent_middleware: compiled_agent.middleware
+      parent_middleware: compiled_agent.middleware,
+      agent_context: AgentContext.get()
     }
 
     chain =

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -168,7 +168,7 @@ defmodule Sagents.SubAgent do
   - `:parent_agent_id` - Parent's agent ID (required)
   - `:instructions` - Task description (required)
   - `:agent_config` - Agent struct with tools, model, middleware (required)
-  - `:parent_state` - Parent agent's current state (required)
+  - `:parent_state` - Parent agent's current state. Metadata will be inherited by the subagent. (optional, defaults to nil)
 
   ## Examples
 
@@ -183,6 +183,7 @@ defmodule Sagents.SubAgent do
     parent_agent_id = Keyword.fetch!(opts, :parent_agent_id)
     instructions = Keyword.fetch!(opts, :instructions)
     agent_config = Keyword.fetch!(opts, :agent_config)
+    parent_state = Keyword.get(opts, :parent_state)
 
     # Generate unique ID
     sub_agent_id = "#{parent_agent_id}-sub-#{:erlang.unique_integer([:positive])}"
@@ -193,6 +194,7 @@ defmodule Sagents.SubAgent do
     # Create SubAgent's OWN state - fresh and independent from parent
     # This ensures true isolation
     subagent_state = State.new!(%{agent_id: sub_agent_id})
+    subagent_state = inherit_metadata(subagent_state, parent_state)
 
     # Build custom_context with SubAgent's OWN state (not parent's!)
     # Tools in SubAgent will access/modify SubAgent's state, not parent's
@@ -238,7 +240,7 @@ defmodule Sagents.SubAgent do
   - `:parent_agent_id` - Parent's agent ID (required)
   - `:instructions` - Task description (required)
   - `:compiled_agent` - Pre-built Agent struct (required)
-  - `:parent_state` - Parent agent's current state (required)
+  - `:parent_state` - Parent agent's current state. Metadata will be inherited by the subagent. (optional, defaults to nil)
   - `:initial_messages` - Optional initial message sequence (default: [])
 
   ## Examples
@@ -256,6 +258,7 @@ defmodule Sagents.SubAgent do
     instructions = Keyword.fetch!(opts, :instructions)
     compiled_agent = Keyword.fetch!(opts, :compiled_agent)
     initial_messages = Keyword.get(opts, :initial_messages, [])
+    parent_state = Keyword.get(opts, :parent_state)
 
     # Generate unique ID
     sub_agent_id = "#{parent_agent_id}-sub-#{:erlang.unique_integer([:positive])}"
@@ -268,6 +271,7 @@ defmodule Sagents.SubAgent do
     # Create SubAgent's OWN state - fresh and independent from parent
     # This ensures true isolation and prevents memory waste from parent's message history
     subagent_state = State.new!(%{agent_id: sub_agent_id})
+    subagent_state = inherit_metadata(subagent_state, parent_state)
 
     # Build custom_context with SubAgent's OWN state (not parent's!)
     # Tools in SubAgent will access/modify SubAgent's state, not parent's
@@ -601,6 +605,17 @@ defmodule Sagents.SubAgent do
   end
 
   ## Private Helper Functions
+
+  # Inherit metadata from parent state into subagent state.
+  # Only metadata is inherited - messages, todos, and agent_id remain independent.
+  defp inherit_metadata(state, nil), do: state
+
+  defp inherit_metadata(state, %{metadata: parent_meta})
+       when is_map(parent_meta) and map_size(parent_meta) > 0 do
+    %{state | metadata: Map.merge(state.metadata, parent_meta)}
+  end
+
+  defp inherit_metadata(state, _), do: state
 
   defp build_initial_messages(system_prompt, instructions)
        when is_binary(system_prompt) and system_prompt != "" do

--- a/lib/sagents/sub_agent_server.ex
+++ b/lib/sagents/sub_agent_server.ex
@@ -82,6 +82,7 @@ defmodule Sagents.SubAgentServer do
   use GenServer
   require Logger
 
+  alias Sagents.AgentContext
   alias Sagents.AgentServer
   alias Sagents.ProcessRegistry
   alias Sagents.SubAgent
@@ -267,6 +268,8 @@ defmodule Sagents.SubAgentServer do
   @impl true
   def init(opts) do
     subagent = Keyword.fetch!(opts, :subagent)
+    agent_context = Keyword.get(opts, :agent_context, %{})
+    AgentContext.init(agent_context)
     started_at = System.monotonic_time(:millisecond)
 
     server_state = %ServerState{

--- a/mix.exs
+++ b/mix.exs
@@ -87,6 +87,7 @@ defmodule Sagents.MixProject do
       groups_for_modules: [
         "Core Agent": [
           Sagents.Agent,
+          Sagents.AgentContext,
           Sagents.AgentServer,
           Sagents.AgentSupervisor,
           Sagents.State,

--- a/test/sagents/agent_context_test.exs
+++ b/test/sagents/agent_context_test.exs
@@ -1,0 +1,148 @@
+defmodule Sagents.AgentContextTest do
+  use ExUnit.Case, async: true
+
+  alias Sagents.AgentContext
+
+  describe "init/1" do
+    test "sets context in process dictionary" do
+      ctx = %{trace_id: "abc", tenant_id: 42}
+      assert :ok = AgentContext.init(ctx)
+      assert AgentContext.get() == ctx
+    end
+
+    test "overwrites previous context" do
+      AgentContext.init(%{a: 1})
+      AgentContext.init(%{b: 2})
+      assert AgentContext.get() == %{b: 2}
+    end
+  end
+
+  describe "get/0" do
+    test "returns empty map when no context initialized" do
+      # Run in a fresh process to guarantee no PD pollution
+      task =
+        Task.async(fn ->
+          AgentContext.get()
+        end)
+
+      assert Task.await(task) == %{}
+    end
+
+    test "returns the initialized context" do
+      ctx = %{trace_id: "xyz"}
+      AgentContext.init(ctx)
+      assert AgentContext.get() == ctx
+    end
+  end
+
+  describe "fetch/2" do
+    test "returns value for existing key" do
+      AgentContext.init(%{tenant_id: 42})
+      assert AgentContext.fetch(:tenant_id) == 42
+    end
+
+    test "returns default for missing key" do
+      AgentContext.init(%{tenant_id: 42})
+      assert AgentContext.fetch(:missing, :default_val) == :default_val
+    end
+
+    test "returns nil as default when not specified" do
+      AgentContext.init(%{})
+      assert AgentContext.fetch(:missing) == nil
+    end
+  end
+
+  describe "fork/1" do
+    test "returns a copy of the current context" do
+      ctx = %{trace_id: "abc", tenant_id: 42}
+      AgentContext.init(ctx)
+      forked = AgentContext.fork()
+      assert forked == ctx
+    end
+
+    test "applies transform function" do
+      AgentContext.init(%{trace_id: "abc"})
+      forked = AgentContext.fork(fn ctx -> Map.put(ctx, :parent_span_id, "span-1") end)
+      assert forked == %{trace_id: "abc", parent_span_id: "span-1"}
+    end
+
+    test "fork does not modify original context" do
+      ctx = %{trace_id: "abc"}
+      AgentContext.init(ctx)
+      _forked = AgentContext.fork(fn c -> Map.put(c, :extra, true) end)
+      assert AgentContext.get() == ctx
+    end
+
+    test "returns empty map when no context set" do
+      task =
+        Task.async(fn ->
+          AgentContext.fork()
+        end)
+
+      assert Task.await(task) == %{}
+    end
+  end
+
+  describe "process isolation" do
+    test "context is isolated between processes" do
+      AgentContext.init(%{process: :parent})
+
+      task =
+        Task.async(fn ->
+          AgentContext.init(%{process: :child})
+          AgentContext.get()
+        end)
+
+      child_ctx = Task.await(task)
+      assert child_ctx == %{process: :child}
+      assert AgentContext.get() == %{process: :parent}
+    end
+  end
+
+  describe "explicit fork + init propagation" do
+    test "fork then init in child process propagates context" do
+      AgentContext.init(%{trace_id: "parent-trace"})
+      forked = AgentContext.fork()
+
+      task =
+        Task.async(fn ->
+          AgentContext.init(forked)
+          AgentContext.get()
+        end)
+
+      assert Task.await(task) == %{trace_id: "parent-trace"}
+    end
+
+    test "fork with transform propagates modified context" do
+      AgentContext.init(%{trace_id: "parent-trace"})
+      forked = AgentContext.fork(fn ctx -> Map.put(ctx, :depth, 1) end)
+
+      task =
+        Task.async(fn ->
+          AgentContext.init(forked)
+          {AgentContext.get(), AgentContext.fetch(:depth)}
+        end)
+
+      {child_ctx, depth} = Task.await(task)
+      assert child_ctx == %{trace_id: "parent-trace", depth: 1}
+      assert depth == 1
+      # Parent unchanged
+      assert AgentContext.get() == %{trace_id: "parent-trace"}
+    end
+
+    test "child init does not affect parent" do
+      AgentContext.init(%{trace_id: "parent"})
+      forked = AgentContext.fork()
+
+      task =
+        Task.async(fn ->
+          AgentContext.init(Map.put(forked, :child_only, true))
+          AgentContext.get()
+        end)
+
+      child_ctx = Task.await(task)
+      assert child_ctx == %{trace_id: "parent", child_only: true}
+      assert AgentContext.get() == %{trace_id: "parent"}
+    end
+  end
+end

--- a/test/sagents/agent_server_context_propagation_test.exs
+++ b/test/sagents/agent_server_context_propagation_test.exs
@@ -1,0 +1,205 @@
+defmodule Sagents.AgentServerContextPropagationTest do
+  @moduledoc """
+  Tests that AgentContext (including middleware-injected process-local state)
+  is properly propagated across the Task.async boundary in AgentServer's
+  execute and resume handlers.
+  """
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.{Agent, AgentContext, AgentServer, State}
+  alias Sagents.MiddlewareEntry
+
+  @process_dict_key {__MODULE__, :forked_state}
+
+  setup :set_mimic_global
+  setup :verify_on_exit!
+
+  setup_all do
+    Mimic.copy(Agent)
+    :ok
+  end
+
+  # A test middleware that uses on_fork_context to register a restore function.
+  # The restore function sets a marker in the child process's process dictionary,
+  # proving that on_fork_context callbacks fire at the Task.async boundary.
+  # This simulates what OTel middleware would do (capture span ctx, restore it).
+  defmodule ProcessDictMiddleware do
+    @behaviour Sagents.Middleware
+
+    @impl true
+    def on_fork_context(context, _config) do
+      # Register a restore function that sets a marker in the child process
+      AgentContext.add_restore_fn(context, fn _ctx ->
+        Process.put(
+          {Sagents.AgentServerContextPropagationTest, :forked_state},
+          "restored-by-middleware"
+        )
+      end)
+    end
+  end
+
+  defp create_agent_with_fork_middleware do
+    middleware_entry = %MiddlewareEntry{
+      id: ProcessDictMiddleware,
+      module: ProcessDictMiddleware,
+      config: %{}
+    }
+
+    Agent.new!(%{
+      agent_id: generate_test_agent_id(),
+      model: mock_model(),
+      base_system_prompt: "Test agent",
+      replace_default_middleware: true,
+      middleware: []
+    })
+    |> Map.update!(:middleware, fn existing -> existing ++ [middleware_entry] end)
+  end
+
+  describe "execute context propagation" do
+    test "propagates AgentContext into Task.async via fork_with_middleware" do
+      agent = create_agent_with_fork_middleware()
+      agent_id = agent.agent_id
+      test_pid = self()
+
+      Agent
+      |> expect(:execute, fn _agent, state, _opts ->
+        # Inside Task.async — verify AgentContext was propagated
+        ctx = AgentContext.get()
+        send(test_pid, {:task_context, ctx})
+        {:ok, state}
+      end)
+
+      {:ok, _pid} =
+        AgentServer.start_link(
+          agent: agent,
+          name: AgentServer.get_name(agent_id),
+          pubsub: nil,
+          agent_context: %{tenant_id: 42, trace_id: "test-trace"}
+        )
+
+      AgentServer.execute(agent_id)
+
+      assert_receive {:task_context, ctx}, 1_000
+      assert ctx.tenant_id == 42
+      assert ctx.trace_id == "test-trace"
+    end
+
+    test "on_fork_context restore functions run in Task.async process" do
+      agent = create_agent_with_fork_middleware()
+      agent_id = agent.agent_id
+      test_pid = self()
+
+      Agent
+      |> expect(:execute, fn _agent, state, _opts ->
+        # Inside Task.async — verify the restore function ran and set the marker
+        restored_value = Process.get(@process_dict_key)
+        send(test_pid, {:restored_value, restored_value})
+        {:ok, state}
+      end)
+
+      {:ok, _pid} =
+        AgentServer.start_link(
+          agent: agent,
+          name: AgentServer.get_name(agent_id),
+          pubsub: nil,
+          agent_context: %{tenant_id: 42}
+        )
+
+      AgentServer.execute(agent_id)
+
+      assert_receive {:restored_value, restored}, 1_000
+      assert restored == "restored-by-middleware"
+    end
+  end
+
+  describe "resume context propagation" do
+    test "propagates AgentContext into Task.async on resume" do
+      agent = create_agent_with_fork_middleware()
+      agent_id = agent.agent_id
+      test_pid = self()
+
+      interrupt_data = %{
+        type: :hitl,
+        tool_calls: [%{name: "test_tool", call_id: "tc-1"}]
+      }
+
+      # First execute — return an interrupt
+      Agent
+      |> expect(:execute, fn _agent, state, _opts ->
+        {:interrupt, state, interrupt_data}
+      end)
+
+      {:ok, _pid} =
+        AgentServer.start_link(
+          agent: agent,
+          name: AgentServer.get_name(agent_id),
+          pubsub: nil,
+          agent_context: %{tenant_id: 42, trace_id: "resume-trace"}
+        )
+
+      AgentServer.execute(agent_id)
+
+      # Wait for interrupt status
+      Process.sleep(50)
+      assert AgentServer.get_status(agent_id) == :interrupted
+
+      # Now resume — verify context is propagated
+      Agent
+      |> expect(:resume, fn _agent, _state, _decisions, _opts ->
+        ctx = AgentContext.get()
+        send(test_pid, {:resume_context, ctx})
+        {:ok, State.new!()}
+      end)
+
+      AgentServer.resume(agent_id, [%{tool_call_id: "tc-1", approved: true}])
+
+      assert_receive {:resume_context, ctx}, 1_000
+      assert ctx.tenant_id == 42
+      assert ctx.trace_id == "resume-trace"
+    end
+
+    test "on_fork_context restore functions run in Task.async on resume" do
+      agent = create_agent_with_fork_middleware()
+      agent_id = agent.agent_id
+      test_pid = self()
+
+      interrupt_data = %{
+        type: :hitl,
+        tool_calls: [%{name: "test_tool", call_id: "tc-1"}]
+      }
+
+      # First execute — return an interrupt
+      Agent
+      |> expect(:execute, fn _agent, state, _opts ->
+        {:interrupt, state, interrupt_data}
+      end)
+
+      {:ok, _pid} =
+        AgentServer.start_link(
+          agent: agent,
+          name: AgentServer.get_name(agent_id),
+          pubsub: nil,
+          agent_context: %{tenant_id: 42}
+        )
+
+      AgentServer.execute(agent_id)
+
+      Process.sleep(50)
+      assert AgentServer.get_status(agent_id) == :interrupted
+
+      # Resume — verify the restore function set the process dict marker
+      Agent
+      |> expect(:resume, fn _agent, _state, _decisions, _opts ->
+        restored_value = Process.get(@process_dict_key)
+        send(test_pid, {:restored_value, restored_value})
+        {:ok, State.new!()}
+      end)
+
+      AgentServer.resume(agent_id, [%{tool_call_id: "tc-1", approved: true}])
+
+      assert_receive {:restored_value, restored}, 1_000
+      assert restored == "restored-by-middleware"
+    end
+  end
+end

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -3,6 +3,7 @@ defmodule Sagents.Middleware.SubAgentTest do
   use Mimic
 
   alias Sagents.Agent
+  alias Sagents.AgentContext
   alias Sagents.Middleware.SubAgent, as: SubAgentMiddleware
   alias Sagents.SubAgent
   alias Sagents.SubAgentServer
@@ -1483,6 +1484,121 @@ defmodule Sagents.Middleware.SubAgentTest do
 
       refute subagent_has_task_tool,
              "Subagent's LLMChain should NOT have task tool - SubAgent middleware should be filtered"
+    end
+  end
+
+  describe "AgentContext restoration in async tool execution" do
+    setup do
+      agent_id = "parent-async-ctx-#{System.unique_integer([:positive])}"
+
+      {:ok, _sup} =
+        start_supervised({
+          SubAgentsDynamicSupervisor,
+          agent_id: agent_id
+        })
+
+      model = test_model()
+
+      {:ok, parent_agent} =
+        Agent.new(%{
+          agent_id: agent_id,
+          model: model,
+          base_system_prompt: "Parent",
+          middleware: []
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: agent_id,
+          model: model,
+          middleware: parent_agent.middleware,
+          subagents: []
+        )
+
+      %{
+        agent_id: agent_id,
+        model: model,
+        parent_agent: parent_agent,
+        middleware_config: middleware_config
+      }
+    end
+
+    test "AgentContext is available to sub-agent when execute_task runs inside Task.async",
+         %{
+           agent_id: agent_id,
+           parent_agent: parent_agent,
+           middleware_config: middleware_config
+         } do
+      # Set up AgentContext in the "parent" process (simulating AgentServer)
+      agent_ctx = %{tenant_id: 42, user_id: "user-123", trace_id: "trace-abc"}
+      AgentContext.init(agent_ctx)
+
+      # Snapshot context into custom_context (what build_chain does)
+      context = %{
+        agent_id: agent_id,
+        state: State.new!(%{messages: []}),
+        parent_middleware: parent_agent.middleware,
+        parent_tools: parent_agent.tools,
+        agent_context: AgentContext.get()
+      }
+
+      # Capture the AgentContext that the sub-agent process receives
+      test_pid = self()
+
+      LLMChain
+      |> stub(:run, fn chain ->
+        # Inside the sub-agent's LLMChain.run, read the AgentContext
+        # that was set in SubAgentServer.init (which receives child_context
+        # from fork_with_middleware). Since fork_with_middleware reads from
+        # the process dictionary, we capture what it produces.
+        send(test_pid, {:sub_agent_context, chain.custom_context[:agent_context]})
+
+        assistant_message = Message.new_assistant!(%{content: "Done"})
+
+        {:ok,
+         Map.merge(chain, %{
+           messages: chain.messages ++ [assistant_message],
+           last_message: assistant_message,
+           needs_response: false
+         })}
+      end)
+
+      args = %{
+        "instructions" => "Test async context",
+        "subagent_type" => "general-purpose"
+      }
+
+      # Run execute_task inside Task.async — this simulates LangChain's
+      # async tool execution, which does NOT inherit the process dictionary.
+      task =
+        Task.async(fn ->
+          # Process dictionary is EMPTY here (Task.async doesn't inherit it).
+          # Without the fix, AgentContext.fork_with_middleware will start
+          # from %{} and the sub-agent gets no context.
+          SubAgentMiddleware.start_subagent(
+            "Test async context",
+            "general-purpose",
+            args,
+            context,
+            middleware_config
+          )
+        end)
+
+      assert {:ok, _result} = Task.await(task, 10_000)
+
+      # Verify the sub-agent received the parent's AgentContext data.
+      # The sub-agent's chain.custom_context[:agent_context] should contain
+      # the original tenant_id, user_id, trace_id values.
+      assert_receive {:sub_agent_context, sub_agent_ctx}, 5_000
+
+      assert sub_agent_ctx[:tenant_id] == 42,
+             "Sub-agent should inherit tenant_id from parent AgentContext"
+
+      assert sub_agent_ctx[:user_id] == "user-123",
+             "Sub-agent should inherit user_id from parent AgentContext"
+
+      assert sub_agent_ctx[:trace_id] == "trace-abc",
+             "Sub-agent should inherit trace_id from parent AgentContext"
     end
   end
 

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -233,7 +233,7 @@ defmodule Sagents.Middleware.SubAgentTest do
 
       # Mock LLMChain.run to verify metadata was inherited
       LLMChain
-      |> stub(:run, fn chain ->
+      |> stub(:run, fn chain, _mode_opts ->
         subagent_state = chain.custom_context.state
         assert subagent_state.metadata["user_id"] == "usr-123"
         assert subagent_state.metadata["organization_id"] == "org-456"
@@ -763,7 +763,7 @@ defmodule Sagents.Middleware.SubAgentTest do
     } do
       # Mock LLMChain.run to capture the chain and verify metadata
       LLMChain
-      |> stub(:run, fn chain ->
+      |> stub(:run, fn chain, _mode_opts ->
         # Verify the subagent's state has inherited metadata
         subagent_state = chain.custom_context.state
         assert subagent_state.metadata["user_id"] == "usr-123"
@@ -1546,7 +1546,7 @@ defmodule Sagents.Middleware.SubAgentTest do
       test_pid = self()
 
       LLMChain
-      |> stub(:run, fn chain ->
+      |> stub(:run, fn chain, _mode_opts ->
         # Inside the sub-agent's LLMChain.run, read the AgentContext
         # that was set in SubAgentServer.init (which receives child_context
         # from fork_with_middleware). Since fork_with_middleware reads from

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -215,6 +215,52 @@ defmodule Sagents.Middleware.SubAgentTest do
       assert result == "Hello!"
     end
 
+    test "passes parent state metadata to pre-configured subagent", %{
+      parent_agent_id: parent_agent_id
+    } do
+      subagent_config = build_subagent_config("researcher", "Research agent")
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: parent_agent_id,
+          model: test_model(),
+          middleware: [],
+          subagents: [subagent_config]
+        )
+
+      [task_tool] = SubAgentMiddleware.tools(middleware_config)
+
+      # Mock LLMChain.run to verify metadata was inherited
+      LLMChain
+      |> stub(:run, fn chain ->
+        subagent_state = chain.custom_context.state
+        assert subagent_state.metadata["user_id"] == "usr-123"
+        assert subagent_state.metadata["organization_id"] == "org-456"
+
+        assistant_message = Message.new_assistant!(%{content: "Research done!"})
+
+        updated_chain =
+          chain
+          |> Map.put(:messages, chain.messages ++ [assistant_message])
+          |> Map.put(:last_message, assistant_message)
+          |> Map.put(:needs_response, false)
+
+        {:ok, updated_chain}
+      end)
+
+      args = %{"instructions" => "Research topic", "subagent_type" => "researcher"}
+
+      parent_state =
+        State.new!(%{
+          metadata: %{"user_id" => "usr-123", "organization_id" => "org-456"}
+        })
+
+      context = %{state: parent_state}
+
+      assert {:ok, result} = task_tool.function.(args, context)
+      assert result == "Research done!"
+    end
+
     test "returns error for unknown subagent type", %{parent_agent_id: parent_agent_id} do
       {:ok, middleware_config} =
         SubAgentMiddleware.init(
@@ -707,6 +753,47 @@ defmodule Sagents.Middleware.SubAgentTest do
       }
 
       # Should succeed with default prompt
+      assert {:ok, _result} = task_tool.function.(args, context)
+    end
+
+    test "passes parent state metadata to dynamic subagent", %{
+      task_tool: task_tool,
+      agent_id: _agent_id
+    } do
+      # Mock LLMChain.run to capture the chain and verify metadata
+      LLMChain
+      |> stub(:run, fn chain ->
+        # Verify the subagent's state has inherited metadata
+        subagent_state = chain.custom_context.state
+        assert subagent_state.metadata["user_id"] == "usr-123"
+
+        assistant_message = Message.new_assistant!(%{content: "Done!"})
+
+        updated_chain =
+          chain
+          |> Map.put(:messages, chain.messages ++ [assistant_message])
+          |> Map.put(:last_message, assistant_message)
+          |> Map.put(:needs_response, false)
+
+        {:ok, updated_chain}
+      end)
+
+      args = %{
+        "instructions" => "Do authorized work",
+        "subagent_type" => "general-purpose"
+      }
+
+      parent_state =
+        Sagents.State.new!(%{
+          metadata: %{"user_id" => "usr-123", "organization_id" => "org-456"}
+        })
+
+      context = %{
+        state: parent_state,
+        parent_middleware: [],
+        parent_tools: []
+      }
+
       assert {:ok, _result} = task_tool.function.(args, context)
     end
 


### PR DESCRIPTION
## Summary

Closes #15

Adds `Sagents.AgentContext` — a process-dictionary-based mechanism for propagating application-level context (e.g., OpenTelemetry trace IDs, tenant IDs, feature flags) through the entire agent execution hierarchy.

### Core implementation

- **`AgentContext` module** — `init/1`, `get/0`, `fetch/2`, `put/2`, `merge/1`, `fork/1`, `fork_with_middleware/1`, and `add_restore_fn/2` for zero-cost reads and safe cross-process propagation
- **`AgentServer` / `SubAgentServer`** — accept `:agent_context` option and call `AgentContext.init/1` during process init; fork context via `fork_with_middleware/1` across `Task.async` boundaries
- **`AgentSupervisor`** — forwards `:agent_context` to child `AgentServer`
- **`on_fork_context/2` middleware callback** — allows middleware (e.g., OTel tracers) to inject process-local state into the context snapshot before sub-agent spawn, with `add_restore_fn/2` for restoring that state in the child process
- **SubAgent middleware** — automatically forks context via `fork_with_middleware/1` when spawning sub-agents

### AgentContext vs State.metadata — clear boundaries

The library now has two context mechanisms with clearly documented, distinct purposes:

| | `AgentContext` | `State.metadata` |
|---|---|---|
| **Storage** | Process dictionary | Ecto field on `State` |
| **Persisted to DB?** | No | Yes (serialized to JSONB) |
| **Survives restart?** | No | Yes |
| **Propagated to sub-agents?** | Yes (automatic via fork) | Yes (inherited from parent) |
| **Access pattern** | `AgentContext.fetch(:key)` | `State.get_metadata(state, key)` |
| **Use for** | tenant_id, trace_id, user_id, feature flags | conversation_title, middleware working state |

**Rule of thumb**: If the value must survive after the process dies, use `State.metadata`. If the value is ambient context that flows through the agent hierarchy, use `AgentContext`.

This decision framework is documented in the `@moduledoc` of `AgentContext`, `State`, and `Middleware`, so middleware authors have clear guidance on which to use.

### Sub-agent metadata inheritance

Sub-agents now inherit all parent metadata via `inherit_metadata/2` (from the previously closed PR #10). Parent metadata is merged into the sub-agent's fresh state, so middleware state like actor context (`user_id`, `organization_id`) flows to child agents. Messages, todos, and agent_id remain independent.

### Other improvements

- Added `AgentContext.put/2` and `merge/1` for symmetric read/write API
- Renamed the confusingly-named `inject_agent_context` private function to `inject_middleware_init_params` to avoid confusion with the `AgentContext` module
- Added middleware author guidance in `Middleware` @moduledoc for choosing between AgentContext and State.metadata

### Issue requirements coverage

| # | Requirement | Status |
|---|---|---|
| 1 | Caller-provided context | Done |
| 2 | Readable within agent process | Done |
| 3 | Readable during tool execution (Task.async) | Done |
| 4 | Propagated to sub-agents | Done |
| 5 | Immutable after initialization | Done (also mutable via `put/2`, `merge/1` for derived values) |
| 6 | Transformable at propagation boundaries | Done |
| 7 | Consumer-managed integrations (generic map) | Done |

## Test plan

- [x] Unit tests for `AgentContext` — init, get, fetch, put, merge, fork, fork_with_middleware, add_restore_fn, restore function error handling
- [x] Integration tests for Task.async context propagation (execute + resume)
- [x] Middleware `on_fork_context/2` callback tests
- [x] Sub-agent metadata inheritance tests
- [x] `mix precommit` passes (930 tests, 0 failures)