### PR TITLE
Rename search_text to find_in_file and validate FileSystem tool config

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Sagents includes several pre-built middleware components:
 | Middleware | Description |
 |------------|-------------|
 | **TodoList** | Task management with `write_todos` tool for tracking multi-step work |
-| **FileSystem** | Virtual filesystem with `ls`, `read_file`, `write_file`, `edit_file`, `search_text`, `edit_lines`, `delete_file` |
+| **FileSystem** | Virtual filesystem with `ls`, `read_file`, `write_file`, `edit_file`, `find_in_file`, `edit_lines`, `delete_file` |
 | **HumanInTheLoop** | Pause execution for human approval on configurable tools |
 | **SubAgent** | Delegate tasks to specialized child agents for parallel execution |
 | **Summarization** | Automatic conversation compression when token limits approach |

--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -374,6 +374,14 @@ defmodule Sagents.Agent do
     end
   end
 
+  # Skip when the changeset already has errors — most commonly this means
+  # `build_and_initialize_middleware/2` called `add_error` after a middleware
+  # `init/1` returned `{:error, _}`. In that case the `:middleware` field still
+  # holds the un-normalized cast value (raw `{Module, opts}` tuples), and
+  # iterating it here would crash with FunctionClauseError, masking the real
+  # error message we want the caller to see.
+  defp assemble_full_system_prompt(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+
   defp assemble_full_system_prompt(changeset) do
     base_prompt = get_field(changeset, :base_system_prompt) || ""
     initialized_middleware = get_field(changeset, :middleware) || []
@@ -390,6 +398,8 @@ defmodule Sagents.Agent do
 
     put_change(changeset, :assembled_system_prompt, full_prompt)
   end
+
+  defp collect_all_tools(%Ecto.Changeset{valid?: false} = changeset), do: changeset
 
   defp collect_all_tools(changeset) do
     base_tools = get_field(changeset, :tools) || []

--- a/lib/sagents/middleware/file_system.ex
+++ b/lib/sagents/middleware/file_system.ex
@@ -9,7 +9,7 @@ defmodule Sagents.Middleware.FileSystem do
   - `replace_text`: Make targeted edits with string replacement
   - `replace_lines`: Replace a range of lines by line number
   - `update_file_attrs`: Update file attributes (title, tags, etc.) — no content changes
-  - `search_text`: Search for text patterns within files or across all files
+  - `find_in_file`: Find text or regex matches within a single file
   - `delete_file`: Delete files from the filesystem
   - `move_file`: Move or rename files and directories
 
@@ -47,7 +47,7 @@ defmodule Sagents.Middleware.FileSystem do
       )
 
   Available tools: `"list_files"`, `"read_file"`, `"create_file"`, `"replace_text"`,
-  `"replace_lines"`, `"update_file_attrs"`, `"search_text"`, `"delete_file"`,
+  `"replace_lines"`, `"update_file_attrs"`, `"find_in_file"`, `"delete_file"`,
   `"move_file"`
 
   ### Custom Tool Descriptions
@@ -141,7 +141,7 @@ defmodule Sagents.Middleware.FileSystem do
     "replace_text",
     "replace_lines",
     "update_file_attrs",
-    "search_text",
+    "find_in_file",
     "delete_file",
     "move_file"
   ]
@@ -156,7 +156,7 @@ defmodule Sagents.Middleware.FileSystem do
   - `replace_text`: Replace a string with another string in an existing file. The old_string must appear exactly once unless replace_all is set.
   - `replace_lines`: Replace a range of lines (by line number) with new content. More token-efficient than replace_text for large block replacements.
   - `update_file_attrs`: Update file attributes (title, tags, etc.) without modifying file content. Validated against the file schema.
-  - `search_text`: Search for text patterns within or across files.
+  - `find_in_file`: Find text or regex matches within a single file. Requires an exact file path — use `list_files` first to discover paths.
   - `delete_file`: Delete a file from the filesystem.
   - `move_file`: Move or rename a file or directory.
 
@@ -208,15 +208,67 @@ defmodule Sagents.Middleware.FileSystem do
           scope
       end
 
-    config = %{
-      filesystem_scope: filesystem_scope,
-      # Tool configuration
-      enabled_tools: Keyword.get(opts, :enabled_tools, @default_enabled_tools),
-      custom_tool_descriptions: Keyword.get(opts, :custom_tool_descriptions, %{}),
-      file_schema: Keyword.get(opts, :file_schema, FileEntry)
-    }
+    enabled_tools = Keyword.get(opts, :enabled_tools, @default_enabled_tools)
+    custom_tool_descriptions = Keyword.get(opts, :custom_tool_descriptions, %{})
 
