### PR TITLE
Add FileSchema behaviour and rename filesystem tools

### DIFF
--- a/lib/sagents/file_system/file_entry.ex
+++ b/lib/sagents/file_system/file_entry.ex
@@ -45,6 +45,8 @@ defmodule Sagents.FileSystem.FileEntry do
   Directory entry:
     %FileEntry{entry_type: :directory, persistence: :persisted, loaded: true, dirty_content: false, content: nil}
   """
+  @behaviour Sagents.FileSystem.FileSchema
+
   use Ecto.Schema
   import Ecto.Changeset
 
@@ -91,9 +93,17 @@ defmodule Sagents.FileSystem.FileEntry do
         }
 
   @doc """
-  Creates a changeset for a file entry.
+  Creates a changeset for a file entry from internal attrs.
+
+  This is the full internal changeset used by `new_memory_file/3`,
+  `new_persisted_file/3`, etc. It casts all schema fields including
+  `:path`, `:content`, and persistence-related state.
+
+  This is **not** the changeset used for LLM-supplied attribute updates —
+  that is `changeset/1` (the `Sagents.FileSystem.FileSchema` callback),
+  which only allows `:title`, `:id`, and `:file_type`.
   """
-  def changeset(entry \\ %FileEntry{}, attrs) do
+  def internal_changeset(entry \\ %FileEntry{}, attrs) do
     entry
     |> cast(attrs, [
       :path,
@@ -120,6 +130,43 @@ defmodule Sagents.FileSystem.FileEntry do
     entry
     |> cast(attrs, [:title, :id, :file_type])
   end
+
+  # --- Sagents.FileSystem.FileSchema callbacks ---
+
+  @doc """
+  Default `Sagents.FileSystem.FileSchema` changeset.
+
+  Casts only entry-level fields safe for LLM updates: `:title`, `:id`,
+  and `:file_type`. `:content` is intentionally **not** in the cast list —
+  content is changed via `replace_text`, `replace_lines`, or `create_file`,
+  never `update_file_attrs`.
+  """
+  @impl Sagents.FileSystem.FileSchema
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:title, :id, :file_type])
+  end
+
+  @doc """
+  Default `Sagents.FileSystem.FileSchema` representation of a file entry
+  for the LLM. Includes path, title, entry_type, file_type, persistence,
+  size, and (when present) id.
+  """
+  @impl Sagents.FileSystem.FileSchema
+  def to_llm_map(%__MODULE__{} = entry) do
+    %{
+      path: entry.path,
+      title: entry.title,
+      entry_type: entry.entry_type,
+      file_type: entry.file_type,
+      persistence: entry.persistence,
+      size: entry.metadata && entry.metadata.size
+    }
+    |> maybe_put_field(:id, entry.id)
+  end
+
+  defp maybe_put_field(map, _key, nil), do: map
+  defp maybe_put_field(map, key, value), do: Map.put(map, key, value)
 
   @doc """
   Validates that a name (title or path segment) is safe for use in paths.
@@ -163,7 +210,7 @@ defmodule Sagents.FileSystem.FileEntry do
         |> maybe_put(:file_type, file_type)
 
       %FileEntry{}
-      |> changeset(attrs)
+      |> internal_changeset(attrs)
       |> put_embed(:metadata, metadata)
       |> apply_action(:insert)
       |> case do
@@ -200,7 +247,7 @@ defmodule Sagents.FileSystem.FileEntry do
         |> maybe_put(:file_type, file_type)
 
       %FileEntry{}
-      |> changeset(attrs)
+      |> internal_changeset(attrs)
       |> put_embed(:metadata, metadata)
       |> apply_action(:insert)
       |> case do
@@ -239,7 +286,7 @@ defmodule Sagents.FileSystem.FileEntry do
 
     result =
       %FileEntry{}
-      |> changeset(attrs)
+      |> internal_changeset(attrs)
       |> maybe_put_embed_metadata(metadata)
       |> apply_action(:insert)
 
@@ -283,7 +330,7 @@ defmodule Sagents.FileSystem.FileEntry do
         }
 
         %FileEntry{}
-        |> changeset(attrs)
+        |> internal_changeset(attrs)
         |> put_embed(:metadata, metadata)
         |> apply_action(:insert)
         |> case do

--- a/lib/sagents/file_system/file_schema.ex
+++ b/lib/sagents/file_system/file_schema.ex
@@ -1,0 +1,94 @@
+defmodule Sagents.FileSystem.FileSchema do
+  @moduledoc """
+  Behaviour for defining how file entries are represented to the LLM
+  and how LLM-supplied attribute updates are validated.
+
+  `Sagents.FileSystem.FileEntry` implements this behaviour by default,
+  supporting basic file attributes (`title`, `id`, `file_type`).
+  Applications can implement this behaviour on their own module to add
+  custom attributes with validation.
+
+  ## Storage Routing
+
+  The `Sagents.Middleware.FileSystem` middleware handles routing validated
+  changes to the correct storage layer automatically. Fields that match
+  `FileEntry` struct fields (`:title`, `:id`, `:file_type`) are updated via
+  `Sagents.FileSystemServer.update_entry/4`. All other fields are stored in
+  `metadata.custom` via `Sagents.FileSystemServer.update_custom_metadata/4`.
+
+  This means implementations only need to define what attributes exist and
+  how to validate them — not where they're stored.
+
+  ## Content is Off-limits
+
+  `update_file_attrs` is for metadata, not content. Implementations should
+  never include `:content` in their changeset cast list. The middleware
+  defends against this anyway: if `:content` appears in validated changes,
+  the routing layer raises an error directing the LLM to use
+  `replace_text`, `replace_lines`, or `create_file`.
+
+  ## Example Implementation
+
+      defmodule MyApp.DocumentFileSchema do
+        @behaviour Sagents.FileSystem.FileSchema
+
+        use Ecto.Schema
+        import Ecto.Changeset
+
+        alias Sagents.FileSystem.FileEntry
+
+        @primary_key false
+        embedded_schema do
+          field :title, :string
+          field :system_tag, :string
+          field :tags, {:array, :string}, default: []
+          field :status, :string
+        end
+
+        @impl true
+        def changeset(attrs) do
+          %__MODULE__{}
+          |> cast(attrs, [:title, :system_tag, :tags, :status])
+          |> validate_inclusion(:system_tag, ~w(draft review approved published))
+        end
+
+        @impl true
+        def to_llm_map(%FileEntry{} = entry) do
+          custom = (entry.metadata && entry.metadata.custom) || %{}
+
+          %{
+            path: entry.path,
+            title: entry.title,
+            file_type: entry.file_type,
+            system_tag: custom["system_tag"],
+            tags: custom["tags"],
+            status: custom["status"],
+            size: entry.metadata && entry.metadata.size
+          }
+          |> Map.reject(fn {_k, v} -> is_nil(v) end)
+        end
+      end
+  """
+
+  alias Sagents.FileSystem.FileEntry
+
+  @doc """
+  Cast and validate LLM-supplied attributes.
+
+  Returns an `Ecto.Changeset`. If invalid, the middleware formats the errors
+  and returns them to the LLM as a tool error so it can self-correct.
+
+  The changeset's underlying schema defines what attributes are accepted.
+  Fields not in the schema's cast list are ignored. Type casting is automatic
+  via Ecto.
+  """
+  @callback changeset(attrs :: map()) :: Ecto.Changeset.t()
+
+  @doc """
+  Convert a `FileEntry` into the map representation the LLM sees.
+
+  Called by `list_files`, `create_file`, and `update_file_attrs` for tool
+  responses. The returned map is JSON-encoded before being sent to the LLM.
+  """
+  @callback to_llm_map(entry :: FileEntry.t()) :: map()
+end

