### PR TITLE
Fix flaky SubAgentServer Registry race in HITL integration test

### DIFF
--- a/test/sagents/subagent_hitl_integration_test.exs
+++ b/test/sagents/subagent_hitl_integration_test.exs
@@ -23,6 +23,8 @@ defmodule Sagents.SubAgentHitlIntegrationTest do
   use ExUnit.Case, async: false
   use Mimic
 
+  import Sagents.TestingHelpers, only: [wait_until: 1]
+
   alias Sagents.{Agent, State}
   alias Sagents.SubAgent
   alias Sagents.SubAgentServer
@@ -195,7 +197,11 @@ defmodule Sagents.SubAgentHitlIntegrationTest do
       refute has_remaining_interrupt
 
       # SubAgentServer should be stopped (D.1)
-      assert SubAgentServer.whereis(interrupt_data.sub_agent_id) == nil
+      # The Registry processes its :DOWN message asynchronously after
+      # GenServer.stop returns, so poll briefly until the entry clears.
+      assert wait_until(fn ->
+               SubAgentServer.whereis(interrupt_data.sub_agent_id) == nil
+             end)
 
       # Final state should have the parent's completion message
       last_msg = List.last(final_state.messages)
@@ -387,10 +393,12 @@ defmodule Sagents.SubAgentHitlIntegrationTest do
       # Kill the SubAgentServer process manually
       pid = SubAgentServer.whereis(sub_agent_id)
       assert pid != nil
+      ref = Process.monitor(pid)
       Process.exit(pid, :kill)
-      # Wait for process to die
-      Process.sleep(50)
-      assert SubAgentServer.whereis(sub_agent_id) == nil
+      # Wait for the process to actually die, then for the Registry to
+      # process its :DOWN message and clear the entry.
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+      assert wait_until(fn -> SubAgentServer.whereis(sub_agent_id) == nil end)
 
       # Resume → should handle the dead process gracefully
       assert {:ok, final_state} = Agent.resume(agent, interrupted_state, [%{type: :approve}])

--- a/test/support/testing_helpers.ex
+++ b/test/support/testing_helpers.ex
@@ -59,6 +59,56 @@ defmodule Sagents.TestingHelpers do
   end
 
   @doc """
+  Polls a function until it returns a truthy value or the timeout elapses.
+
+  Useful for synchronizing tests with asynchronous state changes that don't
+  expose a direct hook to wait on — for example, waiting for an Elixir
+  `Registry` to process the `:DOWN` message that follows a `GenServer.stop/2`,
+  or waiting for an ETS table to reflect an out-of-band write.
+
+  Returns `true` if the function returned a truthy value before the deadline, or
+  `false` if the timeout elapsed first. Pair it with `assert/1` so failures
+  surface at the test's call site:
+
+      assert wait_until(fn -> SubAgentServer.whereis(id) == nil end)
+
+  ## Options
+
+  - `:timeout` - total time to wait, in milliseconds (default: `1_000`)
+  - `:interval` - sleep duration between checks, in milliseconds (default: `10`)
+
+  ## Examples
+
+      # Wait for a process to be deregistered after stop
+      assert wait_until(fn ->
+        SubAgentServer.whereis(sub_agent_id) == nil
+      end)
+
+      # Custom timeout for a slower condition
+      assert wait_until(fn -> some_async_condition() end, timeout: 5_000)
+  """
+  @spec wait_until((-> any()), keyword()) :: boolean()
+  def wait_until(fun, opts \\ []) when is_function(fun, 0) do
+    timeout = Keyword.get(opts, :timeout, 1_000)
+    interval = Keyword.get(opts, :interval, 10)
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, interval, deadline)
+  end
+
+  defp do_wait_until(fun, interval, deadline) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        false
+      else
+        Process.sleep(interval)
+        do_wait_until(fun, interval, deadline)
+      end
+    end
+  end
+
+  @doc """
   Basic conversion of a Message to a DisplayMessage like data map.
   """
   def message_to_display_data(%LangChain.Message{} = message) do


### PR DESCRIPTION
## Problem

`Sagents.SubAgentHitlIntegrationTest` intermittently failed in CI on this assertion:

```
assert SubAgentServer.whereis(interrupt_data.sub_agent_id) == nil
```

The race is in the process registry, not in `SubAgentServer.stop/1`. After `Agent.resume/3` completes, the middleware calls `GenServer.stop(pid, :normal)`, which does wait for the sub-agent process to die — so the PID is genuinely gone. But `SubAgentServer.whereis/1` looks the PID up via `Sagents.ProcessRegistry`, and the registry processes its own `:DOWN` message asynchronously. When `GenServer.stop` returns to the test, the registry may not have cleared its entry yet, so `whereis/1` still returns the (now-dead) PID and the assertion fails.

The same race was already being papered over in another test in the same file with `Process.sleep(50)` after a manual `Process.exit(pid, :kill)` — which is both flaky on slow CI and contradicts the project's testing guideline to avoid `Process.sleep/1` in tests.

## Solution

Adds a general-purpose `wait_until/2` polling helper to `Sagents.TestingHelpers`, and uses it at both flake sites in the integration test.

`wait_until/2` runs the supplied function repeatedly (10ms interval, 1s timeout by default) until it returns a truthy value, returning `true` on success and `false` on timeout. The intended call pattern is `assert wait_until(fn -> condition end)`, which keeps ExUnit's failure reporting pointed at the test's call site. The helper lives in the existing shared module (`test/support/testing_helpers.ex`) so any future test that needs to synchronize against asynchronous bookkeeping — registry cleanups, ETS writes, GenServer mailbox flushes — can reuse it instead of reaching for `Process.sleep`.

For the second flake site (where the test manually kills the SubAgentServer), the fix uses `Process.monitor` + `assert_receive {:DOWN, ...}` to deterministically wait for the process to die, then `wait_until` to cover the registry cleanup separately. This matches the project guideline to use process monitors instead of `Process.alive?` polling.

## Changes

- `test/support/testing_helpers.ex` — Added `wait_until/2`, a polling helper for synchronizing tests against async state changes; documented the call pattern (`assert wait_until(fn -> ... end)`) and the default 1s/10ms timing
- `test/sagents/subagent_hitl_integration_test.exs` — Replaced the failing direct `whereis == nil` assertion with `assert wait_until(...)`
- `test/sagents/subagent_hitl_integration_test.exs` — Replaced `Process.sleep(50)` in the \"handles SubAgentServer crash gracefully\" test with `Process.monitor` + `assert_receive {:DOWN, ...}` followed by `wait_until` for the registry cleanup
- `test/sagents/subagent_hitl_integration_test.exs` — Added `import Sagents.TestingHelpers, only: [wait_until: 1]` (the file uses `ExUnit.Case` directly rather than `Sagents.BaseCase`)

## Testing

Ran the affected file 5 times with different random seeds — all 3 tests pass consistently:

\`\`\`
mix test test/sagents/subagent_hitl_integration_test.exs --seed \$RANDOM
# 3 tests, 0 failures (×5)
\`\`\`

No production code is touched, so no runtime behaviour changes — this is a pure test-stability fix.