-    {:ok, config}
+    with :ok <- validate_enabled_tools(enabled_tools),
+         :ok <- validate_custom_tool_descriptions(custom_tool_descriptions) do
+      config = %{
+        filesystem_scope: filesystem_scope,
+        # Tool configuration
+        enabled_tools: enabled_tools,
+        custom_tool_descriptions: custom_tool_descriptions,
+        file_schema: Keyword.get(opts, :file_schema, FileEntry)
+      }
+
+      {:ok, config}
+    end
+  end
+
+  # Rejects unknown tool names in `:enabled_tools` so misconfigured middleware
+  # fails fast at agent construction (rather than silently dropping the entry
+  # in `tools/1`). This is especially useful when a tool is renamed: stale
+  # config will surface immediately instead of becoming a silent no-op.
+  defp validate_enabled_tools(enabled_tools) when is_list(enabled_tools) do
+    unknown = Enum.reject(enabled_tools, &(&1 in @default_enabled_tools))
+
+    if unknown == [] do
+      :ok
+    else
+      {:error,
+       "Unknown tool name(s) in :enabled_tools: #{inspect(unknown)}. " <>
+         "Valid tools: #{inspect(@default_enabled_tools)}."}
+    end
+  end
+
+  defp validate_enabled_tools(other) do
+    {:error, ":enabled_tools must be a list of tool name strings, got: #{inspect(other)}"}
+  end
+
+  # Rejects unknown keys in `:custom_tool_descriptions`. Same rationale as
+  # `validate_enabled_tools/1`: a stale key from a renamed tool is silently
+  # ignored at lookup time (`get_custom_description/3`), which makes typos
+  # and migration leftovers invisible. Validates against the full set of
+  # known tools — not just the currently-enabled subset — so a description
+  # for a tool the user has temporarily disabled is still allowed.
+  defp validate_custom_tool_descriptions(descriptions) when is_map(descriptions) do
+    unknown =
+      descriptions
+      |> Map.keys()
+      |> Enum.reject(&(&1 in @default_enabled_tools))
+
+    if unknown == [] do
+      :ok
+    else
+      {:error,
+       "Unknown tool name(s) in :custom_tool_descriptions: #{inspect(unknown)}. " <>
+         "Valid tools: #{inspect(@default_enabled_tools)}."}
+    end
+  end
+
+  defp validate_custom_tool_descriptions(other) do
+    {:error,
+     ":custom_tool_descriptions must be a map of tool name strings to descriptions, got: #{inspect(other)}"}
   end
 
   @impl true
@@ -233,7 +285,7 @@ defmodule Sagents.Middleware.FileSystem do
       "replace_text" => build_replace_text_tool(config),
       "replace_lines" => build_replace_lines_tool(config),
       "update_file_attrs" => build_update_file_attrs_tool(config),
-      "search_text" => build_search_text_tool(config),
+      "find_in_file" => build_find_in_file_tool(config),
       "delete_file" => build_delete_file_tool(config),
       "move_file" => build_move_file_tool(config)
     }
@@ -468,32 +520,39 @@ defmodule Sagents.Middleware.FileSystem do
     })
   end
 
-  defp build_search_text_tool(config) do
+  defp build_find_in_file_tool(config) do
     default_description = """
-    Search for text patterns within files.
+    Find text or regex matches within a single file.
 
-    Can search within a specific file or across all loaded files.
-    Returns matches with line numbers and optional context lines.
+    Returns matches with line numbers and optional surrounding context lines.
+    This tool searches one specific file at a time. To search across multiple
+    files, call `list_files` first to discover paths, then call `find_in_file`
+    for each path you want to search.
+
+    Wildcards and glob patterns (e.g. `/chapters/*`) are NOT supported in
+    `file_path` — provide an exact path. Use `list_files` with a pattern to
+    enumerate matching files first.
 
     Usage:
     - Provide pattern (required) - text or regex to search for
-    - Provide file_path (optional) - if omitted, searches all files
+    - Provide file_path (required) - exact path to the file to search
     - Set case_sensitive (optional, default: true)
     - Set context_lines (optional, default: 0) - lines before/after to show
     - Set max_results (optional, default: 50) - limit number of results
 
     Examples (call with a JSON object matching the schema):
-    - Search a single file: {"pattern": "TODO", "file_path": "/notes.txt"}
-    - Search all files: {"pattern": "important", "case_sensitive": false}
-    - With surrounding context: {"pattern": "error", "context_lines": 2}
+    - Find a literal string: {"pattern": "TODO", "file_path": "/notes.txt"}
+    - Case-insensitive: {"pattern": "important", "file_path": "/notes.txt", "case_sensitive": false}
+    - With surrounding context: {"pattern": "error", "file_path": "/app.log", "context_lines": 2}
+    - Regex pattern: {"pattern": "error\\\\d+", "file_path": "/app.log"}
     """
 