--- a/lib/sagents/middleware/file_system.ex
+++ b/lib/sagents/middleware/file_system.ex
@@ -1,14 +1,15 @@
 defmodule Sagents.Middleware.FileSystem do
   @moduledoc """
-  Middleware that adds mock filesystem capabilities to agents.
+  Middleware that adds virtual filesystem capabilities to agents.
 
-  Provides tools for file operations in an isolated, in-memory filesystem:
-  - `ls`: List all files (with optional pattern filtering)
+  Provides tools for file operations in an isolated, persistable filesystem:
+  - `list_files`: List all files (with optional pattern filtering)
   - `read_file`: Read file contents with line numbers and pagination
-  - `write_file`: Create or overwrite files
-  - `edit_file`: Make targeted edits with string replacement
+  - `create_file`: Create new files (errors if file exists)
+  - `replace_text`: Make targeted edits with string replacement
+  - `replace_lines`: Replace a range of lines by line number
+  - `update_file_attrs`: Update file attributes (title, tags, etc.) — no content changes
   - `search_text`: Search for text patterns within files or across all files
-  - `edit_lines`: Replace a range of lines by line number
   - `delete_file`: Delete files from the filesystem
   - `move_file`: Move or rename files and directories
 
@@ -25,12 +26,14 @@ defmodule Sagents.Middleware.FileSystem do
 
   ### Basic Configuration
 
-  - `:long_term_memory` - Enable persistence (default: false)
-  - `:memories_prefix` - Path prefix for long-term persisted files (default: "memories")
+  - `:filesystem_scope` - Scope tuple identifying the filesystem (e.g. `{:agent, id}`,
+    `{:user, id}`, `{:project, id}`)
   - `:enabled_tools` - List of tool names to enable (default: all tools)
   - `:custom_tool_descriptions` - Map of custom descriptions per tool
-  - `:entry_to_map` - Function that converts a `FileEntry` to a JSON-friendly map for LLM
-    tool results (default: `&Sagents.Middleware.FileSystem.default_entry_to_map/1`)
+  - `:file_schema` - Module implementing `Sagents.FileSystem.FileSchema`. Defaults to
+    `Sagents.FileSystem.FileEntry`, which provides basic file attributes
+    (`:title`, `:id`, `:file_type`). Applications override with their own module to
+    add custom attributes with validation.
 
   ### Selective Tool Enabling
 
@@ -39,11 +42,13 @@ defmodule Sagents.Middleware.FileSystem do
       {:ok, agent} = Agent.new(
         model: model,
         filesystem_opts: [
-          enabled_tools: ["ls", "read_file"]  # Read-only, no write/edit
+          enabled_tools: ["list_files", "read_file"]  # Read-only
         ]
       )
 
-  Available tools: `"ls"`, `"read_file"`, `"write_file"`, `"edit_file"`, `"search_text"`, `"edit_lines"`, `"delete_file"`, `"move_file"`
+  Available tools: `"list_files"`, `"read_file"`, `"create_file"`, `"replace_text"`,
+  `"replace_lines"`, `"update_file_attrs"`, `"search_text"`, `"delete_file"`,
+  `"move_file"`
 
   ### Custom Tool Descriptions
 
@@ -54,83 +59,65 @@ defmodule Sagents.Middleware.FileSystem do
         filesystem_opts: [
           custom_tool_descriptions: %{
             "read_file" => "Custom description for reading files...",
-            "write_file" => "Custom description for writing files..."
+            "create_file" => "Custom description for creating files..."
           }
         ]
       )
 
-  ### Custom Entry-to-Map Function
+  ### Custom File Schema
 
-  The `entry_to_map` option controls how `FileEntry` structs are serialized to
-  JSON maps in LLM tool results (used by `ls`, `write_file`, etc.). The default
-  implementation returns path, title, entry_type, file_type, persistence, size,
-  and id (when present). Override it to include application-specific fields:
+  The `:file_schema` option controls both how `FileEntry` structs are serialized
+  to JSON for LLM tool results AND how LLM-supplied attribute updates are
+  validated. The default `Sagents.FileSystem.FileEntry` provides basic file
+  attributes. Provide your own module to add validated custom fields:
+
+      defmodule MyApp.DocumentFileSchema do
+        @behaviour Sagents.FileSystem.FileSchema
+
+        use Ecto.Schema
+        import Ecto.Changeset
+
+        @primary_key false
+        embedded_schema do
+          field :title, :string
+          field :system_tag, :string
+          field :tags, {:array, :string}, default: []
+        end
+
+        @impl true
+        def changeset(attrs) do
+          %__MODULE__{}
+          |> cast(attrs, [:title, :system_tag, :tags])
+          |> validate_inclusion(:system_tag, ~w(draft review approved published))
+        end
+
+        @impl true
+        def to_llm_map(entry), do: # ... build map from entry ...
+      end
 
       {Sagents.Middleware.FileSystem, [
         filesystem_scope: {:project, project_id},
-        entry_to_map: fn %FileEntry{} = entry ->
-          Sagents.Middleware.FileSystem.default_entry_to_map(entry)
-          |> Map.put(:genre, entry.metadata && entry.metadata.custom["genre"])
-          |> Sagents.Middleware.FileSystem.maybe_add_field(:tags, entry.metadata && entry.metadata.custom["tags"])
-        end
+        file_schema: MyApp.DocumentFileSchema
       ]}
-
-  ### Persistence Configuration
-
-  Provide persistence callbacks to save/load files from external storage:
-
-      # Module-based (implement Sagents.FilesystemCallbacks)
-      {:ok, agent} = Agent.new(
-        model: model,
-        filesystem_opts: [
-          persistence: MyApp.FilesystemPersistence,
-          context: %{user_id: user_id}
-        ]
-      )
-
-      # Function-based (inline callbacks)
-      {:ok, agent} = Agent.new(
-        model: model,
-        filesystem_opts: [
-          on_write: fn file_path, content, ctx ->
-            MyApp.Files.save(ctx.user_id, file_path, content)
-          end,
-          on_read: fn file_path, ctx ->
-            MyApp.Files.get(ctx.user_id, file_path)
-          end,
-          context: %{user_id: user_id}
-        ]
-      )
-
-  ### Persistence Options
-
-  - `:persistence` - Module implementing FilesystemCallbacks behavior
-  - `:on_write` - Function for write operations `fn(path, content, ctx) -> result`
-  - `:on_read` - Function for read operations `fn(path, ctx) -> {:ok, content} | {:error, reason}`
-  - `:on_delete` - Function for delete operations `fn(path, ctx) -> result`
-  - `:on_list` - Function for list operations `fn(ctx) -> {:ok, [paths]} | {:error, reason}`
-  - `:context` - Map passed to all callbacks (user_id, session_id, etc.)
-  - `:cache_reads` - Cache reads in memory (default: true)
-  - `:fail_on_persistence_error` - Fail operations if persistence fails (default: false)
 
   ## File Organization
 
   Use hierarchical paths to organize files:
 
-      write_file(file_path: "Chapter 1/summary.md", content: "...")
-      write_file(file_path: "images/diagram.png", content: "...")
-      ls(pattern: "Chapter 1/*")
+      create_file(file_path: "/reports/q1-summary.md", content: "...")
+      create_file(file_path: "/images/diagram.png", content: "...")
+      list_files(pattern: "/reports/*")
 
   ## Pattern Filtering
 
-  The `ls` tool supports wildcard patterns:
+  The `list_files` tool supports wildcard patterns:
   - `*` matches any characters
-  - Examples: `*summary*`, `*.md`, `Chapter 1/*`
+  - Examples: `*summary*`, `*.md`, `reports/*`
 
   ## Path Security
 
   Paths are validated to prevent security issues:
-  - Paths starting with "/" are rejected (system path protection)
+  - Paths must start with "/"
   - Path traversal attempts ("..") are rejected
   - Home directory shortcuts ("~") are rejected
   """
@@ -139,46 +126,65 @@ defmodule Sagents.Middleware.FileSystem do
 
   require Logger
   alias LangChain.Function
+  alias LangChain.Utils
   alias Sagents.FileSystem.FileEntry
   alias Sagents.FileSystemServer
+
+  # Fields that live directly on the FileEntry struct. Anything else in a
+  # validated changeset is routed to metadata.custom.
+  @entry_fields [:title, :id, :file_type]
+
+  @default_enabled_tools [
+    "list_files",
+    "read_file",
+    "create_file",
+    "replace_text",
+    "replace_lines",
+    "update_file_attrs",
+    "search_text",
+    "delete_file",
+    "move_file"
+  ]
 
   @system_prompt """
   ## Filesystem Tools
 
   You have access to a virtual filesystem with these tools:
-  - `ls`: List files — returns a JSON array of file entries with metadata (path, title, file_type, size, etc.)
-  - `read_file`: Read file contents with line numbers and pagination
-  - `write_file`: Create new files — returns JSON metadata of the created file
-  - `edit_file`: Modify existing files with string replacement
-  - `search_text`: Search for text patterns in specific files or across all files
-  - `edit_lines`: Replace a block of lines by line number range
-  - `delete_file`: Delete files from the filesystem
-  - `move_file`: Move or rename files and directories
+  - `list_files`: List files — returns a JSON array of file entries with metadata (path, title, file_type, size, etc.). Optionally filter by wildcard pattern.
+  - `read_file`: Read file contents with line numbers and pagination.
+  - `create_file`: Create a new file with content. Errors if the file already exists.
+  - `replace_text`: Replace a string with another string in an existing file. The old_string must appear exactly once unless replace_all is set.
+  - `replace_lines`: Replace a range of lines (by line number) with new content. More token-efficient than replace_text for large block replacements.
+  - `update_file_attrs`: Update file attributes (title, tags, etc.) without modifying file content. Validated against the file schema.
+  - `search_text`: Search for text patterns within or across files.
+  - `delete_file`: Delete a file from the filesystem.
+  - `move_file`: Move or rename a file or directory.
 
   ## File Organization
 
   Use hierarchical paths to organize files logically:
   - All paths must start with a forward slash "/"
-  - Examples: "/notes.txt", "/Chapter1/summary.md", "/data/results.csv"
+  - Examples: "/notes.txt", "/reports/q1-summary.md", "/data/results.csv"
   - No path traversal ("..") or home directory ("~") allowed
 
   ## Pattern Filtering
 
-  The `ls` tool supports wildcard patterns:
+  The `list_files` tool supports wildcard patterns:
   - `*` matches any characters
-  - Examples: `*summary*`, `*.md`, `/Chapter1/*`
+  - Examples: `*summary*`, `*.md`, `/reports/*`
 
   ## Best Practices
 
-  - Always use `ls` first to see available files
+  - Always use `list_files` first to see available files
   - Read files before editing to understand content
-  - Use `edit_file` for small, targeted edits with string replacement
-  - Use `edit_lines` for large block replacements (more efficient with tokens)
-  - Use `write_file` only for new files
-  - Provide sufficient context in `old_string` to ensure unique matches
+  - Use `replace_text` for small, targeted edits where you have the exact text
+  - Use `replace_lines` for large block replacements (more token-efficient)
+  - Use `create_file` only for new files (errors if file exists)
+  - Use `update_file_attrs` to change metadata like title or tags — never to change content
+  - Provide sufficient context in `old_string` for `replace_text` to ensure unique matches
   - Group related files in the same directory
   - Use `move_file` to rename files or move them to a different directory
-  - Never `delete_file` without first using `ls` to locate it
+  - Never `delete_file` without first using `list_files` to locate it
 
   ## Persistence Behavior
 
@@ -205,19 +211,9 @@ defmodule Sagents.Middleware.FileSystem do
     config = %{
       filesystem_scope: filesystem_scope,
       # Tool configuration
-      enabled_tools:
-        Keyword.get(opts, :enabled_tools, [
-          "ls",
-          "read_file",
-          "write_file",
-          "edit_file",
-          "search_text",
-          "edit_lines",
-          "delete_file",
-          "move_file"
-        ]),
+      enabled_tools: Keyword.get(opts, :enabled_tools, @default_enabled_tools),
       custom_tool_descriptions: Keyword.get(opts, :custom_tool_descriptions, %{}),
-      entry_to_map: Keyword.get(opts, :entry_to_map, &__MODULE__.default_entry_to_map/1)
+      file_schema: Keyword.get(opts, :file_schema, FileEntry)
     }
 
     {:ok, config}
@@ -231,27 +227,18 @@ defmodule Sagents.Middleware.FileSystem do
   @impl true
   def tools(config) do
     all_tools = %{
-      "ls" => build_ls_tool(config),
+      "list_files" => build_list_files_tool(config),
       "read_file" => build_read_file_tool(config),
-      "write_file" => build_write_file_tool(config),
-      "edit_file" => build_edit_file_tool(config),
+      "create_file" => build_create_file_tool(config),
+      "replace_text" => build_replace_text_tool(config),
+      "replace_lines" => build_replace_lines_tool(config),
+      "update_file_attrs" => build_update_file_attrs_tool(config),
       "search_text" => build_search_text_tool(config),
-      "edit_lines" => build_edit_lines_tool(config),
       "delete_file" => build_delete_file_tool(config),
       "move_file" => build_move_file_tool(config)
     }
 
-    enabled_tools =
-      Map.get(config, :enabled_tools, [
-        "ls",
-        "read_file",
-        "write_file",
-        "edit_file",
-        "search_text",
-        "edit_lines",
-        "delete_file",
-        "move_file"
-      ])
+    enabled_tools = Map.get(config, :enabled_tools, @default_enabled_tools)
 
     enabled_tools
     |> Enum.map(fn tool_name -> Map.get(all_tools, tool_name) end)
@@ -264,71 +251,25 @@ defmodule Sagents.Middleware.FileSystem do
     []
   end
 
-  @doc """
-  Converts a FileEntry to a JSON-friendly map for LLM tool results.
-
-  Does not include content (which could be very large). Includes size
-  from metadata when available. Only includes `id` if it has a value.
-
-  This is the default implementation used by the `entry_to_map` config
-  option. Override it by providing a custom function in middleware config:
-
-      {Sagents.Middleware.FileSystem, [
-        filesystem_scope: {:project, project_id},
-        entry_to_map: &MyApp.custom_entry_to_map/1
-      ]}
-  """
-  @spec default_entry_to_map(FileEntry.t()) :: map()
-  def default_entry_to_map(%FileEntry{} = entry) do
-    %{
-      path: entry.path,
-      title: entry.title,
-      entry_type: entry.entry_type,
-      file_type: entry.file_type,
-      persistence: entry.persistence,
-      size: entry.metadata && entry.metadata.size
-    }
-    |> maybe_add_field(:id, entry.id)
-  end
-
-  @doc """
-  Conditionally adds a key-value pair to a map. If the value is nil, the map
-  is returned unchanged. Useful as a helper when building custom `entry_to_map`
-  functions.
-
-  ## Example
-
-      Sagents.Middleware.FileSystem.default_entry_to_map(entry)
-      |> Sagents.Middleware.FileSystem.maybe_add_field(:tags, custom["tags"])
-  """
-  @spec maybe_add_field(map(), atom(), any()) :: map()
-  def maybe_add_field(map, _key, nil), do: map
-  def maybe_add_field(map, key, value), do: Map.put(map, key, value)
-
   # Tool builders
 
-  defp build_ls_tool(config) do
+  defp build_list_files_tool(config) do
     default_description = """
