### PR TITLE
Add enabled flag to DebugLog middleware for production safety

### DIFF
--- a/lib/sagents/middleware/debug_log.ex
+++ b/lib/sagents/middleware/debug_log.ex
@@ -20,11 +20,27 @@ defmodule Sagents.Middleware.DebugLog do
 
   ## Configuration
 
+  - `:enabled` - Enable or disable logging (default: `true`). When `false`, all
+    callbacks become noops -- no files are created and no I/O occurs. Useful for
+    keeping the middleware in the stack but disabling it in non-dev environments.
   - `:log_dir` - Directory for log files (default: `"tmp/agent_logs"`)
   - `:prefix` - Filename prefix (default: `"debug"`)
   - `:log_deltas` - Log streaming deltas? (default: `false`)
   - `:pretty` - Pretty-print inspect output? (default: `true`)
   - `:inspect_limit` - Inspect limit for large structs (default: `:infinity`)
+
+  ## Disabling in Production
+
+  Since `Mix.env()` is not available in compiled releases, use application config:
+
+      # config/dev.exs (or simply omit -- defaults to true)
+      config :my_app, :debug_logging, true
+
+      # config/prod.exs
+      config :my_app, :debug_logging, false
+
+      # In your middleware stack
+      {Sagents.Middleware.DebugLog, [enabled: Application.compile_env(:my_app, :debug_logging, false)]}
 
   ## Log File Naming
 