-    description = get_custom_description(config, "search_text", default_description)
+    description = get_custom_description(config, "find_in_file", default_description)
 
     Function.new!(%{
-      name: "search_text",
+      name: "find_in_file",
       description: description,
-      display_text: "Searching files",
+      display_text: "Searching file",
       parameters_schema: %{
         "type" => "object",
         "properties" => %{
@@ -504,7 +563,7 @@ defmodule Sagents.Middleware.FileSystem do
           "file_path" => %{
             "type" => "string",
             "description" =>
-              "Optional: specific file to search. If omitted, searches all loaded files."
+              "Exact path of the file to search (e.g. '/notes.txt'). Wildcards/globs are not supported."
           },
           "case_sensitive" => %{
             "type" => "boolean",
@@ -522,9 +581,9 @@ defmodule Sagents.Middleware.FileSystem do
             "default" => 50
           }
         },
-        "required" => ["pattern"]
+        "required" => ["pattern", "file_path"]
       },
-      function: fn args, context -> execute_search_text_tool(args, context, config) end
+      function: fn args, context -> execute_find_in_file_tool(args, context, config) end
     })
   end
 
@@ -863,7 +922,7 @@ defmodule Sagents.Middleware.FileSystem do
       {:error, "Filesystem not available: #{Exception.message(e)}"}
   end
 
-  defp execute_search_text_tool(args, _context, config) do
+  defp execute_find_in_file_tool(args, _context, config) do
     pattern = get_arg(args, "pattern")
     file_path = get_arg(args, "file_path")
     case_sensitive = get_boolean_arg(args, "case_sensitive", true)
@@ -874,24 +933,35 @@ defmodule Sagents.Middleware.FileSystem do
       is_nil(pattern) ->
         {:error, "pattern is required"}
 
+      is_nil(file_path) ->
+        {:error, "file_path is required"}
+
+      String.contains?(file_path, ["*", "?", "[", "]"]) ->
+        {:error,
+         "Wildcards and globs are not supported in file_path. Provide an exact file path (e.g., '/notes.txt'). Use list_files to discover matching files first."}
+
       true ->
         # Compile regex pattern with inline flags for case-insensitive search
         pattern_with_flags = if case_sensitive, do: pattern, else: "(?i)#{pattern}"
 
         case Regex.compile(pattern_with_flags) do
           {:ok, regex} ->
-            if file_path do
-              # Search single file
-              search_single_file(
-                config.filesystem_scope,
-                file_path,
-                regex,
-                context_lines,
-                max_results
-              )
+            with {:ok, normalized_path} <- validate_path(file_path),
+                 {:ok, entry} <-
+                   FileSystemServer.read_file(config.filesystem_scope, normalized_path) do
+              {matches, truncated} =
+                find_matches_in_content(entry.content || "", regex, context_lines, max_results)
+
+              format_search_results([{normalized_path, matches}], max_results, truncated)
             else
-              # Search all files
-              search_all_files(config.filesystem_scope, regex, context_lines, max_results)
+              {:error, :enoent} ->
+                {:error, "File not found: #{file_path}"}
+
+              {:error, reason} when is_binary(reason) ->
+                {:error, reason}
+
+              {:error, reason} ->
+                {:error, "Failed to search file: #{inspect(reason)}"}
             end
 
           {:error, _reason} ->
@@ -1038,58 +1108,6 @@ defmodule Sagents.Middleware.FileSystem do
 
   defp stringify_keys(map) do
     Map.new(map, fn {k, v} -> {to_string(k), v} end)
-  end
-
-  defp search_single_file(filesystem_scope, file_path, regex, context_lines, max_results) do
-    with {:ok, normalized_path} <- validate_path(file_path),
-         {:ok, entry} <- FileSystemServer.read_file(filesystem_scope, normalized_path) do
-      {matches, truncated} =
-        find_matches_in_content(entry.content || "", regex, context_lines, max_results)
-
-      format_search_results([{normalized_path, matches}], max_results, truncated)
-    else
-      {:error, :enoent} ->
-        {:error, "File not found: #{file_path}"}
-
-      {:error, reason} ->
-        {:error, "Failed to search file: #{inspect(reason)}"}
-    end
-  end
-
-  defp search_all_files(filesystem_scope, regex, context_lines, max_results) do
-    all_files = FileSystemServer.list_files(filesystem_scope)
-
-    # Search each file and collect matches, tracking total matches
-    {results, _total_matches, any_truncated} =
-      all_files
-      |> Enum.reduce({[], 0, false}, fn file_path, {acc, match_count, truncated} ->
-        # Calculate remaining limit for this file
-        remaining = max_results - match_count
-
-        if remaining <= 0 do
-          # Already hit limit, stop collecting
-          {acc, match_count, truncated}
-        else
-          case FileSystemServer.read_file(filesystem_scope, file_path) do
-            {:ok, entry} ->
-              {matches, file_truncated} =
-                find_matches_in_content(entry.content || "", regex, context_lines, remaining)
-
-              if Enum.empty?(matches) do
-                {acc, match_count, truncated}
-              else
-                {[{file_path, matches} | acc], match_count + length(matches),
-                 truncated or file_truncated}
-              end
-
-            {:error, _} ->
-              {acc, match_count, truncated}
-          end
-        end
-      end)
-
-    results = Enum.reverse(results)
-    format_search_results(results, max_results, any_truncated)
   end
 
   defp find_matches_in_content(content, regex, context_lines, max_results) do

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -134,7 +134,7 @@ defmodule Sagents.AgentTest do
 
       {:ok, agent} = Agent.new(%{model: mock_model(), tools: [tool]})
 