-    Lists files in the filesystem, optionally filtering by pattern or directory.
+    Lists files in the filesystem, optionally filtering by wildcard pattern.
 
-    Usage:
-    - The list_files tool will return a list of the files in the filesystem.
-    - You can optionally provide a path parameter to list files in a specific directory.
-    - You can optionally provide a pattern parameter to filter the files by pattern.
-    - This is very useful for exploring the file system and finding the right file to read or edit.
-    - You should almost ALWAYS use this tool before using the read or edit tools.
+    Returns a JSON array of file entries with metadata (path, title, file_type, size, etc.).
 
-    Optionally filter by pattern using wildcards:
+    Wildcard patterns:
     - Use '*' to match any characters
-    - Examples: '*summary*', '*.md', '/Chapter 1/*'
+    - Examples: '*summary*', '*.md', '/reports/*'
 
-    Without a pattern, lists all files.
+    You should almost ALWAYS use this tool before using the read or replace tools.
     """
 
-    description = get_custom_description(config, "ls", default_description)
+    description = get_custom_description(config, "list_files", default_description)
 
     Function.new!(%{
-      name: "ls",
+      name: "list_files",
       description: description,
       display_text: "Listing files",
       parameters_schema: %{
@@ -337,11 +278,11 @@ defmodule Sagents.Middleware.FileSystem do
           pattern: %{
             type: "string",
             description:
-              "Optional wildcard pattern to filter files (e.g., '*summary*', '*.md', '/Chapter 1/*')"
+              "Optional wildcard pattern to filter files (e.g., '*summary*', '*.md', '/reports/*')"
           }
         }
       },
-      function: fn args, context -> execute_ls_tool(args, context, config) end
+      function: fn args, context -> execute_list_files_tool(args, context, config) end
     })
   end
 
@@ -383,26 +324,26 @@ defmodule Sagents.Middleware.FileSystem do
     })
   end
 
-  defp build_write_file_tool(config) do
+  defp build_create_file_tool(config) do
     default_description = """
-    Write content to a file (creates new files only).
+    Create a new file with content.
 
-    This tool creates new files. If the file already exists, an error will be returned.
-    Use edit_file to modify existing files.
+    This tool only creates new files. If the file already exists, an error will be
+    returned — use replace_text or replace_lines to modify existing files instead.
     """
 
-    description = get_custom_description(config, "write_file", default_description)
+    description = get_custom_description(config, "create_file", default_description)
 
     Function.new!(%{
-      name: "write_file",
+      name: "create_file",
       description: description,
-      display_text: "Writing file",
+      display_text: "Creating file",
       parameters_schema: %{
         type: "object",
         properties: %{
           file_path: %{
             type: "string",
-            description: "Path where the file should be written"
+            description: "Path where the file should be created"
           },
           content: %{
             type: "string",
@@ -411,25 +352,27 @@ defmodule Sagents.Middleware.FileSystem do
         },
         required: ["file_path", "content"]
       },
-      function: fn args, context -> execute_write_file_tool(args, context, config) end
+      function: fn args, context -> execute_create_file_tool(args, context, config) end
     })
   end
 
-  defp build_edit_file_tool(config) do
+  defp build_replace_text_tool(config) do
     default_description = """
-    Edit a file by replacing old_string with new_string.
+    Replace a string with another string in an existing file.
 
-    Performs string replacement within the file. By default, requires
-    old_string to appear exactly once (for safety). Use replace_all: true
-    to replace multiple occurrences.
+    By default, the old_string must appear exactly once in the file (for safety).
+    Use replace_all: true to replace every occurrence.
+
+    For large block replacements where you have line numbers, prefer replace_lines —
+    it is significantly more token-efficient.
     """
 
-    description = get_custom_description(config, "edit_file", default_description)
+    description = get_custom_description(config, "replace_text", default_description)
 
     Function.new!(%{
-      name: "edit_file",
+      name: "replace_text",
       description: description,
-      display_text: "Editing file",
+      display_text: "Replacing text",
       parameters_schema: %{
         type: "object",
         properties: %{
@@ -453,7 +396,7 @@ defmodule Sagents.Middleware.FileSystem do
         },
         required: ["file_path", "old_string", "new_string"]
       },
-      function: fn args, context -> execute_edit_file_tool(args, context, config) end
+      function: fn args, context -> execute_replace_text_tool(args, context, config) end
     })
   end
 
@@ -495,10 +438,10 @@ defmodule Sagents.Middleware.FileSystem do
     - Use this to rename files or reorganize the directory structure
     - The target path must not already exist
 
-    Examples:
-    - Rename: move_file(old_path: "/draft.txt", new_path: "/final.txt")
-    - Move to directory: move_file(old_path: "/notes.txt", new_path: "/archive/notes.txt")
-    - Rename directory: move_file(old_path: "/Chapter 1", new_path: "/Part 1")
+    Examples (call with a JSON object matching the schema):
+    - Rename a file: {"old_path": "/draft.txt", "new_path": "/final.txt"}
+    - Move to a directory: {"old_path": "/notes.txt", "new_path": "/archive/notes.txt"}
+    - Rename a directory: {"old_path": "/drafts", "new_path": "/published"}
     """
 
     description = get_custom_description(config, "move_file", default_description)
@@ -539,10 +482,10 @@ defmodule Sagents.Middleware.FileSystem do
     - Set context_lines (optional, default: 0) - lines before/after to show
     - Set max_results (optional, default: 50) - limit number of results
 
-    Examples:
-    - Search single file: search_text(pattern: "TODO", file_path: "/notes.txt")
-    - Search all files: search_text(pattern: "important", case_sensitive: false)
-    - With context: search_text(pattern: "error", context_lines: 2)
+    Examples (call with a JSON object matching the schema):
+    - Search a single file: {"pattern": "TODO", "file_path": "/notes.txt"}
+    - Search all files: {"pattern": "important", "case_sensitive": false}
+    - With surrounding context: {"pattern": "error", "context_lines": 2}
     """
 
     description = get_custom_description(config, "search_text", default_description)
@@ -585,40 +528,45 @@ defmodule Sagents.Middleware.FileSystem do
     })
   end
 
-  defp build_edit_lines_tool(config) do
+  defp build_replace_lines_tool(config) do
     default_description = """
-    Edit a file by replacing a range of lines with new content.
+    Replace a range of lines (by line number) with new content. Line numbers are
+    1-based and the range is inclusive (both start_line and end_line are replaced).
 
-    This tool is more efficient than edit_file for replacing large blocks of text,
-    such as rewriting multiple paragraphs or sections. It uses line numbers instead
-    of string matching, making it more reliable for large edits.
+    This tool is significantly more token-efficient than replace_text for large
+    block replacements — you don't need to send the original content character-
+    for-character, just the line range.
 
-    Line numbers are 1-based (matching read_file output) and the range is inclusive
-    (both start_line and end_line are replaced).
+    ## Best Practices
 
-    Usage:
-    - First use read_file to see the file with line numbers
-    - Identify the start_line and end_line you want to replace
-    - Provide new_content to replace those lines
-    - The tool will replace lines [start_line, end_line] inclusive
+    - ALWAYS use read_file first to see the current line numbers. Line numbers
+      shift after every edit, so re-read between edits if you're making multiple
+      changes to the same file.
+    - Carefully verify start_line and end_line before calling. Wrong line numbers
+      will destructively replace the wrong content with no way to undo.
+    - For small, targeted edits where you know the exact text, use replace_text
+      instead — it has a built-in safety check (the old_string must match).
+    - For multi-line replacements where you have line numbers from a recent
+      read_file, this tool is the right choice.
 
-    Examples:
-    - Replace lines 10-15: edit_lines(file_path: "/doc.txt", start_line: 10, end_line: 15, new_content: "new text")
-    - Replace single line: edit_lines(file_path: "/doc.txt", start_line: 42, end_line: 42, new_content: "new line")
-    - Replace large block: edit_lines(file_path: "/story.txt", start_line: 120, end_line: 135, new_content: "...")
+    ## Examples
 
