### PR TITLE
Add configurable display_text for TodoList middleware

### DIFF
--- a/lib/sagents/middleware/todo_list.ex
+++ b/lib/sagents/middleware/todo_list.ex
@@ -16,16 +16,28 @@ defmodule Sagents.Middleware.TodoList do
 
   ## Configuration
 
-  No configuration options currently supported. Future options may include:
+  - `:display_text` - Label shown in UI when the `write_todos` tool runs.
+    Defaults to `"Updating task list"`. Useful when the todo list is used
+    internally by the agent (e.g. self-organization during an onboarding
+    flow) and the default label would leak implementation detail to users.
 
-  - `:max_todos` - Maximum number of TODOs allowed
-  - `:auto_cleanup` - Automatically remove completed TODOs
+  ## Usage
+
+      # default label
+      {:ok, agent} = Agent.new(middleware: [TodoList])
+
+      # custom label for a user-facing flow where todos are internal
+      {:ok, agent} = Agent.new(
+        middleware: [{TodoList, display_text: "Updating my notes"}]
+      )
   """
 
   @behaviour Sagents.Middleware
 
   alias Sagents.{AgentServer, State, Todo}
   alias LangChain.Function
+
+  @default_display_text "Updating task list"
 
   @system_prompt """
   ## `write_todos`
@@ -116,13 +128,19 @@ defmodule Sagents.Middleware.TodoList do
   """
 
   @impl true
+  def init(opts) do
+    display_text = Keyword.get(opts, :display_text, @default_display_text)
+    {:ok, %{display_text: display_text}}
+  end
+
+  @impl true
   def system_prompt(_config) do
     @system_prompt
   end
 
   @impl true
-  def tools(_config) do
-    [build_write_todos_tool()]
+  def tools(config) do
+    [build_write_todos_tool(config)]
   end
 
   @impl true
@@ -134,11 +152,17 @@ defmodule Sagents.Middleware.TodoList do
   end
 
   # Build the tool function - called at runtime to avoid compile-time ordering issues
-  defp build_write_todos_tool do
+  defp build_write_todos_tool(config) do
+    display_text =
+      case config do
+        %{display_text: text} when is_binary(text) -> text
+        _ -> @default_display_text
+      end
+
     Function.new!(%{
       name: "write_todos",
       description: @tool_description,
-      display_text: "Updating task list",
+      display_text: display_text,
       parameters_schema: %{
         type: "object",
         properties: %{

--- a/test/sagents/middleware/todo_list_test.exs
+++ b/test/sagents/middleware/todo_list_test.exs
@@ -38,6 +38,33 @@ defmodule Sagents.Middleware.TodoListTest do
     end
   end
 
+  describe "display_text configuration" do
+    test "defaults to 'Updating task list' when called with nil" do
+      [tool] = TodoList.tools(nil)
+      assert tool.display_text == "Updating task list"
+    end
+
+    test "uses default when init/1 is called with empty opts" do
+      {:ok, config} = TodoList.init([])
+      [tool] = TodoList.tools(config)
+      assert tool.display_text == "Updating task list"
+    end
+
+    test "uses custom display_text from init/1 opts" do
+      {:ok, config} = TodoList.init(display_text: "Updating my notes")
+      [tool] = TodoList.tools(config)
+      assert tool.display_text == "Updating my notes"
+    end
+
+    test "flows through Middleware.init_middleware/1 end-to-end" do
+      entry =
+        Sagents.Middleware.init_middleware({TodoList, display_text: "Keeping myself organized"})
+
+      [tool] = Sagents.Middleware.get_tools(entry)
+      assert tool.display_text == "Keeping myself organized"
+    end
+  end
+
   describe "write_todos tool - replace mode" do
     test "replaces all todos when merge is false" do
       state =


### PR DESCRIPTION
## Problem

The `write_todos` tool always shows "Updating task list" in the UI when it runs. When the todo list is used internally by an agent (e.g. for self-organization during an onboarding flow), this label leaks implementation detail to end users.

## Solution

Accept a `:display_text` option in `TodoList.init/1` and pass it through to the `Function` struct built by `build_write_todos_tool/1`. Falls back to the default `"Updating task list"` when no option is provided or when config is nil.

## Changes

- `lib/sagents/middleware/todo_list.ex` -- Added `init/1` callback accepting `:display_text` option; plumbed config into `build_write_todos_tool/1`; replaced placeholder future-config docs with actual usage examples
- `test/sagents/middleware/todo_list_test.exs` -- Tests for default display text, custom display text, nil config fallback, and end-to-end flow through `Middleware.init_middleware/1`

## Testing

Unit tests covering all paths: default, custom, nil config, and integration through the middleware init pipeline.