-      # Now includes custom tool + write_todos (TodoList) + 9 filesystem tools (list_files, read_file, create_file, replace_text, replace_lines, update_file_attrs, search_text, delete_file, move_file) + SubAgents
+      # Now includes custom tool + write_todos (TodoList) + 9 filesystem tools (list_files, read_file, create_file, replace_text, replace_lines, update_file_attrs, find_in_file, delete_file, move_file) + SubAgents
       assert length(agent.tools) == 12
       tool_names = Enum.map(agent.tools, & &1.name)
       assert "custom_tool" in tool_names
@@ -260,6 +260,49 @@ defmodule Sagents.AgentTest do
       assert agent.middleware == []
       assert agent.tools == []
       assert agent.assembled_system_prompt == ""
+    end
+  end
+
+  describe "middleware initialization errors" do
+    # Regression: previously, when a middleware's init/1 returned {:error, _}
+    # the changeset got an error added but `assemble_full_system_prompt/1` and
+    # `collect_all_tools/1` continued running against the un-normalized cast
+    # value (raw {Module, opts} tuples), crashing with FunctionClauseError.
+    # Both functions now short-circuit on invalid changesets, so the original
+    # init error reaches the caller intact.
+    test "Agent.new returns {:error, changeset} when a middleware init/1 fails" do
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Agent.new(
+                 %{
+                   model: mock_model(),
+                   middleware: [
+                     {Sagents.Middleware.FileSystem,
+                      [agent_id: "test", enabled_tools: ["bogus_tool_name"]]}
+                   ]
+                 },
+                 replace_default_middleware: true
+               )
+
+      refute changeset.valid?
+      assert {message, _} = changeset.errors[:middleware]
+      assert message =~ "initialization failed"
+      assert message =~ "bogus_tool_name"
+      assert message =~ "find_in_file"
+    end
+
+    test "Agent.new! raises with a useful message when a middleware init/1 fails" do
+      assert_raise LangChainError, ~r/bogus_tool_name/, fn ->
+        Agent.new!(
+          %{
+            model: mock_model(),
+            middleware: [
+              {Sagents.Middleware.FileSystem,
+               [agent_id: "test", enabled_tools: ["bogus_tool_name"]]}
+            ]
+          },
+          replace_default_middleware: true
+        )
+      end
     end
   end
 

--- a/test/sagents/middleware/file_system_test.exs
+++ b/test/sagents/middleware/file_system_test.exs
@@ -96,7 +96,7 @@ defmodule Sagents.Middleware.FileSystemTest do
                "replace_text",
                "replace_lines",
                "update_file_attrs",
-               "search_text",
+               "find_in_file",
                "delete_file",
                "move_file"
              ]
@@ -137,6 +137,102 @@ defmodule Sagents.Middleware.FileSystemTest do
       assert {:ok, config} = FileSystem.init(agent_id: agent_id)
       assert config.file_schema == FileEntry
     end
+
+    test "rejects unknown tool name in enabled_tools", %{agent_id: agent_id} do
+      assert {:error, message} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 enabled_tools: ["list_files", "search_text"]
+               )
+
+      assert message =~ "Unknown tool name(s) in :enabled_tools"
+      assert message =~ "search_text"
+      # The valid tool list is included so users can spot the rename
+      assert message =~ "find_in_file"
+    end
+
+    test "reports all unknown tool names in enabled_tools", %{agent_id: agent_id} do
+      assert {:error, message} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 enabled_tools: ["list_files", "bogus_one", "bogus_two"]
+               )
+
+      assert message =~ "bogus_one"
+      assert message =~ "bogus_two"
+    end
+
+    test "rejects non-list :enabled_tools", %{agent_id: agent_id} do
+      assert {:error, message} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 enabled_tools: "list_files"
+               )
+
+      assert message =~ ":enabled_tools must be a list"
+    end
+
+    test "accepts an empty enabled_tools list", %{agent_id: agent_id} do
+      assert {:ok, config} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 enabled_tools: []
+               )
+
+      assert config.enabled_tools == []
+    end
+
+    test "rejects unknown tool name in custom_tool_descriptions", %{agent_id: agent_id} do
+      assert {:error, message} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 custom_tool_descriptions: %{"search_text" => "old name"}
+               )
+
+      assert message =~ "Unknown tool name(s) in :custom_tool_descriptions"
+      assert message =~ "search_text"
+      # The valid tool list is included so users can spot the rename
+      assert message =~ "find_in_file"
+    end
+
+    test "reports all unknown keys in custom_tool_descriptions", %{agent_id: agent_id} do
+      assert {:error, message} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 custom_tool_descriptions: %{
+                   "read_file" => "valid",
+                   "bogus_one" => "x",
+                   "bogus_two" => "y"
+                 }
+               )
+
+      assert message =~ "bogus_one"
+      assert message =~ "bogus_two"
+    end
+
+    test "allows custom_tool_descriptions for tools not in enabled_tools", %{agent_id: agent_id} do
+      # A description for a tool the user has temporarily disabled is still
+      # allowed — we're catching typos and renames, not enforcing that every
+      # described tool be enabled.
+      assert {:ok, config} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 enabled_tools: ["list_files", "read_file"],
+                 custom_tool_descriptions: %{"find_in_file" => "Custom find description"}
+               )
+
+      assert config.custom_tool_descriptions == %{"find_in_file" => "Custom find description"}
+    end
+
+    test "rejects non-map :custom_tool_descriptions", %{agent_id: agent_id} do
+      assert {:error, message} =
+               FileSystem.init(
+                 filesystem_scope: {:agent, agent_id},
+                 custom_tool_descriptions: [{"read_file", "x"}]
+               )
+
+      assert message =~ ":custom_tool_descriptions must be a map"
+    end
   end
 
   describe "system_prompt/1" do