-    Best practices:
-    - Use read_file first to verify line numbers
-    - For small, targeted edits, use edit_file instead
-    - For large block replacements, this tool is more efficient
+    Call with a JSON object matching the schema:
+
+    - Replace lines 10-15:
+      {"file_path": "/doc.txt", "start_line": 10, "end_line": 15, "new_content": "new text"}
+    - Replace a single line:
+      {"file_path": "/doc.txt", "start_line": 42, "end_line": 42, "new_content": "new line"}
+    - Replace a large block:
+      {"file_path": "/notes/research.md", "start_line": 120, "end_line": 135, "new_content": "..."}
     """
 
-    description = get_custom_description(config, "edit_lines", default_description)
+    description = get_custom_description(config, "replace_lines", default_description)
 
     Function.new!(%{
-      name: "edit_lines",
+      name: "replace_lines",
       description: description,
-      display_text: "Editing file lines",
+      display_text: "Replacing lines",
       parameters_schema: %{
         type: "object",
         properties: %{
@@ -641,13 +589,49 @@ defmodule Sagents.Middleware.FileSystem do
         },
         required: ["file_path", "start_line", "end_line", "new_content"]
       },
-      function: fn args, context -> execute_edit_lines_tool(args, context, config) end
+      function: fn args, context -> execute_replace_lines_tool(args, context, config) end
+    })
+  end
+
+  defp build_update_file_attrs_tool(config) do
+    default_description = """
+    Update file attributes (title, tags, etc.) without modifying file content.
+
+    Validated against the configured file schema. Pass only the attributes you
+    want to change. Returns the updated file's JSON metadata.
+
+    To change file content use replace_text, replace_lines, or create_file —
+    never this tool.
+    """
+
+    description = get_custom_description(config, "update_file_attrs", default_description)
+
+    Function.new!(%{
+      name: "update_file_attrs",
+      description: description,
+      display_text: "Updating file attributes",
+      parameters_schema: %{
+        type: "object",
+        properties: %{
+          file_path: %{
+            type: "string",
+            description: "Path to the file to update"
+          },
+          attrs: %{
+            type: "object",
+            description: "Attributes to update. Only include fields you want to change.",
+            properties: %{}
+          }
+        },
+        required: ["file_path", "attrs"]
+      },
+      function: fn args, context -> execute_update_file_attrs_tool(args, context, config) end
     })
   end
 
   # Tool execution functions
 
-  defp execute_ls_tool(args, _context, config) do
+  defp execute_list_files_tool(args, _context, config) do
     pattern = get_arg(args, "pattern")
 
     # List all entries using FileSystemServer (returns FileEntry structs with metadata)
@@ -663,7 +647,7 @@ defmodule Sagents.Middleware.FileSystem do
         {:ok, "No files in filesystem"}
       end
     else
-      entry_maps = Enum.map(filtered_entries, &config.entry_to_map.(&1))
+      entry_maps = Enum.map(filtered_entries, &config.file_schema.to_llm_map(&1))
       {:ok, Jason.encode!(entry_maps)}
     end
   rescue
@@ -738,7 +722,7 @@ defmodule Sagents.Middleware.FileSystem do
     {:ok, result}
   end
 
-  defp execute_write_file_tool(args, _context, config) do
+  defp execute_create_file_tool(args, _context, config) do
     file_path = get_arg(args, "file_path")
     content = get_arg(args, "content")
 
@@ -752,7 +736,7 @@ defmodule Sagents.Middleware.FileSystem do
           # Check if file already exists (overwrite protection)
           if FileSystemServer.file_exists?(config.filesystem_scope, normalized_path) do
             {:error,
-             "File already exists: #{normalized_path}. Use edit_file to modify existing files."}
+             "File already exists: #{normalized_path}. Use replace_text or replace_lines to modify existing files."}
           else
             # Write file using FileSystemServer
             case FileSystemServer.write_file(
@@ -761,7 +745,7 @@ defmodule Sagents.Middleware.FileSystem do
                    content
                  ) do
               {:ok, entry} ->
-                {:ok, Jason.encode!(config.entry_to_map.(entry))}
+                {:ok, Jason.encode!(config.file_schema.to_llm_map(entry))}
 
               {:error, reason} ->
                 {:error, "Failed to create file: #{inspect(reason)}"}
@@ -776,7 +760,7 @@ defmodule Sagents.Middleware.FileSystem do
       {:error, "Filesystem not available: #{Exception.message(e)}"}
   end
 
-  defp execute_edit_file_tool(args, _context, config) do
+  defp execute_replace_text_tool(args, _context, config) do
     file_path = get_arg(args, "file_path")
     old_string = get_arg(args, "old_string")
     new_string = get_arg(args, "new_string")
@@ -792,7 +776,7 @@ defmodule Sagents.Middleware.FileSystem do
           # Read current content using FileSystemServer
           case FileSystemServer.read_file(config.filesystem_scope, normalized_path) do
             {:ok, entry} ->
-              perform_edit(
+              perform_text_replacement(
                 config.filesystem_scope,
                 normalized_path,
                 entry.content || "",
@@ -919,7 +903,7 @@ defmodule Sagents.Middleware.FileSystem do
       {:error, "Search failed: #{Exception.message(e)}"}
   end
 
-  defp execute_edit_lines_tool(args, _context, config) do
+  defp execute_replace_lines_tool(args, _context, config) do
     file_path = get_arg(args, "file_path")
     start_line = get_integer_arg(args, "start_line", nil)
     end_line = get_integer_arg(args, "end_line", nil)
@@ -945,7 +929,7 @@ defmodule Sagents.Middleware.FileSystem do
         with {:ok, normalized_path} <- validate_path(file_path),
              {:ok, entry} <-
                FileSystemServer.read_file(config.filesystem_scope, normalized_path) do
-          perform_line_edit(
+          perform_line_replacement(
             config.filesystem_scope,
             normalized_path,
             entry.content || "",
@@ -964,6 +948,96 @@ defmodule Sagents.Middleware.FileSystem do
   rescue
     e ->
       {:error, "Edit failed: #{Exception.message(e)}"}
+  end
+
+  defp execute_update_file_attrs_tool(args, _context, config) do
+    file_path = get_arg(args, "file_path")
+    raw_attrs = get_arg(args, "attrs") || %{}
+    schema = config.file_schema
+
+    with {:ok, normalized_path} <- validate_path(file_path),
+         {:ok, _entry} <-
+           FileSystemServer.read_file(config.filesystem_scope, normalized_path) do
+      changeset = schema.changeset(raw_attrs)
+
+      if changeset.valid? do
+        # Use only the cast-and-validated changes. Fields the LLM supplied that
+        # weren't in the schema's cast list are silently dropped here, which is
+        # the correct behaviour: the schema defines the surface area.
+        changes = changeset.changes
+
+        case apply_validated_changes(config.filesystem_scope, normalized_path, changes) do
+          :ok ->
+            {:ok, updated_entry} =
+              FileSystemServer.read_file(config.filesystem_scope, normalized_path)
+
+            {:ok, Jason.encode!(schema.to_llm_map(updated_entry))}
+
+          {:error, reason} when is_binary(reason) ->
+            {:error, reason}
+
+          {:error, reason} ->
+            {:error, "Failed to update: #{inspect(reason)}"}
+        end
+      else
+        {:error, Utils.changeset_error_to_string(changeset)}
+      end
+    else
+      {:error, :enoent} ->
+        {:error, "File not found: #{file_path}"}
+
+      {:error, reason} when is_binary(reason) ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, inspect(reason)}
+    end
+  rescue
+    e ->
+      {:error, "Filesystem not available: #{Exception.message(e)}"}
+  end
+
+  # Splits a validated change map into entry-level fields and custom metadata,
+  # routing each group to the appropriate FileSystemServer call. Refuses content
+  # changes outright — `update_file_attrs` is metadata-only.
+  defp apply_validated_changes(scope, path, changes) do
+    cond do
+      Map.has_key?(changes, :content) ->
+        {:error,
+         "update_file_attrs cannot modify file content. " <>
+           "Use replace_text or replace_lines to change content, " <>
+           "or create_file for new files."}
+
+      true ->
+        {entry_changes, custom_changes} = Map.split(changes, @entry_fields)
+
+        with :ok <- maybe_update_entry(scope, path, entry_changes),
+             :ok <- maybe_update_custom(scope, path, stringify_keys(custom_changes)) do
+          :ok
+        end
+    end
+  end
+
+  defp maybe_update_entry(_scope, _path, changes) when map_size(changes) == 0, do: :ok
+
+  defp maybe_update_entry(scope, path, changes) do
+    case FileSystemServer.update_entry(scope, path, changes) do
+      {:ok, _entry} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp maybe_update_custom(_scope, _path, changes) when map_size(changes) == 0, do: :ok
+
+  defp maybe_update_custom(scope, path, changes) do
+    case FileSystemServer.update_custom_metadata(scope, path, changes) do
+      {:ok, _entry} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp stringify_keys(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), v} end)
   end
 
   defp search_single_file(filesystem_scope, file_path, regex, context_lines, max_results) do
@@ -1139,7 +1213,14 @@ defmodule Sagents.Middleware.FileSystem do
     lines
   end
 
-  defp perform_edit(filesystem_scope, file_path, content, old_string, new_string, replace_all) do
+  defp perform_text_replacement(
+         filesystem_scope,
+         file_path,
+         content,
+         old_string,
+         new_string,
+         replace_all
+       ) do
     # Split to count occurrences
     parts = String.split(content, old_string, parts: :infinity)
     occurrence_count = length(parts) - 1
@@ -1186,7 +1267,14 @@ defmodule Sagents.Middleware.FileSystem do
     end
   end
 
-  defp perform_line_edit(filesystem_scope, file_path, content, start_line, end_line, new_content) do
+  defp perform_line_replacement(
+         filesystem_scope,
+         file_path,
+         content,
+         start_line,
+         end_line,
+         new_content
+       ) do
     lines = String.split(content, "\n")
     total_lines = length(lines)
 

--- a/mix.exs
+++ b/mix.exs
@@ -113,6 +113,7 @@ defmodule Sagents.MixProject do
           Sagents.FileSystem,
           Sagents.FileSystemServer,
           Sagents.FileSystem.FileEntry,
+          Sagents.FileSystem.FileSchema,
           Sagents.FileSystem.FileMetadata,
           Sagents.FileSystem.FileSystemConfig,
           Sagents.FileSystem.FileSystemState,

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -134,12 +134,12 @@ defmodule Sagents.AgentTest do
 
       {:ok, agent} = Agent.new(%{model: mock_model(), tools: [tool]})
 
-      # Now includes custom tool + write_todos (TodoList) + 8 filesystem tools (ls, read_file, write_file, edit_file, search_text, edit_lines, delete_file, move_file) + SubAgents
-      assert length(agent.tools) == 11
+      # Now includes custom tool + write_todos (TodoList) + 9 filesystem tools (list_files, read_file, create_file, replace_text, replace_lines, update_file_attrs, search_text, delete_file, move_file) + SubAgents
+      assert length(agent.tools) == 12
       tool_names = Enum.map(agent.tools, & &1.name)
       assert "custom_tool" in tool_names
       assert "write_todos" in tool_names
-      assert "ls" in tool_names
+      assert "list_files" in tool_names
       assert "read_file" in tool_names
       assert "task" in tool_names
     end
@@ -194,11 +194,11 @@ defmodule Sagents.AgentTest do
           middleware: [TestMiddleware1, TestMiddleware2]
         })
 
-      # write_todos + 8 filesystem tools + tool1 + tool2 + SubAgents = 12
-      assert length(agent.tools) == 12
+      # write_todos + 9 filesystem tools + tool1 + tool2 + SubAgents = 13
+      assert length(agent.tools) == 13
       tool_names = Enum.map(agent.tools, & &1.name)
       assert "write_todos" in tool_names
-      assert "ls" in tool_names
+      assert "list_files" in tool_names
       assert "tool1" in tool_names
       assert "tool2" in tool_names
       assert "task" in tool_names
@@ -219,13 +219,13 @@ defmodule Sagents.AgentTest do
           middleware: [TestMiddleware1]
         })
 
-      # user_tool + write_todos + 8 filesystem tools + tool1 = 12
-      assert length(agent.tools) == 12
+      # user_tool + write_todos + 9 filesystem tools + tool1 = 13
+      assert length(agent.tools) == 13
       tool_names = Enum.map(agent.tools, & &1.name)
       assert "write_todos" in tool_names
       assert "user_tool" in tool_names
       assert "tool1" in tool_names
-      assert "ls" in tool_names
+      assert "list_files" in tool_names
       assert "delete_file" in tool_names
       assert "task" in tool_names
     end
@@ -473,8 +473,8 @@ defmodule Sagents.AgentTest do
       assert agent.assembled_system_prompt =~ "math assistant"
       assert agent.assembled_system_prompt =~ "logging"
       assert agent.assembled_system_prompt =~ "validation"
-      # calculator + write_todos + 8 filesystem tools + tool1 + tool2 + SubAgents = 13
-      assert length(agent.tools) == 13
+      # calculator + write_todos + 9 filesystem tools + tool1 + tool2 + SubAgents = 14
+      assert length(agent.tools) == 14
 
       # Execute
       initial_state = State.new!(%{messages: [Message.new_user!("What is 2+2?")]})

--- a/test/sagents/file_system/file_entry_test.exs
+++ b/test/sagents/file_system/file_entry_test.exs
@@ -224,9 +224,9 @@ defmodule Sagents.FileSystem.FileEntryTest do
     end
   end
 
-  describe "changeset/2" do
+  describe "internal_changeset/2" do
     test "validates required fields" do
-      changeset = FileEntry.changeset(%FileEntry{}, %{})
+      changeset = FileEntry.internal_changeset(%FileEntry{}, %{})
       refute changeset.valid?
       assert changeset.errors[:path]
       # persistence, loaded, and dirty_content have defaults, so they won't error
@@ -241,8 +241,53 @@ defmodule Sagents.FileSystem.FileEntryTest do
         dirty_content: false
       }
 
-      changeset = FileEntry.changeset(%FileEntry{}, attrs)
+      changeset = FileEntry.internal_changeset(%FileEntry{}, attrs)
       assert changeset.valid?
+    end
+  end
+
+  describe "changeset/1 (FileSchema callback)" do
+    test "casts title, id, and file_type" do
+      changeset = FileEntry.changeset(%{title: "Hello", id: "abc", file_type: "json"})
+      assert changeset.valid?
+      assert changeset.changes == %{title: "Hello", id: "abc", file_type: "json"}
+    end
+
+    test "ignores fields not in cast list" do
+      changeset = FileEntry.changeset(%{title: "Hello", path: "/x", content: "data"})
+      assert changeset.valid?
+      assert changeset.changes == %{title: "Hello"}
+    end
+
+    test "accepts string keys (LLM-supplied attrs)" do
+      changeset = FileEntry.changeset(%{"title" => "Hello", "file_type" => "json"})
+      assert changeset.valid?
+      assert changeset.changes.title == "Hello"
+      assert changeset.changes.file_type == "json"
+    end
+  end
+
+  describe "to_llm_map/1 (FileSchema callback)" do
+    test "returns expected fields" do
+      {:ok, entry} = FileEntry.new_persisted_file("/Characters/Hero", "data", title: "Hero")
+      result = FileEntry.to_llm_map(entry)
+
+      assert result.path == "/Characters/Hero"
+      assert result.title == "Hero"
+      assert result.entry_type == :file
+      assert result.file_type == "markdown"
+      assert result.persistence == :persisted
+      assert is_integer(result.size)
+    end
+
+    test "excludes id when nil" do
+      {:ok, entry} = FileEntry.new_memory_file("/x.txt", "data")
+      refute Map.has_key?(FileEntry.to_llm_map(entry), :id)
+    end
+
+    test "includes id when present" do
+      {:ok, entry} = FileEntry.new_memory_file("/x.txt", "data", id: "doc-1")
+      assert FileEntry.to_llm_map(entry).id == "doc-1"
     end
   end
 

--- a/test/sagents/integration_test.exs
+++ b/test/sagents/integration_test.exs
@@ -113,7 +113,7 @@ defmodule Sagents.IntegrationTest do
                  tool_calls: [
                    ToolCall.new!(%{
                      call_id: "call_456",
-                     name: "write_file",
+                     name: "create_file",
                      arguments: %{
                        "file_path" => "/test.txt",
                        "content" => "Hello, World!"
@@ -214,7 +214,7 @@ defmodule Sagents.IntegrationTest do
                  tool_calls: [
                    ToolCall.new!(%{
                      call_id: "call_2",
-                     name: "write_file",
+                     name: "create_file",
                      arguments: %{
                        "file_path" => "/data.txt",
                        "content" => "Some data"
@@ -296,7 +296,7 @@ defmodule Sagents.IntegrationTest do
                  tool_calls: [
                    ToolCall.new!(%{
                      call_id: "call_1",
-                     name: "write_file",
+                     name: "create_file",
                      arguments: %{"file_path" => "/existing.txt", "content" => "content"}
                    })
                  ]
@@ -312,7 +312,7 @@ defmodule Sagents.IntegrationTest do
                  tool_calls: [
                    ToolCall.new!(%{
                      call_id: "call_2",
-                     name: "write_file",
+                     name: "create_file",
                      arguments: %{"file_path" => "/existing.txt", "content" => "new content"}
                    })
                  ]

--- a/test/sagents/middleware/file_system_test.exs
+++ b/test/sagents/middleware/file_system_test.exs
@@ -1,3 +1,68 @@
+defmodule Sagents.Middleware.FileSystemTest.CustomFileSchema do
+  @moduledoc false
+  @behaviour Sagents.FileSystem.FileSchema
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+    field :title, :string
+    field :system_tag, :string
+    field :tags, {:array, :string}, default: []
+    field :word_count, :integer
+  end
+
+  @impl true
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:title, :system_tag, :tags, :word_count])
+    |> validate_inclusion(:system_tag, ~w(draft review approved published))
+    |> validate_number(:word_count, greater_than: 0)
+  end
+
+  @impl true
+  def to_llm_map(entry) do
+    custom = (entry.metadata && entry.metadata.custom) || %{}
+
+    %{
+      custom_path: entry.path,
+      custom_title: entry.title,
+      system_tag: custom["system_tag"],
+      tags: custom["tags"],
+      word_count: custom["word_count"]
+    }
+    |> Map.reject(fn {_k, v} -> is_nil(v) end)
+  end
+end
+
+defmodule Sagents.Middleware.FileSystemTest.ContentLeakingFileSchema do
+  @moduledoc """
+  An intentionally-broken FileSchema that allows :content in the cast list.
+  Used to verify the middleware's defense-in-depth check rejects content
+  changes even when the schema lets them through.
+  """
+  @behaviour Sagents.FileSystem.FileSchema
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  embedded_schema do
+    field :title, :string
+    field :content, :string
+  end
+
+  @impl true
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:title, :content])
+  end
+
+  @impl true
+  def to_llm_map(entry), do: %{path: entry.path, title: entry.title}
+end
+
 defmodule Sagents.Middleware.FileSystemTest do
   use ExUnit.Case, async: false
 
@@ -25,12 +90,13 @@ defmodule Sagents.Middleware.FileSystemTest do
       assert config.filesystem_scope == {:agent, agent_id}
 
       assert config.enabled_tools == [
-               "ls",
+               "list_files",
                "read_file",
-               "write_file",
-               "edit_file",
+               "create_file",
+               "replace_text",
+               "replace_lines",
+               "update_file_attrs",
                "search_text",
-               "edit_lines",
                "delete_file",
                "move_file"
              ]
@@ -42,14 +108,14 @@ defmodule Sagents.Middleware.FileSystemTest do
       assert {:ok, config} =
                FileSystem.init(
                  filesystem_scope: {:agent, agent_id},
-                 enabled_tools: ["ls", "read_file"]
+                 enabled_tools: ["list_files", "read_file"]
                )
 
-      assert config.enabled_tools == ["ls", "read_file"]
+      assert config.enabled_tools == ["list_files", "read_file"]
     end
 
     test "initializes with custom tool descriptions", %{agent_id: agent_id} do
-      custom = %{"ls" => "Custom ls description"}
+      custom = %{"list_files" => "Custom list_files description"}
       assert {:ok, config} = FileSystem.init(agent_id: agent_id, custom_tool_descriptions: custom)
       assert config.custom_tool_descriptions == custom
     end
@@ -60,79 +126,16 @@ defmodule Sagents.Middleware.FileSystemTest do
       end
     end
 
-    test "accepts custom entry_to_map function", %{agent_id: agent_id} do
-      custom_fn = fn entry -> %{custom_path: entry.path} end
-
+    test "accepts custom file_schema module", %{agent_id: agent_id} do
       assert {:ok, config} =
-               FileSystem.init(agent_id: agent_id, entry_to_map: custom_fn)
+               FileSystem.init(agent_id: agent_id, file_schema: FileEntry)
 
-      assert config.entry_to_map == custom_fn
+      assert config.file_schema == FileEntry
     end
 
-    test "defaults entry_to_map to default_entry_to_map", %{agent_id: agent_id} do
+    test "defaults file_schema to FileEntry", %{agent_id: agent_id} do
       assert {:ok, config} = FileSystem.init(agent_id: agent_id)
-      assert is_function(config.entry_to_map, 1)
-    end
-  end
-
-  describe "default_entry_to_map/1" do
-    test "returns map with expected keys" do
-      {:ok, entry} =
-        FileEntry.new_persisted_file("/Characters/Hero", "some content", title: "Hero")
-
-      result = FileSystem.default_entry_to_map(entry)
-
-      assert result.path == "/Characters/Hero"
-      assert result.title == "Hero"
-      assert result.entry_type == :file
-      assert result.file_type == "markdown"
-      assert result.persistence == :persisted
-      assert is_integer(result.size)
-    end
-
-    test "excludes content" do
-      {:ok, entry} = FileEntry.new_memory_file("/test.txt", "lots of content here")
-      result = FileSystem.default_entry_to_map(entry)
-      refute Map.has_key?(result, :content)
-    end
-
-    test "excludes id when nil" do
-      {:ok, entry} = FileEntry.new_memory_file("/test.txt", "data")
-      result = FileSystem.default_entry_to_map(entry)
-      refute Map.has_key?(result, :id)
-    end
-
-    test "includes id when present" do
-      {:ok, entry} = FileEntry.new_memory_file("/test.txt", "data", id: "doc-123")
-      result = FileSystem.default_entry_to_map(entry)
-      assert result.id == "doc-123"
-    end
-
-    test "handles directory entries" do
-      {:ok, entry} = FileEntry.new_directory("/Characters", title: "Characters")
-      result = FileSystem.default_entry_to_map(entry)
-
-      assert result.entry_type == :directory
-      assert result.file_type == nil
-      assert result.title == "Characters"
-    end
-
-    test "includes size from metadata" do
-      {:ok, entry} = FileEntry.new_memory_file("/test.txt", "hello")
-      result = FileSystem.default_entry_to_map(entry)
-      assert result.size == byte_size("hello")
-    end
-  end
-
-  describe "maybe_add_field/3" do
-    test "adds field when value is non-nil" do
-      result = FileSystem.maybe_add_field(%{a: 1}, :b, "value")
-      assert result == %{a: 1, b: "value"}
-    end
-
-    test "skips field when value is nil" do
-      result = FileSystem.maybe_add_field(%{a: 1}, :b, nil)
-      assert result == %{a: 1}
+      assert config.file_schema == FileEntry
     end
   end
 
@@ -142,39 +145,44 @@ defmodule Sagents.Middleware.FileSystemTest do
       prompt = FileSystem.system_prompt(config)
 
       assert prompt =~ "Filesystem Tools"
-      assert prompt =~ "ls"
+      assert prompt =~ "list_files"
       assert prompt =~ "read_file"
-      assert prompt =~ "write_file"
-      assert prompt =~ "edit_file"
+      assert prompt =~ "create_file"
+      assert prompt =~ "replace_text"
+      assert prompt =~ "replace_lines"
+      assert prompt =~ "update_file_attrs"
       assert prompt =~ "must start with a forward slash"
     end
   end
 
   describe "tools/1" do
-    test "returns all eight filesystem tools by default", %{agent_id: agent_id} do
+    test "returns all nine filesystem tools by default", %{agent_id: agent_id} do
       tools =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
+          file_schema: FileEntry,
           enabled_tools: [
-            "ls",
+            "list_files",
             "read_file",
-            "write_file",
-            "edit_file",
+            "create_file",
+            "replace_text",
+            "replace_lines",
+            "update_file_attrs",
             "search_text",
-            "edit_lines",
             "delete_file",
             "move_file"
           ]
         })
 
-      assert length(tools) == 8
+      assert length(tools) == 9
       tool_names = Enum.map(tools, & &1.name)
-      assert "ls" in tool_names
+      assert "list_files" in tool_names
       assert "read_file" in tool_names
-      assert "write_file" in tool_names
-      assert "edit_file" in tool_names
+      assert "create_file" in tool_names
+      assert "replace_text" in tool_names
+      assert "replace_lines" in tool_names
+      assert "update_file_attrs" in tool_names
       assert "search_text" in tool_names
-      assert "edit_lines" in tool_names
       assert "delete_file" in tool_names
       assert "move_file" in tool_names
     end
@@ -183,32 +191,47 @@ defmodule Sagents.Middleware.FileSystemTest do
       tools =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file"]
+          file_schema: FileEntry,
+          enabled_tools: ["list_files", "read_file"]
         })
 
       assert length(tools) == 2
       tool_names = Enum.map(tools, & &1.name)
-      assert "ls" in tool_names
+      assert "list_files" in tool_names
       assert "read_file" in tool_names
-      refute "write_file" in tool_names
-      refute "edit_file" in tool_names
+      refute "create_file" in tool_names
+      refute "replace_text" in tool_names
+    end
+
+    test "old tool names no longer resolve", %{agent_id: agent_id} do
+      tools =
+        FileSystem.tools(%{
+          filesystem_scope: {:agent, agent_id},
+          file_schema: FileEntry,
+          enabled_tools: ["ls", "write_file", "edit_file", "edit_lines"]
+        })
+
+      assert tools == []
     end
   end
 
-  describe "ls tool" do
+  defp tool_named(tools, name), do: Enum.find(tools, &(&1.name == name))
+
+  describe "list_files tool" do
     test "lists files as JSON array of entry maps", %{agent_id: agent_id} do
       # Write some files
       FileSystemServer.write_file({:agent, agent_id}, "/file1.txt", "content1")
       FileSystemServer.write_file({:agent, agent_id}, "/file2.txt", "content2")
 
-      [ls_tool | _] =
+      list_files_tool =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file", "edit_file"],
-          entry_to_map: &FileSystem.default_entry_to_map/1
+          enabled_tools: ["list_files"],
+          file_schema: FileEntry
         })
+        |> tool_named("list_files")
 
-      assert {:ok, result} = ls_tool.function.(%{}, %{state: State.new!()})
+      assert {:ok, result} = list_files_tool.function.(%{}, %{state: State.new!()})
       entries = Jason.decode!(result)
       assert is_list(entries)
       paths = Enum.map(entries, & &1["path"])
@@ -223,14 +246,15 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
 
     test "reports empty filesystem", %{agent_id: agent_id} do
-      [ls_tool | _] =
+      list_files_tool =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file", "edit_file"],
-          entry_to_map: &FileSystem.default_entry_to_map/1
+          enabled_tools: ["list_files"],
+          file_schema: FileEntry
         })
+        |> tool_named("list_files")
 
-      assert {:ok, result} = ls_tool.function.(%{}, %{state: State.new!()})
+      assert {:ok, result} = list_files_tool.function.(%{}, %{state: State.new!()})
       assert result == "No files in filesystem"
     end
 
@@ -239,14 +263,17 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.md", "content")
       FileSystemServer.write_file({:agent, agent_id}, "/other.txt", "content")
 
-      [ls_tool | _] =
+      list_files_tool =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file", "edit_file"],
-          entry_to_map: &FileSystem.default_entry_to_map/1
+          enabled_tools: ["list_files"],
+          file_schema: FileEntry
         })
+        |> tool_named("list_files")
 
-      assert {:ok, result} = ls_tool.function.(%{"pattern" => "*test*"}, %{state: State.new!()})
+      assert {:ok, result} =
+               list_files_tool.function.(%{"pattern" => "*test*"}, %{state: State.new!()})
+
       entries = Jason.decode!(result)
       paths = Enum.map(entries, & &1["path"])
       assert "/test.txt" in paths
@@ -254,22 +281,21 @@ defmodule Sagents.Middleware.FileSystemTest do
       refute "/other.txt" in paths
     end
 
-    test "uses custom entry_to_map function", %{agent_id: agent_id} do
-      FileSystemServer.write_file({:agent, agent_id}, "/doc.txt", "hello")
+    test "uses custom file_schema module", %{agent_id: agent_id} do
+      FileSystemServer.write_file({:agent, agent_id}, "/doc.txt", "hello", title: "Doc Title")
 
-      custom_fn = fn entry -> %{custom_path: entry.path, custom_title: entry.title} end
-
-      [ls_tool | _] =
+      list_files_tool =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls"],
-          entry_to_map: custom_fn
+          enabled_tools: ["list_files"],
+          file_schema: Sagents.Middleware.FileSystemTest.CustomFileSchema
         })
+        |> tool_named("list_files")
 
-      assert {:ok, result} = ls_tool.function.(%{}, %{state: State.new!()})
+      assert {:ok, result} = list_files_tool.function.(%{}, %{state: State.new!()})
       [entry] = Jason.decode!(result)
       assert entry["custom_path"] == "/doc.txt"
-      assert Map.has_key?(entry, "custom_title")
+      assert entry["custom_title"] == "Doc Title"
       refute Map.has_key?(entry, "entry_type")
     end
   end
@@ -286,13 +312,14 @@ defmodule Sagents.Middleware.FileSystemTest do
 
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", String.trim(content))
 
-      [_, read_file_tool | _] =
+      tool =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file", "edit_file"]
+          enabled_tools: ["read_file"]
         })
+        |> tool_named("read_file")
 
-      %{tool: read_file_tool}
+      %{tool: tool}
     end
 
     test "reads entire file with line numbers", %{tool: tool} do
@@ -347,16 +374,17 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "write_file tool" do
+  describe "create_file tool" do
     setup %{agent_id: agent_id} do
-      [_, _, write_file_tool | _] =
+      tool =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file", "edit_file"],
-          entry_to_map: &FileSystem.default_entry_to_map/1
+          enabled_tools: ["create_file"],
+          file_schema: FileEntry
         })
+        |> tool_named("create_file")
 
-      %{tool: write_file_tool}
+      %{tool: tool}
     end
 
     test "creates new file and returns JSON entry map", %{agent_id: agent_id, tool: tool} do
@@ -383,6 +411,7 @@ defmodule Sagents.Middleware.FileSystemTest do
 
       assert {:error, message} = tool.function.(args, %{state: State.new!()})
       assert message =~ "already exists"
+      assert message =~ "replace_text or replace_lines"
     end
 
     test "rejects paths without leading slash", %{tool: tool} do
@@ -400,17 +429,18 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "edit_file tool" do
+  describe "replace_text tool" do
     setup %{agent_id: agent_id} do
       FileSystemServer.write_file({:agent, agent_id}, "/edit.txt", "Hello World")
 
-      [_, _, _, edit_file_tool] =
+      tool =
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file", "edit_file"]
+          enabled_tools: ["replace_text"]
         })
+        |> tool_named("replace_text")
 
-      %{tool: edit_file_tool}
+      %{tool: tool}
     end
 
     test "edits file with single occurrence", %{agent_id: agent_id, tool: tool} do
@@ -491,7 +521,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         FileSystem.tools(%{
           filesystem_scope: {:agent, agent_id},
           enabled_tools: ["move_file"],
-          entry_to_map: &FileSystem.default_entry_to_map/1
+          file_schema: FileEntry
         })
 
       [move_file_tool] = tools
@@ -924,7 +954,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       {:ok, config} =
         FileSystem.init(
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file"]
+          enabled_tools: ["list_files", "read_file", "create_file"]
         )
 
       search_tool = config |> FileSystem.tools() |> get_search_text_tool()
@@ -1024,15 +1054,15 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  defp get_edit_lines_tool(tools) when is_list(tools) do
-    Enum.find(tools, fn tool -> tool.name == "edit_lines" end)
+  defp get_replace_lines_tool(tools) when is_list(tools) do
+    Enum.find(tools, fn tool -> tool.name == "replace_lines" end)
   end
 
-  describe "edit_lines tool - basic functionality" do
-    test "edit_lines tool is enabled in FileSystem", %{agent_id: agent_id} do
+  describe "replace_lines tool - basic functionality" do
+    test "replace_lines tool is enabled in FileSystem", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
-      assert edit_lines_tool != nil
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
+      assert replace_lines_tool != nil
     end
 
     test "replaces a single line", %{agent_id: agent_id} do
@@ -1045,7 +1075,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1054,7 +1084,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "REPLACED LINE 3"
       }
 
-      {:ok, result} = edit_lines_tool.function.(args, %{})
+      {:ok, result} = replace_lines_tool.function.(args, %{})
 
       assert result =~ "File edited successfully"
       assert result =~ "Replaced 1 lines (3-3)"
@@ -1079,7 +1109,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1088,7 +1118,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "NEW LINE A\nNEW LINE B"
       }
 
-      {:ok, result} = edit_lines_tool.function.(args, %{})
+      {:ok, result} = replace_lines_tool.function.(args, %{})
 
       assert result =~ "File edited successfully"
       assert result =~ "Replaced 3 lines (2-4)"
@@ -1108,7 +1138,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       new_content = """
       New paragraph 1
