### PR TITLE
Document FileSchema and updated tool names in filesystem setup guide

### DIFF
--- a/docs/filesystem_setup.md
+++ b/docs/filesystem_setup.md
@@ -4,7 +4,7 @@ This guide covers how to set up, configure, and populate the `FileSystemServer` 
 
 ## Overview
 
-The `FileSystem` middleware gives agents tools like `ls`, `read_file`, `write_file`, and `delete_file`. But the middleware itself holds no file data — it is a thin client that delegates every operation to a `FileSystemServer` GenServer, identified by a **scope key** like `{:user, 123}`.
+The `FileSystem` middleware gives agents tools like `list_files`, `read_file`, `create_file`, `replace_text`, `replace_lines`, `update_file_attrs`, and `delete_file`. But the middleware itself holds no file data — it is a thin client that delegates every operation to a `FileSystemServer` GenServer, identified by a **scope key** like `{:user, 123}`.
 
 This means:
 
@@ -272,6 +272,243 @@ Configure it in place of `Disk`:
 ```
 
 The `storage_opts` keyword list is passed through to every persistence callback, so you can include whatever context your implementation needs (`user_id`, `tenant_id`, S3 bucket name, etc.).
+
+If you want the LLM to see and edit *application-defined attributes* on these entries (status, tags, author, word count, etc.), pair this backend with a `FileSchema` — see [Customizing What the LLM Sees: FileSchema](#customizing-what-the-llm-sees-fileschema) below.
+
+## Customizing What the LLM Sees: FileSchema
+
+By default, when the agent calls `list_files` or `update_file_attrs`, the LLM sees a generic `FileEntry` shape — `path`, `title`, `entry_type`, `file_type`, `persistence`, and `size`. For many applications that's enough. But if you want to expose **domain-specific attributes** like `tags`, `status`, `author`, `published_at`, `word_count`, etc. — and have the LLM read or update them through built-in tools — you need to teach the filesystem two things:
+
+- **What attributes exist and how to validate them** (when the LLM proposes a change)
+- **How to render a file entry as JSON the LLM will understand** (when the LLM reads or lists)
+
+`Sagents.FileSystem.FileSchema` is the behaviour that captures both, in a single module.
+
+### The two callbacks
+
+| Callback | When called | Purpose |
+|---|---|---|
+| `changeset(attrs)` | LLM calls `update_file_attrs` | Cast and validate the LLM's proposed attribute changes. Returns an `Ecto.Changeset`. Invalid changesets become tool errors so the LLM can self-correct on its next turn. |
+| `to_llm_map(entry)` | `list_files`, `create_file`, and `update_file_attrs` responses | Convert a `FileEntry` into the JSON map sent back to the LLM. You decide which fields are visible and how they're shaped. |
+
+`Sagents.FileSystem.FileEntry` itself implements `FileSchema`, which is why the basic setup just works — when no schema is configured, the middleware uses `FileEntry`'s own `changeset/1` and `to_llm_map/1` as the defaults.
+
+### Example: a `DocumentFileSchema`
+
+```elixir
+defmodule MyApp.DocumentFileSchema do
+  @behaviour Sagents.FileSystem.FileSchema
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Sagents.FileSystem.FileEntry
+
+  @primary_key false
+  embedded_schema do
+    field :title, :string
+    field :system_tag, :string
+    field :tags, {:array, :string}, default: []
+    field :status, :string
+  end
+
+  @impl true
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:title, :system_tag, :tags, :status])
+    |> validate_inclusion(:system_tag, ~w(draft review approved published))
+  end
+
+  @impl true
+  def to_llm_map(%FileEntry{} = entry) do
+    custom = (entry.metadata && entry.metadata.custom) || %{}
+
+    %{
+      path: entry.path,
+      title: entry.title,
+      file_type: entry.file_type,
+      system_tag: custom["system_tag"],
+      tags: custom["tags"],
+      status: custom["status"],
+      size: entry.metadata && entry.metadata.size
+    }
+    |> Map.reject(fn {_k, v} -> is_nil(v) end)
+  end
+end
+```
+
+The `embedded_schema` declares what attributes exist and what their types are. The `changeset/1` callback decides which of those are accepted from the LLM and what validations apply. The `to_llm_map/1` callback decides what the LLM sees back — note that it pulls custom attributes out of `entry.metadata.custom` (string-keyed) and surfaces them as top-level fields in the response.
+
+### Wiring it in — at the middleware level
+
+This is the most important detail to get right: `:file_schema` is configured on `Sagents.Middleware.FileSystem`, **not** on `FileSystemConfig`. `FileSystemConfig` describes persistence (where data lives); `FileSchema` describes the LLM-facing surface (what attributes exist). They're two independent dimensions.
+
+```elixir
+# In your agent factory
+{:ok, agent} = Sagents.Agent.new(%{
+  model: model,
+  middleware: [
+    {Sagents.Middleware.FileSystem, [
+      filesystem_scope: {:user, user_id},
+      file_schema: MyApp.DocumentFileSchema
+    ]},
+    # ... other middleware
+  ]
+})
+```
+
+If `:file_schema` is omitted, the middleware uses `Sagents.FileSystem.FileEntry` itself as the default schema.
+
+### How updates flow: automatic field routing
+
+When the LLM calls `update_file_attrs`, the middleware handles the entire lifecycle for you:
+
+1. The LLM calls `update_file_attrs` with, for example, `attrs: %{"title" => "New Title", "system_tag" => "draft", "tags" => ["a", "b"]}`.
+2. The middleware calls `MyApp.DocumentFileSchema.changeset(attrs)`. If the changeset is invalid, the formatted error is returned to the LLM as a tool error so it can retry with a corrected payload.
+3. The middleware takes the validated changes and splits them against the built-in `FileEntry` struct fields `[:title, :id, :file_type]`:
+   - **`:title`** matches a struct field → routed to `Sagents.FileSystemServer.update_entry/4` (modifies the `FileEntry` struct directly).
+   - **`:system_tag`, `:tags`** don't match → routed to `Sagents.FileSystemServer.update_custom_metadata/4` (stored as string-keyed entries in `entry.metadata.custom`).
+4. The middleware reads the updated entry, calls `to_llm_map(entry)`, and returns the JSON to the LLM.
+
+You don't write any routing code. You only declare fields in the schema; the middleware decides where each one belongs.
+
+> **`update_file_attrs` is metadata-only.** If your schema includes `:content` in its cast list, the middleware rejects the change with an error directing the LLM to use `replace_text`, `replace_lines`, or `create_file` instead. File content is never changed through `update_file_attrs`.
+
+### Mapping a domain entity into the filesystem
+
+The headline use case for `FileSchema` is exposing existing application entities (database rows, blog posts, knowledge-base articles) as files the LLM can interact with through built-in tools. The recipe combines a custom `Persistence` backend (for loading and saving) with a custom `FileSchema` (for validation and presentation):
+
+```elixir
+# 1. Your domain entity
+defmodule MyApp.Document do
+  use Ecto.Schema
+
+  schema "documents" do
+    field :slug, :string
+    field :title, :string
+    field :body, :string
+    field :status, :string
+    field :tags, {:array, :string}
+    field :user_id, :integer
+    timestamps()
+  end
+end
+
+# 2. Persistence — loads Documents as FileEntries
+defmodule MyApp.DocumentPersistence do
+  @behaviour Sagents.FileSystem.Persistence
+
+  import Ecto.Query
+  alias Sagents.FileSystem.{FileEntry, FileMetadata}
+  alias MyApp.{Repo, Document}
+
+  @impl true
+  def list_persisted_entries(_scope_key, opts) do
+    user_id = Keyword.fetch!(opts, :user_id)
+
+    entries =
+      Document
+      |> where(user_id: ^user_id)
+      |> Repo.all()
+      |> Enum.map(&document_to_entry/1)
+
+    {:ok, entries}
+  end
+
+  @impl true
+  def load_from_storage(entry, opts) do
+    user_id = Keyword.fetch!(opts, :user_id)
+
+    case Repo.get_by(Document, user_id: user_id, slug: entry.id) do
+      nil -> {:error, :enoent}
+      doc -> {:ok, %{entry | content: doc.body, loaded: true, dirty_content: false}}
+    end
+  end
+
+  @impl true
+  def write_to_storage(entry, opts) do
+    user_id = Keyword.fetch!(opts, :user_id)
+    custom = (entry.metadata && entry.metadata.custom) || %{}
+
+    attrs = %{
+      user_id: user_id,
+      slug: entry.id,
+      title: entry.title,
+      body: entry.content,
+      status: custom["status"],
+      tags: custom["tags"] || []
+    }
+
+    result =
+      case Repo.get_by(Document, user_id: user_id, slug: entry.id) do
+        nil -> %Document{} |> Document.changeset(attrs) |> Repo.insert()
+        doc -> doc |> Document.changeset(attrs) |> Repo.update()
+      end
+
+    case result do
+      {:ok, _} -> {:ok, %{entry | dirty_content: false}}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  @impl true
+  def delete_from_storage(entry, opts) do
+    user_id = Keyword.fetch!(opts, :user_id)
+
+    Document
+    |> where([d], d.user_id == ^user_id and d.slug == ^entry.id)
+    |> Repo.delete_all()
+
+    :ok
+  end
+
+  defp document_to_entry(%Document{} = doc) do
+    {:ok, metadata} =
+      FileMetadata.new("", custom: %{
+        "status" => doc.status,
+        "tags" => doc.tags
+      })
+
+    %FileEntry{
+      path: "/documents/#{doc.slug}.md",
+      id: doc.slug,
+      title: doc.title,
+      file_type: "markdown",
+      entry_type: :file,
+      persistence: :persisted,
+      loaded: false,
+      metadata: metadata
+    }
+  end
+end
+
+# 3. Wire them together
+{:ok, fs_config} = FileSystemConfig.new(%{
+  default: true,
+  persistence_module: MyApp.DocumentPersistence,
+  storage_opts: [user_id: user_id]
+})
+
+{:ok, _pid} = FileSystem.ensure_filesystem({:user, user_id}, [fs_config])
+
+# In your agent factory:
+{Sagents.Middleware.FileSystem, [
+  filesystem_scope: {:user, user_id},
+  file_schema: MyApp.DocumentFileSchema
+]}
+```
+
+This is the canonical pattern: **`Persistence` decides how entities are loaded and saved; `FileSchema` decides how they appear and what the LLM is allowed to change about them.** Together they let an existing application expose its domain objects to the agent as files, with no custom tools required.
+
+Notice how `entry.id` doubles as the slug for lookups — using a stable identifier rather than the path makes renames safe. The path is presentation; the id is identity.
+
+### Tips and gotchas
+
+- **Custom metadata keys are strings, not atoms.** Read them as `entry.metadata.custom["status"]`, not `[:status]`. The middleware stringifies keys before storing them, regardless of how your schema declared the fields.
+- **Don't put `:content` in your schema's cast list.** It's metadata only; content is changed via `replace_text`, `replace_lines`, or `create_file`. The middleware enforces this by raising a tool error if `:content` shows up in validated changes.
+- **`:title`, `:id`, and `:file_type`** are the only built-in `FileEntry` struct fields the LLM can update through `update_file_attrs`; everything else falls into `metadata.custom` automatically. If your domain "title" really is the file's display name, declaring `:title` in your schema will cause the routing to write it to the struct field — exactly what you want.
+- **`to_llm_map` is the LLM's view of the file.** You can rename, hide, or reformat any field. Invest in keeping this map small and unambiguous; it directly affects how well the LLM uses your files.
+- **Validation errors become LLM tool errors.** Use `validate_inclusion`, `validate_number`, `validate_format`, etc. liberally — when the LLM passes a bad value, it sees the changeset error in the tool result and can self-correct on the next turn without any application code in the loop.
 
 ## Default Configs — Catch-All Persistence
 


### PR DESCRIPTION
## Problem

PR #54 made two significant changes to the FileSystem subsystem that aren't reflected in the integrator-facing documentation:

1. The LLM-facing tools were renamed (`ls` → `list_files`, `write_file` → `create_file`, `edit_file` → `replace_text`, `edit_lines` → `replace_lines`) and a new `update_file_attrs` tool was added.
2. A new `Sagents.FileSystem.FileSchema` behaviour was introduced, letting integrating applications declare custom validated attributes on files and control how each `FileEntry` is serialized to the LLM.

The existing `docs/filesystem_setup.md` covered persistence, scoping, seeding, and PubSub — but said nothing about `FileSchema`. An integrator reading the doc could make files appear, but had no guidance on how to attach domain attributes (status, tags, author, slug, word count) to them or expose those attributes through built-in tools. This is the missing piece for projects that want to map their own domain entities (documents, blog posts, knowledge-base articles, database rows) into the agent's filesystem without writing custom tools per project.

## Solution

Adds a new top-level section — **"Customizing What the LLM Sees: FileSchema"** — to the filesystem setup guide, placed after "Database-Backed Persistence" and before "Default Configs". The section explains the two `FileSchema` callbacks (`changeset/1` and `to_llm_map/1`), shows the canonical `DocumentFileSchema` example, clarifies the most common wiring mistake (`:file_schema` lives on `Sagents.Middleware.FileSystem`, not on `FileSystemConfig`), and walks through the automatic field-routing lifecycle: validated changes get split against `[:title, :id, :file_type]`, with matches going to `update_entry/4` and the rest landing in `metadata.custom` via `update_custom_metadata/4`. A complete worked example pairs a custom `Persistence` backend with a custom `FileSchema` to expose `MyApp.Document` Ecto records as files the LLM can list, read, and tag.

The Overview was also updated to reflect the new tool names. `search_text` is intentionally omitted from the listed tools because it is being renamed to `find_in_file` in another in-flight PR — leaving it out avoids baking in a soon-to-be-stale name.

## Changes

- `docs/filesystem_setup.md` — Added new \"Customizing What the LLM Sees: FileSchema\" section covering the two callbacks, an example schema, middleware-level wiring, the validation/routing lifecycle, the metadata-only content guard, a full domain-entity mapping recipe (Document → DocumentPersistence → DocumentFileSchema), and tips/gotchas
- `docs/filesystem_setup.md` — Updated the Overview tool list to the new tool names (`list_files`, `read_file`, `create_file`, `replace_text`, `replace_lines`, `update_file_attrs`, `delete_file`); deliberately omits `search_text` pending its rename in another PR
- `docs/filesystem_setup.md` — Added a forward cross-reference from \"Database-Backed Persistence\" to the new FileSchema section, since the two compose to expose application entities

## Testing

Documentation only — no source or test changes. Verified by reading the new section end-to-end against the actual middleware code (`apply_validated_changes/3` routing in `lib/sagents/middleware/file_system.ex`, the `:file_schema` init option, and `FileEntry`'s default implementation of the behaviour) to confirm the described lifecycle matches what the code does.