@@ -168,7 +264,7 @@ defmodule Sagents.Middleware.FileSystemTest do
             "replace_text",
             "replace_lines",
             "update_file_attrs",
-            "search_text",
+            "find_in_file",
             "delete_file",
             "move_file"
           ]
@@ -182,7 +278,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       assert "replace_text" in tool_names
       assert "replace_lines" in tool_names
       assert "update_file_attrs" in tool_names
-      assert "search_text" in tool_names
+      assert "find_in_file" in tool_names
       assert "delete_file" in tool_names
       assert "move_file" in tool_names
     end
@@ -648,17 +744,17 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  defp get_search_text_tool(tools) when is_list(tools) do
-    Enum.find(tools, fn tool -> tool.name == "search_text" end)
+  defp get_find_in_file_tool(tools) when is_list(tools) do
+    Enum.find(tools, fn tool -> tool.name == "find_in_file" end)
   end
 
-  describe "search_text tool - single file search" do
-    test "search_text tool is enabled in FileSystem", %{agent_id: agent_id} do
+  describe "find_in_file tool - basic search" do
+    test "find_in_file tool is enabled in FileSystem", %{agent_id: agent_id} do
       # Initialize middleware
       {:ok, config} = FileSystem.init(agent_id: agent_id)
 
-      # Find the search_text tool
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      # Find the find_in_file tool
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
       assert search_tool != nil
     end
 
@@ -675,7 +771,7 @@ defmodule Sagents.Middleware.FileSystemTest do
 
       # Initialize middleware
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       # Execute search
       args = %{"pattern" => "TODO", "file_path" => "/test.txt"}
@@ -694,9 +790,9 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
-      args = %{"pattern" => "NOTFOUND"}
+      args = %{"pattern" => "NOTFOUND", "file_path" => "/test.txt"}
       {:ok, result} = search_tool.function.(args, %{})
 
       assert result == "No matches found"
@@ -710,7 +806,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       args = %{"pattern" => "hello", "file_path" => "/test.txt", "case_sensitive" => false}
       {:ok, result} = search_tool.function.(args, %{})
@@ -729,7 +825,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       args = %{"pattern" => "hello", "file_path" => "/test.txt", "case_sensitive" => true}
       {:ok, result} = search_tool.function.(args, %{})
@@ -749,7 +845,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       # Search for lines starting with "error" followed by digits
       args = %{"pattern" => "error\\d+", "file_path" => "/test.txt"}
@@ -765,7 +861,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", "content")
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       args = %{"pattern" => "[invalid(regex", "file_path" => "/test.txt"}
       {:error, error_msg} = search_tool.function.(args, %{})
@@ -775,7 +871,7 @@ defmodule Sagents.Middleware.FileSystemTest do
 
     test "returns error for non-existent file", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       args = %{"pattern" => "test", "file_path" => "/nonexistent.txt"}
       {:error, error_msg} = search_tool.function.(args, %{})
@@ -784,7 +880,7 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "search_text tool - context lines" do
+  describe "find_in_file tool - context lines" do
     test "includes context lines before and after matches", %{agent_id: agent_id} do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", """
       Before context 1
@@ -795,7 +891,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       args = %{"pattern" => "MATCH", "file_path" => "/test.txt", "context_lines" => 2}
       {:ok, result} = search_tool.function.(args, %{})
@@ -817,7 +913,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       # Request 2 context lines, but match is at line 1 (no lines before)
       args = %{"pattern" => "MATCH", "file_path" => "/test.txt", "context_lines" => 2}