@@ -1123,7 +1153,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => String.trim(new_content)
       }
 
-      {:ok, result} = edit_lines_tool.function.(args, %{})
+      {:ok, result} = replace_lines_tool.function.(args, %{})
       assert result =~ "Replaced 2 lines"
 
       {:ok, %{content: content}} = FileSystemServer.read_file({:agent, agent_id}, "/story.txt")
@@ -1136,7 +1166,7 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "edit_lines tool - boundary conditions" do
+  describe "replace_lines tool - boundary conditions" do
     test "replaces first line only", %{agent_id: agent_id} do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", """
       Line 1
@@ -1145,7 +1175,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1154,7 +1184,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "REPLACED FIRST LINE"
       }
 
-      {:ok, result} = edit_lines_tool.function.(args, %{})
+      {:ok, result} = replace_lines_tool.function.(args, %{})
       assert result =~ "Replaced 1 lines (1-1)"
 
       {:ok, %{content: content}} = FileSystemServer.read_file({:agent, agent_id}, "/test.txt")
@@ -1170,7 +1200,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1179,7 +1209,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "REPLACED LAST LINE"
       }
 
-      {:ok, result} = edit_lines_tool.function.(args, %{})
+      {:ok, result} = replace_lines_tool.function.(args, %{})
       assert result =~ "Replaced 1 lines (4-4)"
 
       {:ok, %{content: content}} = FileSystemServer.read_file({:agent, agent_id}, "/test.txt")