@@ -48,6 +64,7 @@ defmodule Sagents.Middleware.DebugLog do
   @impl true
   def init(opts) do
     config = %{
+      enabled: Keyword.get(opts, :enabled, true),
       log_dir: Keyword.get(opts, :log_dir, "tmp/agent_logs"),
       prefix: Keyword.get(opts, :prefix, "debug"),
       log_deltas: Keyword.get(opts, :log_deltas, false),
@@ -60,6 +77,8 @@ defmodule Sagents.Middleware.DebugLog do
   end
 
   @impl true
+  def on_server_start(state, %{enabled: false}), do: {:ok, state}
+
   def on_server_start(state, config) do
     log_event(config, state.agent_id, "ON_SERVER_START", fn ->
       msg_count = length(state.messages)
@@ -87,6 +106,8 @@ defmodule Sagents.Middleware.DebugLog do
   end
 
   @impl true
+  def before_model(state, %{enabled: false}), do: {:ok, state}
+
   def before_model(state, config) do
     prev_count = State.get_metadata(state, "debug_log.msg_count", 0)
     current_count = length(state.messages)
@@ -116,6 +137,8 @@ defmodule Sagents.Middleware.DebugLog do
   end
 
   @impl true
+  def after_model(state, %{enabled: false}), do: {:ok, state}
+
   def after_model(state, config) do
     prev_count = State.get_metadata(state, "debug_log.msg_count", 0)
     current_count = length(state.messages)
@@ -169,6 +192,8 @@ defmodule Sagents.Middleware.DebugLog do
   end
 
   @impl true
+  def handle_resume(_agent, state, _resume_data, %{enabled: false}, _opts), do: {:cont, state}
+
   def handle_resume(agent, state, resume_data, config, _opts) do
     log_event(config, state.agent_id, "HANDLE_RESUME", fn ->
       lines = [
@@ -184,6 +209,8 @@ defmodule Sagents.Middleware.DebugLog do
   end
 
   @impl true
+  def handle_message(_message, state, %{enabled: false}), do: {:ok, state}
+
   def handle_message(message, state, config) do
     log_event(config, state.agent_id, "HANDLE_MESSAGE", fn ->
       safe_inspect(message, config)
@@ -193,6 +220,8 @@ defmodule Sagents.Middleware.DebugLog do
   end
 
   @impl true
+  def callbacks(%{enabled: false}), do: %{}
+
   def callbacks(config) do
     callback_map = %{
       on_llm_new_message: fn chain, message ->

--- a/test/sagents/middleware/debug_log_test.exs
+++ b/test/sagents/middleware/debug_log_test.exs
@@ -364,6 +364,79 @@ defmodule Sagents.Middleware.DebugLogTest do
     end
   end
 
+  describe "enabled: false" do
+    setup do
+      {:ok, disabled_config} = DebugLog.init(log_dir: @test_log_dir, enabled: false)
+      {:ok, disabled_config: disabled_config}
+    end
+
+    test "init stores enabled: false in config" do
+      {:ok, config} = DebugLog.init(enabled: false)
+      assert config.enabled == false
+    end
+
+    test "init defaults enabled to true" do
+      {:ok, config} = DebugLog.init([])
+      assert config.enabled == true
+    end
+
+    test "on_server_start is a noop and creates no log file", %{disabled_config: config} do
+      state =
+        State.new!(%{
+          agent_id: "test-disabled-oss",
+          messages: [Message.new_user!("Hello")]
+        })
+
+      assert {:ok, ^state} = DebugLog.on_server_start(state, config)
+      refute File.exists?(DebugLog.log_path(config, "test-disabled-oss"))
+    end
+
+    test "before_model is a noop, creates no log file, and does not modify metadata", %{
+      disabled_config: config
+    } do
+      state =
+        State.new!(%{
+          agent_id: "test-disabled-bm",
+          messages: [Message.new_user!("Hello")]
+        })
+
+      assert {:ok, ^state} = DebugLog.before_model(state, config)
+      refute File.exists?(DebugLog.log_path(config, "test-disabled-bm"))
+      assert State.get_metadata(state, "debug_log.msg_count") == nil
+    end
+
+    test "after_model is a noop and creates no log file", %{disabled_config: config} do
+      state =
+        State.new!(%{
+          agent_id: "test-disabled-am",
+          messages: [Message.new_user!("Hello")],
+          metadata: %{"debug_log.msg_count" => 0}
+        })
+
+      assert {:ok, ^state} = DebugLog.after_model(state, config)
+      refute File.exists?(DebugLog.log_path(config, "test-disabled-am"))
+    end
+
+    test "handle_resume is a noop and creates no log file", %{disabled_config: config} do
+      agent = %Sagents.Agent{agent_id: "test-disabled-hr", model: nil, middleware: []}
+      state = State.new!(%{agent_id: "test-disabled-hr", messages: []})
+
+      assert {:cont, ^state} = DebugLog.handle_resume(agent, state, %{}, config, [])
+      refute File.exists?(DebugLog.log_path(config, "test-disabled-hr"))
+    end
+
+    test "handle_message is a noop and creates no log file", %{disabled_config: config} do
+      state = State.new!(%{agent_id: "test-disabled-hm", messages: []})
+
+      assert {:ok, ^state} = DebugLog.handle_message({:some, "message"}, state, config)
+      refute File.exists?(DebugLog.log_path(config, "test-disabled-hm"))
+    end
+
+    test "callbacks returns an empty map", %{disabled_config: config} do
+      assert DebugLog.callbacks(config) == %{}
+    end
+  end
+
   # -- Helpers --
 
   defp read_log(config, agent_id) do


### PR DESCRIPTION
## Problem

The DebugLog middleware writes detailed per-conversation log files to disk for every agent event. In non-dev environments this is unnecessary overhead and a potential data concern -- but there was no way to disable it without removing it from the middleware stack entirely.

## Solution

Add an `enabled` option (defaults to `true`) that makes every callback a noop when `false`. The middleware stays in the stack for easy re-enablement, but performs zero I/O and registers no LLM event callbacks when disabled.

Each callback gets a pattern-matching function head on `%{enabled: false}` that returns immediately, so the BEAM dispatches the skip at the pattern-match level with no runtime branching.

## Changes

- `lib/sagents/middleware/debug_log.ex` -- Added `enabled` to init config map; added early-return function heads for `on_server_start`, `before_model`, `after_model`, `handle_resume`, `handle_message`, and `callbacks`
- `lib/sagents/middleware/debug_log.ex` (`@moduledoc`) -- Documented the `:enabled` option and added a "Disabling in Production" section with `Application.compile_env` example (since `Mix.env()` is unavailable in compiled releases)
- `test/sagents/middleware/debug_log_test.exs` -- Added 7 tests in a new `describe "enabled: false"` block verifying all callbacks are noops, no log files are created, and metadata is untouched

## Testing

All existing and new tests pass (`mix precommit` -- 1241 tests, 0 failures).