@@ -828,53 +924,7 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "search_text tool - multi-file search" do
-    test "searches across all files when no file_path specified", %{agent_id: agent_id} do
-      # Create multiple files
-      FileSystemServer.write_file({:agent, agent_id}, "/file1.txt", """
-      TODO in file 1
-      Normal line
-      """)
-
-      FileSystemServer.write_file({:agent, agent_id}, "/file2.txt", """
-      Normal line
-      TODO in file 2
-      """)
-
-      FileSystemServer.write_file({:agent, agent_id}, "/file3.txt", """
-      No match here
-      """)
-
-      {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
-
-      # Search all files without specifying file_path
-      args = %{"pattern" => "TODO"}
-      {:ok, result} = search_tool.function.(args, %{})
-
-      # Should find matches in both file1 and file2
-      assert result =~ "File: /file1.txt"
-      assert result =~ "     1\tTODO in file 1"
-      assert result =~ "File: /file2.txt"
-      assert result =~ "     2\tTODO in file 2"
-      refute result =~ "file3.txt"
-    end
-
-    test "returns no matches when pattern not in any file", %{agent_id: agent_id} do
-      FileSystemServer.write_file({:agent, agent_id}, "/file1.txt", "content 1")
-      FileSystemServer.write_file({:agent, agent_id}, "/file2.txt", "content 2")
-
-      {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
-
-      args = %{"pattern" => "NOTFOUND"}
-      {:ok, result} = search_tool.function.(args, %{})
-
-      assert result == "No matches found"
-    end
-  end
-
-  describe "search_text tool - max_results limiting" do
+  describe "find_in_file tool - max_results limiting" do
     test "limits results to max_results parameter", %{agent_id: agent_id} do
       # Create a file with many matches
       content =
@@ -884,7 +934,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", content)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       # Limit to 10 results
       args = %{"pattern" => "MATCH", "file_path" => "/test.txt", "max_results" => 10}
@@ -909,7 +959,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       FileSystemServer.write_file({:agent, agent_id}, "/test.txt", content)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       # Use default max_results (50)
       args = %{"pattern" => "MATCH", "file_path" => "/test.txt"}
@@ -920,20 +970,56 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "search_text tool - parameter validation" do
+  describe "find_in_file tool - parameter validation" do
     test "returns error when pattern is missing", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
-      args = %{}
+      args = %{"file_path" => "/test.txt"}
       {:error, error_msg} = search_tool.function.(args, %{})
 
       assert error_msg =~ "pattern is required"
     end
 
+    test "returns error when file_path is missing", %{agent_id: agent_id} do
+      {:ok, config} = FileSystem.init(agent_id: agent_id)
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
+
+      args = %{"pattern" => "TODO"}
+      {:error, error_msg} = search_tool.function.(args, %{})
+
+      assert error_msg =~ "file_path is required"
+    end
+
+    test "rejects wildcard '*' in file_path", %{agent_id: agent_id} do
+      {:ok, config} = FileSystem.init(agent_id: agent_id)
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
+
+      args = %{"pattern" => "TODO", "file_path" => "/chapters/*"}
+      {:error, error_msg} = search_tool.function.(args, %{})
+
+      assert error_msg =~ "Wildcards and globs are not supported"
+      assert error_msg =~ "list_files"
+    end
+
+    test "rejects glob characters '?' and '[' in file_path", %{agent_id: agent_id} do
+      {:ok, config} = FileSystem.init(agent_id: agent_id)
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
+
+      assert {:error, msg1} =
+               search_tool.function.(%{"pattern" => "x", "file_path" => "/file?.txt"}, %{})
+
+      assert msg1 =~ "Wildcards and globs are not supported"
+
+      assert {:error, msg2} =
+               search_tool.function.(%{"pattern" => "x", "file_path" => "/file[1].txt"}, %{})
+
+      assert msg2 =~ "Wildcards and globs are not supported"
+    end
+
     test "handles invalid path", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       # Path without leading slash
       args = %{"pattern" => "test", "file_path" => "invalid/path.txt"}
@@ -943,36 +1029,37 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "search_text tool - tool registration" do
-    test "search_text tool is included in default enabled tools", %{agent_id: agent_id} do
+  describe "find_in_file tool - tool registration" do
+    test "find_in_file tool is included in default enabled tools", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
 
-      assert "search_text" in config.enabled_tools
+      assert "find_in_file" in config.enabled_tools
     end
 
-    test "search_text tool can be disabled via config", %{agent_id: agent_id} do
+    test "find_in_file tool can be disabled via config", %{agent_id: agent_id} do
       {:ok, config} =
         FileSystem.init(
           filesystem_scope: {:agent, agent_id},
           enabled_tools: ["list_files", "read_file", "create_file"]
         )
 
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
       assert search_tool == nil
     end
 
-    test "search_text tool has correct schema", %{agent_id: agent_id} do
+    test "find_in_file tool has correct schema", %{agent_id: agent_id} do
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      search_tool = config |> FileSystem.tools() |> get_find_in_file_tool()
 
-      assert search_tool.name == "search_text"
+      assert search_tool.name == "find_in_file"
       assert is_binary(search_tool.description)
 
       # Verify parameters schema
       schema = search_tool.parameters_schema
       assert schema["type"] == "object"
       assert "pattern" in schema["required"]
+      assert "file_path" in schema["required"]
 
       properties = schema["properties"]
       assert Map.has_key?(properties, "pattern")
@@ -983,7 +1070,7 @@ defmodule Sagents.Middleware.FileSystemTest do
     end
   end
 
-  describe "search_text tool - integration scenarios" do
+  describe "find_in_file tool - integration scenarios" do
     test "search then read workflow", %{agent_id: agent_id} do
       # Create a file with searchable content
       FileSystemServer.write_file({:agent, agent_id}, "/project.md", """
@@ -1006,7 +1093,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       tools = FileSystem.tools(config)
 
       # First, search for TODOs
-      search_tool = Enum.find(tools, fn tool -> tool.name == "search_text" end)
+      search_tool = Enum.find(tools, fn tool -> tool.name == "find_in_file" end)
       args = %{"pattern" => "TODO", "file_path" => "/project.md"}
       {:ok, search_result} = search_tool.function.(args, %{})
 
@@ -1023,7 +1110,7 @@ defmodule Sagents.Middleware.FileSystemTest do
       assert read_result =~ "TODO: Complete this section"
     end
 
-    test "search across multiple files with different patterns", %{agent_id: agent_id} do
+    test "list_files then find_in_file workflow across multiple files", %{agent_id: agent_id} do
       FileSystemServer.write_file({:agent, agent_id}, "/config.json", """
       {
         "error_log": true,
@@ -1039,18 +1126,36 @@ defmodule Sagents.Middleware.FileSystemTest do
       """)
 
       {:ok, config} = FileSystem.init(agent_id: agent_id)
-      search_tool = config |> FileSystem.tools() |> get_search_text_tool()
+      tools = FileSystem.tools(config)
 
-      # Search for "error" (case-insensitive) across all files
-      args = %{"pattern" => "error", "case_sensitive" => false}
-      {:ok, result} = search_tool.function.(args, %{})
+      # An LLM searching multiple files calls list_files first, then find_in_file
+      # for each path it wants to inspect. This test verifies that compositional
+      # workflow rather than a single multi-file call.
+      list_tool = Enum.find(tools, fn tool -> tool.name == "list_files" end)
+      {:ok, _list_result} = list_tool.function.(%{}, %{})
 
-      # Should find matches in both files (with padded line numbers)
-      assert result =~ "/config.json"
-      assert result =~ "     2\t  \"error_log\": true,"
-      assert result =~ "/app.log"
-      assert result =~ "     2\t2024-01-01 10:05:00 ERROR: Connection failed"
-      assert result =~ "     4\t2024-01-01 10:15:00 ERROR: Timeout occurred"
+      search_tool = get_find_in_file_tool(tools)
+
+      # Search "/config.json" for the literal "error" substring (case-insensitive)
+      {:ok, config_result} =
+        search_tool.function.(
+          %{"pattern" => "error", "file_path" => "/config.json", "case_sensitive" => false},
+          %{}
+        )
+
+      assert config_result =~ "/config.json"
+      assert config_result =~ "     2\t  \"error_log\": true,"
+
+      # Search "/app.log" for ERROR lines (case-insensitive)
+      {:ok, log_result} =
+        search_tool.function.(
+          %{"pattern" => "error", "file_path" => "/app.log", "case_sensitive" => false},
+          %{}
+        )
+
+      assert log_result =~ "/app.log"
+      assert log_result =~ "     2\t2024-01-01 10:05:00 ERROR: Connection failed"
+      assert log_result =~ "     4\t2024-01-01 10:15:00 ERROR: Timeout occurred"
     end
   end
 

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -719,7 +719,7 @@ defmodule Sagents.Middleware.SubAgentTest do
          [
            agent_id: "test",
            custom_tool_descriptions: %{},
-           enabled_tools: ["read_file", "write_file"]
+           enabled_tools: ["read_file", "create_file"]
          ]}
       ]
 


### PR DESCRIPTION
## Problem

The `search_text` tool in the FileSystem middleware was vague and confusing. The name didn't communicate that it searched within a *single* file, and the schema also accepted an optional `file_path` that, when omitted, silently fell back to scanning every loaded file in the FileSystem. That fallback was a footgun: if a file wasn't loaded yet, it was silently skipped, and the LLM got "No matches found" with no signal that the corpus was incomplete. Downstream projects that need their own domain-specific search tools were also colliding with the generic name.

A second, related issue: when middleware config used a stale or typo'd tool name (e.g. `"write_file"` after the rename to `"create_file"`, or `"search_text"` after this rename), `FileSystem.tools/1` silently dropped the unknown entry via `Enum.reject(&is_nil/1)`. Misconfigurations were invisible until someone noticed a tool was missing from an agent.

A latent bug in `Agent.new/2` made these failures even uglier: when middleware `init/1` returned `{:error, _}`, the changeset got an error added but the pipeline kept running and crashed later in `assemble_full_system_prompt/1` with a `FunctionClauseError`, masking the real error message.

## Solution

**Rename and tighten the search tool.** `search_text` becomes `find_in_file`. `file_path` is now required, multi-file mode is gone, and wildcard/glob characters (`*`, `?`, `[`, `]`) in `file_path` are explicitly rejected with an error message that points the LLM at `list_files` for path discovery. This forces the compositional pattern *list → pick path → find_in_file* and removes the silent-false-negative trap entirely.

**Validate FileSystem config at init time.** `FileSystem.init/1` now rejects unknown tool names in both `:enabled_tools` and `:custom_tool_descriptions`, returning `{:error, message}` that lists both the unknowns and the full valid set (so a user upgrading from `search_text` sees `find_in_file` right next to it). The middleware loader at `Sagents.Middleware.init_middleware/1` already raised on `{:error, _}`, so misconfigured agents now fail fast at construction with a stack trace pointing at the agent factory.

**Fix the cascade-failure pipeline bug in `Agent.new/2`.** Added `%Ecto.Changeset{valid?: false}` function-head clauses to `assemble_full_system_prompt/1` and `collect_all_tools/1` so they short-circuit when a previous step (typically `build_and_initialize_middleware/2`) added an error. The original `:middleware` error now reaches `apply_action(:insert)` intact and surfaces as a clean `{:error, changeset}` (or a `LangChainError` from `new!`).

This is a **breaking change**: any project with `enabled_tools: [..., "search_text", ...]` or `custom_tool_descriptions: %{"search_text" => ...}` will now fail to construct an agent until they update to `"find_in_file"`. That's the point — the alternative is silent feature regression.

## Changes

### Tool rename and behavior tightening

- `lib/sagents/middleware/file_system.ex` — Renamed `build_search_text_tool/1` → `build_find_in_file_tool/1` and `execute_search_text_tool/3` → `execute_find_in_file_tool/3`. Tool name in `Function.new!` is now `"find_in_file"`. `file_path` is in `"required"`. Description rewritten to explain single-file behavior and point at `list_files`. Inlined the old `search_single_file/5` helper into the execute function and **deleted `search_all_files/4`** entirely.
- `lib/sagents/middleware/file_system.ex` — Updated `@moduledoc`, `@system_prompt`, `@default_enabled_tools`, and the `tools/1` dispatch map to use the new name.
- `lib/sagents/middleware/file_system.ex` — Added wildcard rejection: `String.contains?(file_path, ["*", "?", "[", "]"])` returns a tool-specific error pointing at `list_files`, so the LLM gets a useful signal instead of a confusing `:enoent`.

### Config validation in `FileSystem.init/1`

- `lib/sagents/middleware/file_system.ex` — Added `validate_enabled_tools/1` and `validate_custom_tool_descriptions/1`, composed via a `with` chain in `init/1`. Both helpers list unknown names *and* the valid set in their error message. `custom_tool_descriptions` is validated against the full tool set (not just enabled), so a description for a temporarily-disabled tool is still allowed — the goal is catching typos and renames, not enforcing membership.

### Pipeline fix in `Agent.new/2`

- `lib/sagents/agent.ex` — Added `%Ecto.Changeset{valid?: false}` clauses to `assemble_full_system_prompt/1` and `collect_all_tools/1` with an explanatory comment. Previously these crashed on raw `{Module, opts}` tuples when middleware init failed, masking the real error.

### Test changes

- `test/sagents/middleware/file_system_test.exs` — Renamed helper `get_search_text_tool/1` → `get_find_in_file_tool/1`; renamed all describe blocks; updated `init/1` and `tools/1` enabled-tools assertions. **Deleted** the entire `multi-file search` describe block. Rewrote the cross-file integration test as a *list_files then find_in_file workflow* showing the new compositional pattern. Added validation tests: `file_path is required`, wildcard rejection (`*`, `?`, `[`), `enabled_tools` unknown-name rejection (uses `"search_text"` to document the migration path), `custom_tool_descriptions` unknown-key rejection, multi-unknown reporting, type validation, and an empty-list edge case. File grew from 95 → 105 tests.
- `test/sagents/agent_test.exs` — Added new describe block `middleware initialization errors` with two regression tests covering the pipeline fix: one asserts `Agent.new/2` returns `{:error, %Ecto.Changeset{}}` with a useful message; the other asserts `Agent.new!/2` raises `LangChainError`. Updated the inline tool-count comment.
- `test/sagents/middleware/sub_agent_test.exs` — Fixed a fossil bug the new validation caught: `enabled_tools: ["read_file", "write_file"]` had been left over from a prior `write_file` → `create_file` rename. The test passed for years because the unknown name was silently filtered out. Changed to `["read_file", "create_file"]`.

### Documentation

- `README.md` — Updated the FileSystem middleware tool list table to show `find_in_file` instead of `search_text`.
- `lib/sagents/middleware/file_system.ex` (`@moduledoc`, `@system_prompt`) — Both updated to describe the new tool's single-file behavior and point at `list_files` for path discovery.

## Testing

- `mix precommit` clean: **1250 tests, 0 failures, 1 skipped** in sagents.
- `file_system_test.exs` grew from 95 → 105 tests (10 net new, covering wildcard rejection, file_path required, both validators, edge cases).
- `agent_test.exs` gained 2 regression tests for the middleware-init pipeline short-circuit.
- The fossil bug in `sub_agent_test.exs` (stale `"write_file"` config) was caught by the new validation on the first run after enabling it — proof that the validation pulls its weight on real history, not just hypothetical migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)