@@ -1195,7 +1225,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1204,7 +1234,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "Completely new content"
       }
 
-      {:ok, result} = edit_lines_tool.function.(args, %{})
+      {:ok, result} = replace_lines_tool.function.(args, %{})
       assert result =~ "Replaced 4 lines (1-4)"
 
       {:ok, %{content: content}} = FileSystemServer.read_file({:agent, agent_id}, "/test.txt")
@@ -1219,7 +1249,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1228,7 +1258,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => ""
       }
 
-      {:ok, result} = edit_lines_tool.function.(args, %{})
+      {:ok, result} = replace_lines_tool.function.(args, %{})
       assert result =~ "Replaced 1 lines"
 
       {:ok, %{content: content}} = FileSystemServer.read_file({:agent, agent_id}, "/test.txt")
@@ -1238,10 +1268,10 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "edit_lines tool - error cases" do
+  describe "replace_lines tool - error cases" do
     test "returns error for non-existent file", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/nonexistent.txt",
@@ -1250,7 +1280,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "File not found"
     end
 
@@ -1258,7 +1288,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", "Line 1\nLine 2")
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1267,7 +1297,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "start_line must be >= 1"
     end
 
@@ -1275,7 +1305,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", "Line 1\nLine 2\nLine 3")
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1284,7 +1314,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "end_line must be >= start_line"
     end
 
@@ -1292,7 +1322,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", "Line 1\nLine 2")
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1301,7 +1331,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "start_line 10 is beyond file length"
     end
 
@@ -1309,7 +1339,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", "Line 1\nLine 2\nLine 3")
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1318,13 +1348,13 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "end_line 10 is beyond file length"
     end
 
     test "returns error for invalid path", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "no-slash.txt",
@@ -1333,13 +1363,13 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "Path must start with '/'"
     end
 
     test "returns error when file_path is missing", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "start_line" => 1,
@@ -1347,13 +1377,13 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "file_path is required"
     end
 
     test "returns error when start_line is missing", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1361,13 +1391,13 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "content"
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "start_line and end_line are required"
     end
 
     test "returns error when new_content is missing", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
       args = %{
         "file_path" => "/test.txt",
@@ -1375,13 +1405,13 @@ defmodule Sagents.Middleware.FileSystemTest do
         "end_line" => 1
       }
 
-      {:error, error_msg} = edit_lines_tool.function.(args, %{})
+      {:error, error_msg} = replace_lines_tool.function.(args, %{})
       assert error_msg =~ "new_content is required"
     end
   end
 
-  describe "edit_lines tool - integration scenarios" do
-    test "read then edit_lines workflow", %{agent_id: agent_id} do
+  describe "replace_lines tool - integration scenarios" do
+    test "read then replace_lines workflow", %{agent_id: agent_id} do
       FileSystemServer.write_file({:agent, agent_id}, "/document.md", """
       # Title
 
@@ -1404,8 +1434,8 @@ defmodule Sagents.Middleware.FileSystemTest do
       assert read_result =~ "4\tOld content here."
       assert read_result =~ "5\tMore old content."
 
-      # Now use edit_lines to replace lines 4-5
-      edit_lines_tool = Enum.find(tools, fn tool -> tool.name == "edit_lines" end)
+      # Now use replace_lines to replace lines 4-5
+      replace_lines_tool = Enum.find(tools, fn tool -> tool.name == "replace_lines" end)
 
       args = %{
         "file_path" => "/document.md",
@@ -1414,7 +1444,7 @@ defmodule Sagents.Middleware.FileSystemTest do
         "new_content" => "Brand new content.\nCompletely rewritten."
       }
 
-      {:ok, edit_result} = edit_lines_tool.function.(args, %{})
+      {:ok, edit_result} = replace_lines_tool.function.(args, %{})
       assert edit_result =~ "Replaced 2 lines"
 
       # Read again to verify
@@ -1424,26 +1454,26 @@ defmodule Sagents.Middleware.FileSystemTest do
       refute final_result =~ "Old content here."
     end
 
-    test "edit_lines can be disabled via config", %{agent_id: agent_id} do
+    test "replace_lines can be disabled via config", %{agent_id: agent_id} do
       {:ok, config} =
         FileSystem.init(
           filesystem_scope: {:agent, agent_id},
-          enabled_tools: ["ls", "read_file", "write_file"]
+          enabled_tools: ["list_files", "read_file", "create_file"]
         )
 
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
-      assert edit_lines_tool == nil
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
+      assert replace_lines_tool == nil
     end
 
-    test "edit_lines tool has correct schema", %{agent_id: agent_id} do
+    test "replace_lines tool has correct schema", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      edit_lines_tool = config |> FileSystem.tools() |> get_edit_lines_tool()
+      replace_lines_tool = config |> FileSystem.tools() |> get_replace_lines_tool()
 
-      assert edit_lines_tool.name == "edit_lines"
-      assert is_binary(edit_lines_tool.description)
+      assert replace_lines_tool.name == "replace_lines"
+      assert is_binary(replace_lines_tool.description)
 
       # Verify parameters schema
-      schema = edit_lines_tool.parameters_schema
+      schema = replace_lines_tool.parameters_schema
       assert schema.type == "object"
       assert "file_path" in schema.required
       assert "start_line" in schema.required
@@ -1455,6 +1485,203 @@ defmodule Sagents.Middleware.FileSystemTest do
       assert Map.has_key?(properties, :start_line)
       assert Map.has_key?(properties, :end_line)
       assert Map.has_key?(properties, :new_content)
+    end
+  end
+
+  describe "update_file_attrs tool" do
+    alias Sagents.Middleware.FileSystemTest.{CustomFileSchema, ContentLeakingFileSchema}
+
+    defp update_attrs_tool(agent_id, opts \\ []) do
+      schema = Keyword.get(opts, :file_schema, FileEntry)
+
+      FileSystem.tools(%{
+        filesystem_scope: {:agent, agent_id},
+        enabled_tools: ["update_file_attrs"],
+        file_schema: schema
+      })
+      |> tool_named("update_file_attrs")
+    end
+
+    test "is registered with correct name and display text", %{agent_id: agent_id} do
+      tool = update_attrs_tool(agent_id)
+      assert tool.name == "update_file_attrs"
+      assert tool.display_text == "Updating file attributes"
+    end
+
+    test "updates entry-level fields (title, file_type)", %{agent_id: agent_id} do
+      FileSystemServer.write_file({:agent, agent_id}, "/doc.md", "body", title: "Old Title")
+      tool = update_attrs_tool(agent_id)
+
+      args = %{
+        "file_path" => "/doc.md",
+        "attrs" => %{"title" => "New Title", "file_type" => "json"}
+      }
+
+      assert {:ok, json} = tool.function.(args, %{state: State.new!()})
+      result = Jason.decode!(json)
+      assert result["title"] == "New Title"
+      assert result["file_type"] == "json"
+
+      {:ok, entry} = FileSystemServer.read_file({:agent, agent_id}, "/doc.md")
+      assert entry.title == "New Title"
+      assert entry.file_type == "json"
+      assert entry.content == "body"
+    end
+
+    test "updates custom metadata fields via custom schema", %{agent_id: agent_id} do
+      FileSystemServer.write_file({:agent, agent_id}, "/doc.md", "body", title: "Doc")
+      tool = update_attrs_tool(agent_id, file_schema: CustomFileSchema)
+
+      args = %{
+        "file_path" => "/doc.md",
+        "attrs" => %{"system_tag" => "draft", "tags" => ["a", "b"], "word_count" => 100}
+      }
+
+      assert {:ok, json} = tool.function.(args, %{state: State.new!()})
+      result = Jason.decode!(json)
+      assert result["system_tag"] == "draft"
+      assert result["tags"] == ["a", "b"]
+      assert result["word_count"] == 100
+
+      {:ok, entry} = FileSystemServer.read_file({:agent, agent_id}, "/doc.md")
+      # Custom fields go into metadata.custom (string keys)
+      assert entry.metadata.custom["system_tag"] == "draft"
+      assert entry.metadata.custom["tags"] == ["a", "b"]
+      assert entry.metadata.custom["word_count"] == 100
+    end
+
+    test "updates entry-level and custom fields in one call", %{agent_id: agent_id} do
+      FileSystemServer.write_file({:agent, agent_id}, "/doc.md", "body", title: "Old")
+      tool = update_attrs_tool(agent_id, file_schema: CustomFileSchema)
+
+      args = %{
+        "file_path" => "/doc.md",
+        "attrs" => %{"title" => "New", "system_tag" => "review"}
+      }
+
+      assert {:ok, _json} = tool.function.(args, %{state: State.new!()})
+
+      {:ok, entry} = FileSystemServer.read_file({:agent, agent_id}, "/doc.md")
+      assert entry.title == "New"
+      assert entry.metadata.custom["system_tag"] == "review"
+    end
+
+    test "returns formatted changeset errors when validation fails", %{agent_id: agent_id} do
+      FileSystemServer.write_file({:agent, agent_id}, "/doc.md", "body")
+      tool = update_attrs_tool(agent_id, file_schema: CustomFileSchema)
+
+      args = %{
+        "file_path" => "/doc.md",
+        "attrs" => %{"system_tag" => "garbage", "word_count" => -5}
+      }
+
+      assert {:error, message} = tool.function.(args, %{state: State.new!()})
+      assert message =~ "system_tag"
+      assert message =~ "word_count"
+    end
+
+    test "returns 'File not found' for missing file", %{agent_id: agent_id} do
+      tool = update_attrs_tool(agent_id)
+
+      args = %{"file_path" => "/missing.md", "attrs" => %{"title" => "x"}}
+
+      assert {:error, message} = tool.function.(args, %{state: State.new!()})
+      assert message =~ "not found"
+    end
+
+    test "rejects :content with redirect-to-replace-tools error", %{agent_id: agent_id} do
+      FileSystemServer.write_file({:agent, agent_id}, "/doc.md", "body")
+      tool = update_attrs_tool(agent_id, file_schema: ContentLeakingFileSchema)
+
+      args = %{
+        "file_path" => "/doc.md",
+        "attrs" => %{"content" => "rewritten"}
+      }
+
+      assert {:error, message} = tool.function.(args, %{state: State.new!()})
+      assert message =~ "cannot modify file content"
+      assert message =~ "replace_text or replace_lines"
+      assert message =~ "create_file"
+
+      # Content was not changed
+      {:ok, entry} = FileSystemServer.read_file({:agent, agent_id}, "/doc.md")
+      assert entry.content == "body"
+    end
+
+    test "default FileEntry schema silently drops :content from cast", %{agent_id: agent_id} do
+      FileSystemServer.write_file({:agent, agent_id}, "/doc.md", "body", title: "Title")
+      tool = update_attrs_tool(agent_id)
+
+      # Default FileEntry.changeset/1 doesn't cast :content, so it's dropped
+      # before the routing-layer check ever sees it.
+      args = %{
+        "file_path" => "/doc.md",
+        "attrs" => %{"content" => "rewritten", "title" => "Updated"}
+      }
+
+      assert {:ok, json} = tool.function.(args, %{state: State.new!()})
+      result = Jason.decode!(json)
+      assert result["title"] == "Updated"
+
+      {:ok, entry} = FileSystemServer.read_file({:agent, agent_id}, "/doc.md")
+      assert entry.content == "body"
+      assert entry.title == "Updated"
+    end
+
+    test "rejects invalid path", %{agent_id: agent_id} do
+      tool = update_attrs_tool(agent_id)
+
+      args = %{"file_path" => "no-slash.md", "attrs" => %{"title" => "x"}}
+
+      assert {:error, message} = tool.function.(args, %{state: State.new!()})
+      assert message =~ "must start with"
+    end
+
+    test "to_llm_map output is consistent across list_files, create_file, update_file_attrs",
+         %{agent_id: agent_id} do
+      tools =
+        FileSystem.tools(%{
+          filesystem_scope: {:agent, agent_id},
+          enabled_tools: ["list_files", "create_file", "update_file_attrs"],
+          file_schema: FileEntry
+        })
+
+      create_tool = tool_named(tools, "create_file")
+      list_tool = tool_named(tools, "list_files")
+      update_tool = tool_named(tools, "update_file_attrs")
+
+      {:ok, create_json} =
+        create_tool.function.(
+          %{"file_path" => "/doc.md", "content" => "hi"},
+          %{state: State.new!()}
+        )
+
+      {:ok, list_json} = list_tool.function.(%{}, %{state: State.new!()})
+
+      {:ok, update_json} =
+        update_tool.function.(
+          %{"file_path" => "/doc.md", "attrs" => %{"title" => "Title"}},
+          %{state: State.new!()}
+        )
+
+      create_map = Jason.decode!(create_json)
+      [list_map] = Jason.decode!(list_json)
+      update_map = Jason.decode!(update_json)
+
+      # All three should have the same shape (path, entry_type, file_type, etc.)
+      assert Map.keys(create_map) -- [:title] == Map.keys(list_map) -- [:title]
+      assert Map.keys(update_map) -- ["title"] == Map.keys(create_map) -- ["title"]
+    end
+  end
+
+  describe "FileSchema callback contract" do
+    test "FileEntry implements the FileSchema behaviour" do
+      assert function_exported?(FileEntry, :changeset, 1)
+      assert function_exported?(FileEntry, :to_llm_map, 1)
+    end
+
+    test "behaviours/0 lists FileSchema for FileEntry" do
+      assert Sagents.FileSystem.FileSchema in FileEntry.module_info(:attributes)[:behaviour]
     end
   end
 end


### PR DESCRIPTION
## Problem

The `Sagents.Middleware.FileSystem` middleware previously had no clean way for applications to add custom validated attributes to files. Custom serialization required passing an `entry_to_map` function, but there was no corresponding hook for *validating* LLM-supplied attribute updates — applications couldn't enforce things like \"a file's `system_tag` must be one of `draft|review|approved|published`\".

Separately, the filesystem tool names (`ls`, `write_file`, `edit_file`, `edit_lines`) were leading to weaker LLM tool selection. Models would reach for `write_file` to modify existing files or get confused between `edit_file` and `edit_lines`.

## Solution

Introduce a new `Sagents.FileSystem.FileSchema` behaviour with two callbacks:

- `changeset/1` — casts and validates LLM-supplied attribute updates, returning an `Ecto.Changeset` so errors can be formatted back to the LLM for self-correction.
- `to_llm_map/1` — converts a `FileEntry` into the JSON map representation the LLM sees.

`Sagents.FileSystem.FileEntry` implements the behaviour by default, so existing code keeps working. Applications now provide their own schema module via the `:file_schema` middleware option to add custom fields with validation. The middleware automatically routes validated changes: fields matching the `FileEntry` struct (`:title`, `:id`, `:file_type`) update the entry directly, while everything else is stored in `metadata.custom`. Implementations declare *what* attributes exist — the middleware decides *where* they live.

The middleware also defends against schemas that mistakenly include `:content` in their cast list — content changes must always go through `replace_text`, `replace_lines`, or `create_file`.

Tools were renamed for clearer LLM tool selection:

- `ls` → `list_files`
- `write_file` → `create_file` (now errors if the file already exists)
- `edit_file` → `replace_text`
- `edit_lines` → `replace_lines`
- New `update_file_attrs` tool for metadata-only updates

The `FileEntry` internal changeset was renamed `internal_changeset/2` to disambiguate it from the new `FileSchema.changeset/1` callback.

## Changes

- \`lib/sagents/file_system/file_schema.ex\` — New behaviour module defining `changeset/1` and `to_llm_map/1` callbacks, with full module docs and a worked example.
- \`lib/sagents/file_system/file_entry.ex\` — Implements `FileSchema` behaviour with default `changeset/1` (casts `:title`, `:id`, `:file_type`) and `to_llm_map/1`. Renamed existing `changeset/2` to `internal_changeset/2`.
- \`lib/sagents/middleware/file_system.ex\` — Renamed tools (`list_files`, `create_file`, `replace_text`, `replace_lines`, `update_file_attrs`); added `:file_schema` config option; routes validated changes to entry fields vs `metadata.custom`; rejects `:content` in attribute updates; updated system prompt and tool descriptions for better LLM performance.
- \`mix.exs\` — Added `Sagents.FileSystem.FileSchema` to the FileSystem ExDoc group.
- \`test/sagents/middleware/file_system_test.exs\` — Substantial expansion: tests for custom `FileSchema` modules, validation error formatting, content-rejection defense, and the renamed tools. Includes two test schema modules (`CustomFileSchema`, `ContentLeakingFileSchema`).
- \`test/sagents/file_system/file_entry_test.exs\` — Updated for the renamed `internal_changeset/2` and the new `FileSchema` callbacks on `FileEntry`.
- \`test/sagents/agent_test.exs\`, \`test/sagents/integration_test.exs\` — Updated to use the new tool names.

## Testing

- `mix test` — All unit tests pass, including the new `FileSchema` behaviour tests, custom schema validation tests, and the content-rejection defense-in-depth tests.
- The renamed tools are exercised end-to-end in the integration test.
- No live API tests were added — the changes are purely about tool registration, schema validation, and state routing, all of which are testable without an LLM.