### PR TITLE
Add task-style sub-agents, cancellation hardening, CI pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -46,14 +46,16 @@ jobs:
             lint: lint
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           elixir-version: ${{ matrix.pair.elixir }}
           otp-version: ${{ matrix.pair.otp }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/lib/sagents/agent_persistence.ex
+++ b/lib/sagents/agent_persistence.ex
@@ -13,6 +13,7 @@ defmodule Sagents.AgentPersistence do
   | Context | When | Notes |
   |---------|------|-------|
   | `:on_completion` | Agent execution completes successfully (status → :idle) | Most common persistence point |
+  | `:on_cancel` | Execution cancelled by user | Preserves rolling state up to cancel point |
   | `:on_error` | Agent execution fails (status → :error) | Preserves state up to the error |
   | `:on_interrupt` | Execution paused for HITL approval (status → :interrupted) | Preserves interrupt context |
   | `:on_title_generated` | Conversation title auto-generated | State includes updated metadata |
@@ -33,6 +34,7 @@ defmodule Sagents.AgentPersistence do
 
   @type context ::
           :on_completion
+          | :on_cancel
           | :on_error
           | :on_interrupt
           | :on_title_generated

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -256,6 +256,9 @@ defmodule Sagents.AgentServer do
       # Presence module for agent discovery (e.g., MyApp.Presence)
       # When set, agent tracks presence on "agent_server:presence" topic
       :presence_module,
+      # Monotonic counter bumped on each execute/resume. Turn casts carry their seq
+      # so late messages from a cancelled or superseded run are rejected.
+      execution_seq: 0,
       # Whether this server was restored from persisted state (vs fresh start)
       # Used to broadcast :node_transferred event on startup after Horde migration
       restored: false
@@ -1460,11 +1463,16 @@ defmodule Sagents.AgentServer do
 
   @impl true
   def handle_call(:execute, _from, %ServerState{status: :idle} = server_state) do
-    # Build PubSub callback handlers (created in GenServer, captures server_state)
-    pubsub_callbacks = build_pubsub_callbacks(server_state)
+    # Bump execution sequence so late callbacks from any prior run are rejected.
+    # Build callbacks AFTER bumping so the closure captures the current seq.
+    new_state = %{
+      server_state
+      | execution_seq: server_state.execution_seq + 1,
+        status: :running
+    }
 
-    # Transition to running
-    new_state = %{server_state | status: :running}
+    pubsub_callbacks = build_pubsub_callbacks(new_state)
+
     broadcast_event(new_state, {:status_changed, :running, nil})
     update_presence_status(new_state, :running)
 
@@ -1492,22 +1500,44 @@ defmodule Sagents.AgentServer do
       when not is_nil(task) do
     Logger.info("Cancelling agent execution for agent: #{server_state.agent.agent_id}")
 
-    # Shutdown the running task
-    Task.shutdown(task, :brutal_kill)
+    # Kill any running sub-agents FIRST. The main Task may be blocked in a
+    # synchronous GenServer.call to a SubAgentServer -- without this, Task.shutdown
+    # would spend its full 2s grace waiting on a call that can never return.
+    # Sub-agents emit a :subagent_cancelled broadcast before terminating so
+    # observability is preserved.
+    cancel_all_subagents(server_state)
 
-    # Transition to cancelled status (not completed)
-    # Note: We don't include the state in the broadcast because it may be in an
-    # inconsistent state after brutal task termination
-    new_state = %{server_state | status: :cancelled}
+    # Two-phase shutdown: give the chain up to 2s to flush the in-progress turn
+    # through callbacks (which top up the rolling state). If it doesn't return
+    # in time, brutal-kill. Either way, the rolling state in `server_state.state`
+    # already reflects every fully-processed turn up to this point.
+    _ = Task.shutdown(task, :timer.seconds(2)) || Task.shutdown(task, :brutal_kill)
+
+    # Drain any final turn casts the task may have emitted before exit so the
+    # rolling state captures as much as possible before we snapshot it.
+    server_state = drain_turn_casts(server_state)
+
+    new_state = %{server_state | status: :cancelled, task: nil}
+
+    # Persist the rolling state — the database now reflects messages produced
+    # up to the cancel point, so page reload recovers them.
+    maybe_persist_state(new_state, :on_cancel)
+
+    # Persist an assistant display message for the cancellation so it survives
+    # page reload. Persisting here (not in the LiveView) avoids duplicate rows
+    # when multiple LiveViews are subscribed to the same agent. Mirrors the
+    # :error path's persist_error_as_display_message.
+    persist_cancel_as_display_message(new_state)
 
     # Reset inactivity timer after cancellation
     new_state = reset_inactivity_timer(new_state)
 
-    # Broadcast cancellation event
+    # Broadcast in-flight state so the debugger shows what actually happened.
+    broadcast_debug_event(new_state, {:agent_state_update, new_state.state})
     broadcast_event(new_state, {:status_changed, :cancelled, nil})
     update_presence_status(new_state, :cancelled)
 
-    {:reply, :ok, Map.put(new_state, :task, nil)}
+    {:reply, :ok, new_state}
   end
 
   @impl true
@@ -1526,11 +1556,13 @@ defmodule Sagents.AgentServer do
     # display message updates (e.g., marking ask_user tools as completed).
     resolved_interrupt_data = server_state.interrupt_data
 
-    # Transition back to running
+    # Transition back to running. Bump execution_seq so callbacks from a prior
+    # run can't pollute the rolling state.
     new_state = %{
       server_state
       | status: :running,
-        interrupt_data: nil
+        interrupt_data: nil,
+        execution_seq: server_state.execution_seq + 1
     }
 
     broadcast_event(new_state, {:status_changed, :running, nil})
@@ -1771,6 +1803,30 @@ defmodule Sagents.AgentServer do
   def handle_cast({:publish_debug_event, event}, server_state) do
     broadcast_debug_event(server_state, event)
     {:noreply, server_state}
+  end
+
+  # Rolling-state turn update: append the completed message to the live state so
+  # `get_state/1`, debuggers, and persistence all observe turn-level progress
+  # before Agent.execute/3 returns. Out-of-order casts (from a cancelled or
+  # superseded run) are silently dropped.
+  @impl true
+  def handle_cast({:turn_state_update, exec_seq, %LangChain.Message{} = message}, server_state) do
+    if exec_seq == server_state.execution_seq and server_state.status == :running do
+      updated_messages = server_state.state.messages ++ [message]
+      updated_state = %{server_state.state | messages: updated_messages}
+      new_server_state = %{server_state | state: updated_state}
+
+      # Incremental broadcast: observers append to their local copy rather than
+      # rebuilding from the full state on every turn.
+      broadcast_debug_event(
+        new_server_state,
+        {:agent_state_messages_appended, [message]}
+      )
+
+      {:noreply, new_server_state}
+    else
+      {:noreply, server_state}
+    end
   end
 
   @impl true
@@ -2044,6 +2100,10 @@ defmodule Sagents.AgentServer do
   # This map is combined with middleware callback maps into a list
   # in execute_agent/2 and resume_agent/2 before being passed to Agent.execute/3.
   defp build_pubsub_callbacks(%ServerState{} = server_state) do
+    agent_id = server_state.agent.agent_id
+    exec_seq = server_state.execution_seq
+    server_name = get_name(agent_id)
+
     %{
       # Sagents-specific callback (NOT a LangChain key).
       # Fired by Agent.fire_callback/3 after before_model hooks, before LLM call.
@@ -2063,6 +2123,9 @@ defmodule Sagents.AgentServer do
       on_message_processed: fn _chain, message ->
         # Save and broadcast message (if callback configured)
         maybe_save_and_broadcast_message(server_state, message)
+        # Append to the rolling state so every observer (debugger, persistence,
+        # get_state) sees turn-level progress before Agent.execute/3 returns.
+        safe_cast(server_name, {:turn_state_update, exec_seq, message})
       end,
 
       # Callback for token usage information
@@ -2225,6 +2288,10 @@ defmodule Sagents.AgentServer do
   end
 
   defp handle_execution_result({:ok, new_state}, server_state) do
+    # Reconcile: the canonical state from Agent.execute replaces the rolling
+    # state wholesale. The rolling state is a best-effort live view; middleware
+    # after_model hooks may have transformed the state in ways our per-turn
+    # appender doesn't capture.
     updated_state = %{
       server_state
       | status: :idle,
@@ -2371,6 +2438,145 @@ defmodule Sagents.AgentServer do
 
       _ ->
         :ok
+    end
+  end
+
+  # Cancel every running sub-agent for this main agent. Called from the main
+  # agent's :cancel handler so that sub-agents don't outlive their parent.
+  #
+  # Two broadcast paths:
+  #   1. If the sub-agent can respond to :prepare_cancel within 300ms, IT
+  #      broadcasts the event (rich context with its final_messages).
+  #   2. If it is blocked (e.g. in-flight LLM call), the PARENT broadcasts a
+  #      minimal :subagent_cancelled event directly from this process.
+  # Either way, observers see a terminal event before the sub-agent is killed.
+  defp cancel_all_subagents(%ServerState{} = server_state) do
+    agent_id = server_state.agent.agent_id
+
+    case Sagents.SubAgentsDynamicSupervisor.whereis(agent_id) do
+      nil ->
+        :ok
+
+      sup_pid ->
+        children = DynamicSupervisor.which_children(sup_pid)
+
+        Enum.each(children, fn
+          {_id, child_pid, :worker, _mods} when is_pid(child_pid) ->
+            cancel_subagent_child(server_state, child_pid, sup_pid)
+
+          _ ->
+            :ok
+        end)
+
+        :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp cancel_subagent_child(server_state, child_pid, sup_pid) do
+    # Snapshot the tool_call_id from the sub-agent's process dictionary BEFORE
+    # we terminate it -- Process.info doesn't go through the message queue, so
+    # it works even when the process is blocked in an LLM call.
+    tool_call_id = read_tool_call_id(child_pid)
+
+    broadcast_ok =
+      try do
+        GenServer.call(child_pid, :prepare_cancel, 300) == :ok
+      catch
+        :exit, _ -> false
+      end
+
+    unless broadcast_ok do
+      # Sub-agent was blocked and couldn't self-broadcast. Fire a minimal
+      # :subagent_cancelled event from the parent so observability still works.
+      broadcast_fallback_subagent_cancel(server_state, child_pid)
+    end
+
+    # Update the main agent's "task" tool-call display message to :cancelled
+    # so the chat UI stops showing a spinner for work that was abandoned.
+    # Fires the :tool_execution_update broadcast AND persists via
+    # DisplayMessagePersistence (if configured), mirroring the normal tool
+    # completion path.
+    if is_binary(tool_call_id) do
+      broadcast_tool_event(server_state, :cancelled, %{
+        call_id: tool_call_id,
+        name: "task"
+      })
+    end
+
+    case DynamicSupervisor.terminate_child(sup_pid, child_pid) do
+      :ok -> :ok
+      {:error, :not_found} -> :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp read_tool_call_id(pid) do
+    case Process.info(pid, :dictionary) do
+      {:dictionary, dict} -> Keyword.get(dict, :tool_call_id)
+      _ -> nil
+    end
+  end
+
+  defp broadcast_fallback_subagent_cancel(%ServerState{} = server_state, child_pid) do
+    sub_agent_id = lookup_sub_agent_id(child_pid)
+
+    if sub_agent_id do
+      # Use the same wire format as SubAgentServer.broadcast_subagent_event/2.
+      # NB: no final_messages/turn_count in this payload -- the sub-agent was
+      # blocked in an LLM call and we can't query its current chain. Observers
+      # (the debugger) already have every :subagent_llm_message they received
+      # in their own state, so shipping empty placeholders here would only
+      # overwrite their real data.
+      broadcast_debug_event(
+        server_state,
+        {:subagent, sub_agent_id, {:subagent_status_changed, :cancelled}}
+      )
+
+      broadcast_debug_event(
+        server_state,
+        {:subagent, sub_agent_id, {:subagent_cancelled, %{}}}
+      )
+    end
+
+    :ok
+  end
+
+  defp lookup_sub_agent_id(child_pid) do
+    Sagents.ProcessRegistry.keys(child_pid)
+    |> Enum.find_value(fn
+      {:sub_agent, id} -> id
+      _ -> nil
+    end)
+  catch
+    :exit, _ -> nil
+  end
+
+  # Drain any pending turn-update casts from the mailbox so the rolling state
+  # captures every turn the task managed to emit before shutdown. Bounded loop:
+  # each iteration either appends a valid turn or returns immediately.
+  defp drain_turn_casts(%ServerState{} = server_state) do
+    receive do
+      {:"$gen_cast", {:turn_state_update, exec_seq, %LangChain.Message{} = message}}
+      when exec_seq == server_state.execution_seq ->
+        updated_messages = server_state.state.messages ++ [message]
+        updated_state = %{server_state.state | messages: updated_messages}
+        drain_turn_casts(%{server_state | state: updated_state})
+    after
+      0 -> server_state
+    end
+  end
+
+  # safe_cast is used from callback closures that run in the Task process. If
+  # the GenServer is no longer registered (crashed, shut down) the cast is a
+  # silent no-op rather than crashing the Task.
+  defp safe_cast(server_name, message) do
+    try do
+      GenServer.cast(server_name, message)
+    catch
+      :exit, _ -> :ok
     end
   end
 
@@ -2592,6 +2798,16 @@ defmodule Sagents.AgentServer do
     error_text = format_error_for_display(reason)
     error_message = Message.new_assistant!(error_text)
     maybe_save_and_broadcast_message(server_state, error_message)
+  end
+
+  # Create and persist an assistant message on cancellation so it survives page
+  # reload and reaches every subscribed LiveView via :display_message_saved.
+  # Persisting here (single authoritative writer) avoids duplicate inserts when
+  # multiple LiveViews are subscribed to the same agent.
+  defp persist_cancel_as_display_message(server_state) do
+    cancel_text = "_Agent execution cancelled by user. Partial response discarded._"
+    cancel_message = Message.new_assistant!(cancel_text)
+    maybe_save_and_broadcast_message(server_state, cancel_message)
   end
 
   defp format_error_for_display(%LangChain.LangChainError{message: message})

--- a/lib/sagents/display_message_persistence.ex
+++ b/lib/sagents/display_message_persistence.ex
@@ -70,7 +70,7 @@ defmodule Sagents.DisplayMessagePersistence do
   @callback save_message(conversation_id :: String.t(), message :: LangChain.Message.t()) ::
               {:ok, list()} | {:error, term()}
 
-  @type tool_status :: :executing | :completed | :failed | :interrupted
+  @type tool_status :: :executing | :completed | :failed | :interrupted | :cancelled
 
   @doc """
   Update the status of a persisted tool call display message.
@@ -89,6 +89,7 @@ defmodule Sagents.DisplayMessagePersistence do
     | `:completed` | `%{call_id: "...", name: "...", result: "..."}` |
     | `:failed` | `%{call_id: "...", name: "...", error: "..."}` |
     | `:interrupted` | `%{call_id: "...", display_text: "..."}` |
+    | `:cancelled` | `%{call_id: "...", name: "..."}` |
 
   ## Returns
 

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -612,9 +612,12 @@ defmodule Sagents.Middleware.SubAgent do
 
         # Spawn SubAgentServer under supervision
         # SubAgentServer will register itself in Sagents.Registry
+        tool_call_id = Map.get(context, :tool_call_id)
+
         child_spec = %{
           id: subagent.id,
-          start: {SubAgentServer, :start_link, [[subagent: subagent]]},
+          start:
+            {SubAgentServer, :start_link, [[subagent: subagent, tool_call_id: tool_call_id]]},
           # Don't restart on crash
           restart: :temporary
         }
@@ -694,10 +697,12 @@ defmodule Sagents.Middleware.SubAgent do
 
         # Get supervisor and start SubAgent (same as pre-configured)
         supervisor_name = SubAgentsDynamicSupervisor.get_name(config.agent_id)
+        tool_call_id = Map.get(context, :tool_call_id)
 
         child_spec = %{
           id: subagent.id,
-          start: {SubAgentServer, :start_link, [[subagent: subagent]]},
+          start:
+            {SubAgentServer, :start_link, [[subagent: subagent, tool_call_id: tool_call_id]]},
           restart: :temporary
         }
 
@@ -832,9 +837,24 @@ defmodule Sagents.Middleware.SubAgent do
 
       {:error, reason} ->
         Logger.error("SubAgent #{sub_agent_id} failed: #{inspect(reason)}")
+        # The rich error (final_messages, turn_count, original term) is
+        # broadcast to the debugger via SubAgentServer's :subagent_failed_with_context
+        # event -- see sub_agent_server.ex. This tool-result string is just the
+        # summary returned to the parent LLM.
         SubAgentServer.stop(sub_agent_id)
-        {:error, "SubAgent execution failed: #{inspect(reason)}"}
+        {:error, format_subagent_error(reason, subagent_type)}
     end
+  end
+
+  # Preserve structure for LangChainError (e.g., length-stopped) so the caller
+  # can tell an LLM length truncation apart from an infrastructure failure.
+  defp format_subagent_error(%LangChain.LangChainError{type: type, message: msg}, subagent_type)
+       when is_binary(msg) do
+    "SubAgent '#{subagent_type}' failed (#{type || "error"}): #{msg}"
+  end
+
+  defp format_subagent_error(reason, subagent_type) do
+    "SubAgent '#{subagent_type}' failed: #{inspect(reason)}"
   end
 
   @doc """
@@ -888,7 +908,7 @@ defmodule Sagents.Middleware.SubAgent do
         error_result =
           ToolResult.new!(%{
             tool_call_id: tool_call_id,
-            content: "SubAgent resume failed: #{inspect(reason)}",
+            content: format_subagent_error(reason, subagent_type),
             name: "task",
             is_error: true,
             is_interrupt: false
@@ -936,7 +956,7 @@ defmodule Sagents.Middleware.SubAgent do
       {:error, reason} ->
         Logger.error("SubAgent #{sub_agent_id} resume failed: #{inspect(reason)}")
         SubAgentServer.stop(sub_agent_id)
-        {:error, "SubAgent resume failed: #{inspect(reason)}"}
+        {:error, format_subagent_error(reason, subagent_type)}
     end
   end
 end

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -144,6 +144,7 @@ defmodule Sagents.Middleware.SubAgent do
   alias Sagents.SubAgent
   alias Sagents.SubAgentServer
   alias Sagents.SubAgentsDynamicSupervisor
+  alias LangChain.Callbacks
   alias LangChain.Function
   alias LangChain.Message.ToolResult
 
@@ -177,6 +178,25 @@ defmodule Sagents.Middleware.SubAgent do
           end)
           |> Map.new(fn config -> {config.name, config.until_tool} end)
 
+        # Build display_texts map: %{subagent_type => display_text}.
+        # Used by the :on_tool_call_identified callback to re-label the
+        # `task` tool call in the UI based on which subagent was picked.
+        display_texts_map =
+          for cfg <- subagents,
+              text = Map.get(cfg, :display_text),
+              is_binary(text) and text != "",
+              into: %{},
+              do: {cfg.name, text}
+
+        # Build use_instructions map: %{subagent_type => use_instructions}.
+        # Presence of any entry enables the `get_task_instructions` tool.
+        use_instructions_map =
+          for cfg <- subagents,
+              text = Map.get(cfg, :use_instructions),
+              is_binary(text) and text != "",
+              into: %{},
+              do: {cfg.name, text}
+
         # Add "general-purpose" entry for dynamic subagent creation
         # This special marker enables runtime tool inheritance
         agent_map_with_general = Map.put(agent_map, "general-purpose", :dynamic)
@@ -196,7 +216,9 @@ defmodule Sagents.Middleware.SubAgent do
           agent_id: agent_id,
           model: model,
           block_middleware: block_middleware,
-          until_tool_map: until_tool_map
+          until_tool_map: until_tool_map,
+          display_texts_map: display_texts_map,
+          use_instructions_map: use_instructions_map
         }
 
         {:ok, config}
@@ -207,8 +229,8 @@ defmodule Sagents.Middleware.SubAgent do
   end
 
   @impl true
-  def system_prompt(_config) do
-    """
+  def system_prompt(config) do
+    base = """
     ## SubAgent Delegation
 
     You have access to a `task` tool for delegating work to specialized SubAgents.
@@ -227,12 +249,90 @@ defmodule Sagents.Middleware.SubAgent do
     SubAgents have their own conversation context and will work independently
     to complete the task. You will receive only their final result.
     """
+
+    if has_use_instructions?(config) do
+      base <>
+        """
+
+        When a sub-agent in the `task` menu has a terse description, call
+        `get_task_instructions(subagent_type: "...")` first to fetch its full
+        usage guide, then invoke `task` with informed `instructions`. For
+        trivial cases where the description is clear, skip the fetch and call
+        `task` directly.
+        """
+    else
+      base
+    end
   end
 
   @impl true
   def tools(config) do
-    [build_task_tool(config)]
+    if has_use_instructions?(config) do
+      [build_task_tool(config), build_get_task_instructions_tool(config)]
+    else
+      [build_task_tool(config)]
+    end
   end
+
+  @impl true
+  def callbacks(config) do
+    display_texts_map = Map.get(config, :display_texts_map, %{})
+
+    if map_size(display_texts_map) == 0 do
+      %{}
+    else
+      %{
+        on_tool_call_identified: fn chain, tool_call, _function ->
+          maybe_refire_with_subagent_display_text(chain, tool_call, display_texts_map)
+        end
+      }
+    end
+  end
+
+  defp has_use_instructions?(config) when is_map(config) do
+    config
+    |> Map.get(:use_instructions_map, %{})
+    |> map_size()
+    |> Kernel.>(0)
+  end
+
+  defp has_use_instructions?(_), do: false
+
+  # When the `task` tool call is identified, the chain augments it with the
+  # tool's static display_text ("Running task"). If the parent picked a
+  # subagent_type with its own `display_text`, re-fire the callback with the
+  # overridden ToolCall so downstream observers (UI) can re-label the running
+  # tool call.
+  defp maybe_refire_with_subagent_display_text(chain, %{name: "task"} = tool_call, display_texts) do
+    case Map.get(tool_call, :arguments) do
+      args when is_map(args) ->
+        subagent_type = Map.get(args, "subagent_type")
+
+        case Map.get(display_texts, subagent_type) do
+          nil ->
+            :ok
+
+          override when is_binary(override) ->
+            if tool_call.display_text != override do
+              updated_call = %{tool_call | display_text: override}
+              func = chain._tool_map[tool_call.name]
+
+              Callbacks.fire(chain.callbacks, :on_tool_call_identified, [
+                chain,
+                updated_call,
+                func
+              ])
+            end
+
+            :ok
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp maybe_refire_with_subagent_display_text(_chain, _tool_call, _display_texts), do: :ok
 
   ## Private Functions - Tool Building
 
@@ -240,8 +340,13 @@ defmodule Sagents.Middleware.SubAgent do
     # Get list of available subagent names from the lookup map
     subagent_names = config.agent_map |> Map.keys()
 
-    # Build description with available subagents
-    description = build_task_description(config.descriptions)
+    # Build description with available subagents (adding usage-guide hints
+    # for those with `use_instructions` set).
+    description =
+      build_task_description(
+        config.descriptions,
+        Map.get(config, :use_instructions_map, %{})
+      )
 
     Function.new!(%{
       name: "task",
@@ -278,15 +383,52 @@ defmodule Sagents.Middleware.SubAgent do
     })
   end
 
-  defp build_task_description(descriptions) do
+  defp build_task_description(descriptions, use_instructions_map) do
     base = "Delegate a task to a specialized SubAgent.\n\nAvailable SubAgents:\n"
 
     subagent_list =
       descriptions
-      |> Enum.map(fn {name, desc} -> "- #{name}: #{desc}" end)
+      |> Enum.map(fn {name, desc} ->
+        if Map.has_key?(use_instructions_map, name) do
+          "- #{name}: #{desc} Call get_task_instructions(\"#{name}\") for the full usage guide before invoking."
+        else
+          "- #{name}: #{desc}"
+        end
+      end)
       |> Enum.join("\n")
 
     base <> subagent_list
+  end
+
+  defp build_get_task_instructions_tool(config) do
+    use_instructions_map = Map.get(config, :use_instructions_map, %{})
+    eligible = Map.keys(use_instructions_map)
+
+    Function.new!(%{
+      name: "get_task_instructions",
+      description:
+        "Fetch the full usage guide for a specific sub-agent before calling `task`. " <>
+          "Use this to learn how to frame the `instructions` argument or what prerequisites the sub-agent expects.",
+      display_text: "Reading task instructions",
+      async: true,
+      parameters_schema: %{
+        type: "object",
+        required: ["subagent_type"],
+        properties: %{
+          "subagent_type" => %{
+            type: "string",
+            enum: eligible,
+            description: "Which sub-agent's usage guide to retrieve."
+          }
+        }
+      },
+      function: fn %{"subagent_type" => name}, _ctx ->
+        case Map.fetch(use_instructions_map, name) do
+          {:ok, txt} -> {:ok, txt}
+          :error -> {:error, "no usage guide for sub-agent #{inspect(name)}"}
+        end
+      end
+    })
   end
 
   ## Private Functions - Task Execution

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -719,6 +719,10 @@ defmodule Sagents.SubAgent do
       field :name, :string
       field :description, :string
       field :system_prompt, :string
+      field :instructions, :string
+      field :system_prompt_override, :string
+      field :use_instructions, :string
+      field :display_text, :string
       field :tools, {:array, :any}, default: [], virtual: true
       field :model, :any, virtual: true
       field :middleware, {:array, :any}, default: [], virtual: true
@@ -729,7 +733,11 @@ defmodule Sagents.SubAgent do
     @type t :: %Config{
             name: String.t(),
             description: String.t(),
-            system_prompt: String.t(),
+            system_prompt: String.t() | nil,
+            instructions: String.t() | nil,
+            system_prompt_override: String.t() | nil,
+            use_instructions: String.t() | nil,
+            display_text: String.t() | nil,
             tools: [LangChain.Function.t()],
             model: term() | nil,
             middleware: list(),
@@ -743,18 +751,27 @@ defmodule Sagents.SubAgent do
         :name,
         :description,
         :system_prompt,
+        :instructions,
+        :system_prompt_override,
+        :use_instructions,
+        :display_text,
         :tools,
         :model,
         :middleware,
         :interrupt_on,
         :until_tool
       ])
-      |> validate_required([:name, :description, :system_prompt, :tools])
+      |> validate_required([:name, :description, :tools])
       |> validate_length(:name, min: 1, max: 100)
       |> validate_length(:description, min: 1, max: 500)
       |> validate_length(:system_prompt, min: 1, max: 10_000)
+      |> validate_length(:instructions, min: 1, max: 10_000)
+      |> validate_length(:system_prompt_override, min: 1, max: 10_000)
+      |> validate_length(:use_instructions, min: 1, max: 10_000)
+      |> validate_length(:display_text, min: 1, max: 200)
       |> validate_tools()
       |> validate_until_tool()
+      |> validate_prompt_source()
       |> apply_action(:insert)
     end
 
@@ -822,6 +839,29 @@ defmodule Sagents.SubAgent do
     end
 
     defp validate_tool_names_exist(changeset, _names, _tools), do: changeset
+
+    # At least one of system_prompt, instructions, or system_prompt_override
+    # must be present so the sub-agent has *some* task framing beyond the
+    # boilerplate.
+    defp validate_prompt_source(changeset) do
+      sources = [:system_prompt, :instructions, :system_prompt_override]
+      any_present? = Enum.any?(sources, &present?(get_field(changeset, &1)))
+
+      if any_present? do
+        changeset
+      else
+        add_error(
+          changeset,
+          :system_prompt,
+          "at least one of :system_prompt, :instructions, or :system_prompt_override must be set"
+        )
+      end
+    end
+
+    defp present?(nil), do: false
+    defp present?(""), do: false
+    defp present?(str) when is_binary(str), do: true
+    defp present?(_), do: false
   end
 
   defmodule Compiled do
@@ -837,6 +877,8 @@ defmodule Sagents.SubAgent do
     embedded_schema do
       field :name, :string
       field :description, :string
+      field :use_instructions, :string
+      field :display_text, :string
       field :agent, :any, virtual: true
       field :extract_result, :any, virtual: true
       field :initial_messages, {:array, :any}, default: [], virtual: true
@@ -845,6 +887,8 @@ defmodule Sagents.SubAgent do
     @type t :: %Compiled{
             name: String.t(),
             description: String.t(),
+            use_instructions: String.t() | nil,
+            display_text: String.t() | nil,
             agent: Sagents.Agent.t(),
             extract_result: (State.t() -> any()) | nil,
             initial_messages: [LangChain.Message.t()]
@@ -852,10 +896,20 @@ defmodule Sagents.SubAgent do
 
     def new(attrs) do
       %Compiled{}
-      |> cast(attrs, [:name, :description, :agent, :extract_result, :initial_messages])
+      |> cast(attrs, [
+        :name,
+        :description,
+        :use_instructions,
+        :display_text,
+        :agent,
+        :extract_result,
+        :initial_messages
+      ])
       |> validate_required([:name, :description, :agent])
       |> validate_length(:name, min: 1, max: 100)
       |> validate_length(:description, min: 1, max: 500)
+      |> validate_length(:use_instructions, min: 1, max: 10_000)
+      |> validate_length(:display_text, min: 1, max: 200)
       |> validate_agent()
       |> validate_extract_result()
       |> validate_initial_messages()
@@ -1033,6 +1087,42 @@ defmodule Sagents.SubAgent do
 
   ## Private Functions
 
+  # Universal framing for task-style sub-agents. Prepended to every Config-path
+  # sub-agent's system prompt so authors can focus on task specifics in
+  # `instructions`. Overridable via `system_prompt_override`.
+  @task_subagent_boilerplate """
+  You are a sub-agent invoked by to perform a specific, bounded task. You have access to tools. Focus on completing the task you've been given.
+
+  - You must complete the task and return a result, or fail and return a clear error. Do not stall.
+  - You cannot ask the user questions. There is no user in this conversation — only the instructions you've been given.
+  - Do not request clarification. Make the best decision with the information you have and report what you did.
+  - When finished, return a clear, concise result suitable for the parent agent to use.
+  """
+
+  @doc false
+  def task_subagent_boilerplate, do: @task_subagent_boilerplate
+
+  @doc """
+  Compose the child agent's `base_system_prompt` from a Config.
+
+  Composition rule:
+  - Header = `system_prompt_override` (if set) else the built-in boilerplate.
+  - Body = `instructions` (if set) else `system_prompt` (legacy) else "".
+
+  The header and body are joined with a blank line. Middleware-contributed
+  prompt fragments are appended later by the normal `Sagents.Agent` compile
+  path — this function does not handle those.
+  """
+  def compose_child_system_prompt(%Config{} = cfg) do
+    header = cfg.system_prompt_override || @task_subagent_boilerplate
+    body = cfg.instructions || cfg.system_prompt || ""
+
+    [header, body]
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n\n")
+  end
+
   defp configure_new_subagent(%Config{} = config, default_model, default_middleware) do
     # Use config's model or fall back to default
     model = config.model || default_model
@@ -1046,11 +1136,13 @@ defmodule Sagents.SubAgent do
     middleware =
       Sagents.Middleware.HumanInTheLoop.maybe_append(middleware, config.interrupt_on)
 
+    base_system_prompt = compose_child_system_prompt(config)
+
     # Create the agent with explicit middleware (replace defaults to avoid duplication)
     Sagents.Agent.new!(
       %{
         model: model,
-        base_system_prompt: config.system_prompt,
+        base_system_prompt: base_system_prompt,
         tools: config.tools,
         middleware: middleware
       },

--- a/lib/sagents/sub_agent/task.ex
+++ b/lib/sagents/sub_agent/task.ex
@@ -1,0 +1,41 @@
+defmodule Sagents.SubAgent.Task do
+  @moduledoc """
+  Behaviour for task modules that describe a named sub-agent "skill".
+
+  Each task module describes a sub-agent that is registered on the parent
+  agent's `Sagents.Middleware.SubAgent` and invoked via the built-in
+  `task` tool. The sub-agent runs in an isolated context with its own
+  middleware/tool stack, performs task-specific work, and reports back
+  to the parent.
+
+  Task modules are typically compiled into `Sagents.SubAgent.Compiled`
+  entries by host applications, which combine the task's `instructions/0`
+  with `Sagents.SubAgent.task_subagent_boilerplate/0` to form the child
+  agent's system prompt.
+
+  ## Callbacks
+
+  - `task_name/0` — short, kebab-case identifier exposed to the parent LLM
+    as the `subagent_type` enum value (e.g. `"search-web"`).
+  - `description/0` — one-line blurb surfaced in the `task` tool's auto-
+    generated menu. Always in the parent's context.
+  - `use_instructions/0` — detailed "how to invoke this" guide for the
+    parent LLM. Lazy-loaded via `get_task_instructions` only when the
+    parent decides it wants to use this task. Describes prerequisites
+    (what inputs/source data must exist), what to pass in the
+    `instructions` arg, and what outputs the task produces.
+  - `instructions/0` — the task's internal working prompt. Baked into the
+    child sub-agent's system prompt at invocation. Never shown to the
+    parent. Should focus on the substantive procedure — the universal
+    boilerplate (no user questions, complete-or-fail, etc.) is supplied
+    by `Sagents.SubAgent.task_subagent_boilerplate/0`.
+  - `display_text/0` — human-facing status string shown in the host UI
+    while this task is running.
+  """
+
+  @callback task_name() :: String.t()
+  @callback description() :: String.t()
+  @callback use_instructions() :: String.t()
+  @callback instructions() :: String.t()
+  @callback display_text() :: String.t()
+end

--- a/lib/sagents/sub_agent/task.ex
+++ b/lib/sagents/sub_agent/task.ex
@@ -19,18 +19,35 @@ defmodule Sagents.SubAgent.Task do
     as the `subagent_type` enum value (e.g. `"search-web"`).
   - `description/0` — one-line blurb surfaced in the `task` tool's auto-
     generated menu. Always in the parent's context.
-  - `use_instructions/0` — detailed "how to invoke this" guide for the
-    parent LLM. Lazy-loaded via `get_task_instructions` only when the
-    parent decides it wants to use this task. Describes prerequisites
-    (what inputs/source data must exist), what to pass in the
-    `instructions` arg, and what outputs the task produces.
+  - `use_instructions/0` — *optional.* Detailed "how to invoke this" guide
+    for the parent LLM. Lazy-loaded via `get_task_instructions` only
+    when the parent decides it wants to use this task. Describes
+    prerequisites (what inputs/source data must exist), what to pass
+    in the `instructions` arg, and what outputs the task produces. If
+    not implemented, the host should treat this as "no lazy-loaded
+    docs" — the task is invoked using only `description/0` as parent-
+    visible guidance.
   - `instructions/0` — the task's internal working prompt. Baked into the
     child sub-agent's system prompt at invocation. Never shown to the
     parent. Should focus on the substantive procedure — the universal
     boilerplate (no user questions, complete-or-fail, etc.) is supplied
     by `Sagents.SubAgent.task_subagent_boilerplate/0`.
-  - `display_text/0` — human-facing status string shown in the host UI
-    while this task is running.
+  - `display_text/0` — *optional.* Human-facing status string shown in
+    the host UI while this task is running. If not implemented, the
+    middleware falls back to a generic `"Running task"` label (see
+    `Sagents.Middleware.SubAgent`); host compilers may instead derive
+    a humanized form of `task_name/0`.
+  - `model_override/0` — *optional.* If defined and returns a non-nil
+    value, the host should use the returned model (e.g. a configured
+    chat-model struct) for this task's sub-agent instead of the default
+    model supplied at compile time. Useful for narrow, bounded tasks
+    where a cheaper/faster model is sufficient (e.g. summarization,
+    classification). Returning `nil` — or not implementing this
+    callback at all — means "use the host's default."
+
+  Host compilers should guard optional callbacks with
+  `function_exported?/3` before calling them, and supply the documented
+  fallback when absent.
   """
 
   @callback task_name() :: String.t()
@@ -38,4 +55,7 @@ defmodule Sagents.SubAgent.Task do
   @callback use_instructions() :: String.t()
   @callback instructions() :: String.t()
   @callback display_text() :: String.t()
+  @callback model_override() :: term() | nil
+
+  @optional_callbacks use_instructions: 0, display_text: 0, model_override: 0
 end

--- a/lib/sagents/sub_agent_server.ex
+++ b/lib/sagents/sub_agent_server.ex
@@ -262,12 +262,93 @@ defmodule Sagents.SubAgentServer do
     :exit, {:noproc, _} -> :ok
   end
 
+  @doc """
+  Cancel a running SubAgentServer process.
+
+  Called when the parent AgentServer is cancelled — the sub-agent's work is
+  being abandoned because there is no longer anyone to return results to.
+
+  Broadcasts `{:subagent_status_changed, :cancelled}` and
+  `{:subagent_cancelled, %{final_messages, turn_count}}` on the parent's debug
+  topic BEFORE terminating, so observers (debugger) see the terminal event
+  instead of the sub-agent silently vanishing.
+
+  If the sub-agent is blocked in an LLM call and cannot respond to the
+  pre-cancel broadcast within a short window, it is terminated regardless —
+  the parent cancel must not be delayed.
+
+  Idempotent: returns `:ok` if the sub-agent is already gone.
+  """
+  @spec cancel(String.t()) :: :ok
+  def cancel(sub_agent_id) when is_binary(sub_agent_id) do
+    case whereis(sub_agent_id) do
+      nil ->
+        :ok
+
+      pid ->
+        # Best-effort pre-cancel broadcast. If the sub-agent is stuck in an
+        # LLM call it can't process this message — we still terminate below.
+        try do
+          GenServer.call(pid, :prepare_cancel, 500)
+        catch
+          :exit, _ -> :ok
+        end
+
+        terminate_via_supervisor(pid)
+    end
+  end
+
+  defp terminate_via_supervisor(pid) do
+    parent_agent_id =
+      try do
+        %{parent_agent_id: id} = GenServer.call(pid, :get_subagent, 200)
+        id
+      catch
+        :exit, _ -> nil
+      end
+
+    sup_pid =
+      parent_agent_id &&
+        Sagents.SubAgentsDynamicSupervisor.whereis(parent_agent_id)
+
+    cond do
+      is_pid(sup_pid) ->
+        # terminate_child/2 sends :shutdown and waits for the process to exit.
+        case DynamicSupervisor.terminate_child(sup_pid, pid) do
+          :ok -> :ok
+          {:error, :not_found} -> :ok
+        end
+
+      Process.alive?(pid) ->
+        # Fallback: no supervisor lookup possible (e.g. test harness ran the
+        # sub-agent standalone). Exit the process directly.
+        Process.exit(pid, :shutdown)
+        :ok
+
+      true ->
+        :ok
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
   ## Server Callbacks
 
   @impl true
   def init(opts) do
     subagent = Keyword.fetch!(opts, :subagent)
     started_at = System.monotonic_time(:millisecond)
+
+    # Stash the originating tool_call_id in the process dictionary so the
+    # parent AgentServer can read it via `Process.info(pid, :dictionary)` at
+    # cancel time WITHOUT doing a GenServer.call (which would block if this
+    # process is mid-LLM-call). The value is optional — older callers that
+    # don't pass :tool_call_id simply won't get the terminal tool-status
+    # display update on cancel.
+    case Keyword.get(opts, :tool_call_id) do
+      id when is_binary(id) -> Process.put(:tool_call_id, id)
+      _ -> :ok
+    end
 
     server_state = %ServerState{
       subagent: subagent,
@@ -319,8 +400,9 @@ defmodule Sagents.SubAgentServer do
 
         new_state = %{server_state | subagent: error_subagent}
 
-        # Broadcast error event
-        broadcast_subagent_event(new_state, {:subagent_error, error_subagent.error})
+        # Broadcast structured failure context so the debugger can render
+        # "Last N messages before failure" alongside the error type/message.
+        broadcast_subagent_failure(new_state, error_subagent)
 
         {:reply, {:error, error_subagent.error}, new_state}
     end
@@ -367,8 +449,9 @@ defmodule Sagents.SubAgentServer do
 
         new_state = %{server_state | subagent: error_subagent}
 
-        # Broadcast error event
-        broadcast_subagent_event(new_state, {:subagent_error, error_subagent.error})
+        # Broadcast structured failure context so the debugger can render
+        # the final chain messages alongside the error.
+        broadcast_subagent_failure(new_state, error_subagent)
 
         {:reply, {:error, error_subagent.error}, new_state}
 
@@ -386,6 +469,33 @@ defmodule Sagents.SubAgentServer do
   @impl true
   def handle_call(:get_status, _from, %ServerState{subagent: subagent} = server_state) do
     {:reply, subagent.status, server_state}
+  end
+
+  # Pre-cancel broadcast. Fires the terminal :cancelled events so observers see
+  # the sub-agent's final state before the process dies. May not be reachable
+  # if the sub-agent is currently blocked in an LLM call — in that case the
+  # caller times out and terminates via DynamicSupervisor regardless.
+  @impl true
+  def handle_call(:prepare_cancel, _from, %ServerState{subagent: subagent} = server_state) do
+    cancelled = %{subagent | status: :cancelled}
+    new_state = %{server_state | subagent: cancelled}
+
+    broadcast_subagent_event(new_state, {:subagent_status_changed, :cancelled})
+
+    # Only ship context if we actually have messages. Empty context would
+    # overwrite the debugger's accumulated per-turn view with placeholders.
+    ctx =
+      case cancelled.chain do
+        %{messages: messages} when is_list(messages) and messages != [] ->
+          %{error: nil, final_messages: messages, turn_count: length(messages)}
+
+        _ ->
+          %{}
+      end
+
+    broadcast_subagent_event(new_state, {:subagent_cancelled, ctx})
+
+    {:reply, :ok, new_state}
   end
 
   @impl true
@@ -424,13 +534,39 @@ defmodule Sagents.SubAgentServer do
           "SubAgentServer: #{completed_subagent.id} result extraction error: #{inspect(reason)}"
         )
 
-        new_state = %{server_state | subagent: completed_subagent}
+        # Overlay the extraction error onto the completed subagent so the
+        # failure broadcast carries both the chain's final messages and the
+        # structured error term (e.g., LangChainError{type: "to_string"} when
+        # the final message was length-truncated).
+        failed = %{completed_subagent | status: :error, error: reason}
+        new_state = %{server_state | subagent: failed}
 
-        # Broadcast error event
-        broadcast_subagent_event(new_state, {:subagent_error, reason})
+        broadcast_subagent_failure(new_state, failed)
 
         {:reply, {:error, reason}, new_state}
     end
+  end
+
+  # Broadcast a structured failure event that includes:
+  # - the raw error term (so the debugger can pattern-match on LangChainError)
+  # - the final chain messages (so the debugger can show context)
+  # - a turn_count convenience field
+  # Also emits the legacy :subagent_error event so existing consumers keep working.
+  defp broadcast_subagent_failure(server_state, %SubAgent{} = subagent) do
+    final_messages =
+      case subagent.chain do
+        %{messages: messages} when is_list(messages) -> messages
+        _ -> []
+      end
+
+    context = %{
+      error: subagent.error,
+      final_messages: final_messages,
+      turn_count: length(final_messages)
+    }
+
+    broadcast_subagent_event(server_state, {:subagent_failed_with_context, context})
+    broadcast_subagent_event(server_state, {:subagent_error, subagent.error})
   end
 
   # Build callbacks for LLMChain that broadcast message events to the parent's debug PubSub.

--- a/mix.exs
+++ b/mix.exs
@@ -106,6 +106,7 @@ defmodule Sagents.MixProject do
         ],
         SubAgents: [
           Sagents.SubAgent,
+          Sagents.SubAgent.Task,
           Sagents.SubAgentServer,
           Sagents.SubAgentsDynamicSupervisor
         ],

--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule Sagents.MixProject do
         "compile --warnings-as-errors",
         "deps.unlock --unused",
         "format",
-        "test --include cluster"
+        "test --include cluster --include slow"
       ]
     ]
   end

--- a/priv/templates/agent_live_helpers.ex.eex
+++ b/priv/templates/agent_live_helpers.ex.eex
@@ -351,26 +351,14 @@ defmodule <%= module %> do
   @doc """
   Handles agent status change to :cancelled (user cancelled execution).
 
-  Creates a cancellation message, updates status, clears loading and streaming state.
-
-  Note: Does NOT persist agent state after cancellation because the state may be
-  inconsistent or incomplete after the task was killed.
+  The cancellation message is persisted as a display message by AgentServer and
+  arrives via `{:display_message_saved, ...}`. This handler just updates UI state.
   """
   def handle_status_cancelled(socket) do
-    cancellation_text = "_Agent execution cancelled by user. Partial response discarded._"
-
-    cancellation_message =
-      create_or_persist_message(
-        socket,
-        :assistant,
-        cancellation_text
-      )
-
     socket
     |> assign(:loading, false)
     |> assign(:agent_status, :cancelled)
     |> assign(:streaming_delta, nil)
-    |> stream_insert(:messages, cancellation_message)
   end
 
   @doc """

--- a/priv/templates/display_message_persistence.ex.eex
+++ b/priv/templates/display_message_persistence.ex.eex
@@ -76,6 +76,10 @@ defmodule <%= module %> do
     <%= conversations_module %>.interrupt_tool_call(call_id, %{"display_text" => display_text})
   end
 
+  def update_tool_status(:cancelled, %{call_id: call_id}) do
+    <%= conversations_module %>.cancel_tool_call(call_id)
+  end
+
   @doc """
   Resolves an interrupted tool result display message with the actual result content.
   Called after a sub-agent resumes and completes.

--- a/priv/templates/sagents.gen.persistence/context.ex.eex
+++ b/priv/templates/sagents.gen.persistence/context.ex.eex
@@ -436,6 +436,38 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
+  Updates a tool call message to "cancelled" status.
+
+  Called when a tool execution (typically a sub-agent task) was abandoned because
+  the parent agent was cancelled. Accepts tool calls in "pending", "executing",
+  or "interrupted" status.
+
+  ## Returns
+    - {:ok, %DisplayMessage{}} on success
+    - {:error, :not_found} if no eligible tool call with this call_id exists
+    - {:error, changeset} on validation failure
+  """
+  @spec cancel_tool_call(String.t()) ::
+          {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def cancel_tool_call(call_id) do
+    query =
+      from m in DisplayMessage,
+        where: fragment("?->>'call_id' = ?", m.content, ^call_id),
+        where: m.content_type == "tool_call",
+        where: m.status in ["pending", "executing", "interrupted"]
+
+    case Repo.one(query) do
+      nil ->
+        {:error, :not_found}
+
+      message ->
+        message
+        |> DisplayMessage.changeset(%{"status" => "cancelled"})
+        |> Repo.update()
+    end
+  end
+
+  @doc """
   Records an HITL decision (approved/rejected) on a tool call display message.
 
   Adds `"hitl_decision"` to the tool call's metadata so the UI can display

--- a/priv/templates/sagents.gen.persistence/display_message.ex.eex
+++ b/priv/templates/sagents.gen.persistence/display_message.ex.eex
@@ -100,7 +100,8 @@ defmodule <%= @context_module %>.DisplayMessage do
     field :content_type, :string
     # Message-local ordering (0-based, resets per message)
     field :sequence, :integer, default: 0
-    # Tool execution status: "pending", "executing", "completed", "failed"
+    # Tool execution status: "pending", "executing", "completed", "failed",
+    # "interrupted", "cancelled"
     field :status, :string, default: "completed"
     field :metadata, :map, default: %{}
 
@@ -126,7 +127,14 @@ defmodule <%= @context_module %>.DisplayMessage do
     changeset
     |> validate_required([:conversation_id, :message_type, :content, :content_type])
     |> validate_inclusion(:content_type, @content_types)
-    |> validate_inclusion(:status, ["pending", "executing", "completed", "failed", "interrupted"])
+    |> validate_inclusion(:status, [
+      "pending",
+      "executing",
+      "completed",
+      "failed",
+      "interrupted",
+      "cancelled"
+    ])
     |> validate_number(:sequence, greater_than_or_equal_to: 0)
     |> validate_content_structure()
     |> foreign_key_constraint(:conversation_id)

--- a/test/sagents/agent_cancel_subagent_test.exs
+++ b/test/sagents/agent_cancel_subagent_test.exs
@@ -1,0 +1,184 @@
+defmodule Sagents.AgentCancelSubAgentTest do
+  @moduledoc """
+  Integration test for the main-agent-cancel → sub-agent-cancel contract.
+
+  When the main agent is cancelled, every running SubAgentServer must die too
+  (the parent won't consume the sub-agent's result) AND the debugger must see
+  a terminal :subagent_cancelled event before the sub-agent vanishes.
+
+  Tagged :slow because it mocks a sub-agent that sleeps 5 seconds; the test
+  asserts the sub-agent dies well before that. Without the fix the sub-agent
+  runs to completion and the assertion times out.
+  """
+
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.{Agent, AgentServer, State, SubAgent}
+  alias Sagents.SubAgentsDynamicSupervisor
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.Function
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+
+  setup :set_mimic_global
+  setup :verify_on_exit!
+
+  setup_all do
+    Mimic.copy(ChatAnthropic)
+    :ok
+  end
+
+  defp test_model do
+    ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"})
+  end
+
+  defp make_parent_agent(agent_id, subagent_configs) do
+    Agent.new!(
+      %{
+        agent_id: agent_id,
+        model: test_model(),
+        system_prompt: "You delegate tasks to sub-agents."
+      },
+      subagent_opts: [subagents: subagent_configs]
+    )
+  end
+
+  @tag :slow
+  test "cancelling main agent kills running sub-agent and broadcasts :subagent_cancelled" do
+    agent_id = "parent-cancel-#{System.unique_integer([:positive])}"
+
+    subagent_config =
+      SubAgent.Config.new!(%{
+        name: "slow-researcher",
+        description: "Performs slow research",
+        system_prompt: "You research things slowly.",
+        tools: [
+          Function.new!(%{
+            name: "noop",
+            description: "Placeholder tool; never actually called in this test.",
+            function: fn _args, _ctx -> {:ok, "noop"} end
+          })
+        ]
+      })
+
+    agent = make_parent_agent(agent_id, [subagent_config])
+
+    # Start the SubAgentsDynamicSupervisor that the SubAgent middleware needs.
+    {:ok, _sup} = SubAgentsDynamicSupervisor.start_link(agent_id: agent_id)
+
+    # Subscribe to both the main agent topic (tool events) and the debug topic
+    # (sub-agent events). Tool-call cancel goes out on the main topic; sub-agent
+    # cancel on the debug topic.
+    Phoenix.PubSub.subscribe(:test_pubsub, "agent_server:#{agent_id}")
+    Phoenix.PubSub.subscribe(:test_pubsub, "agent_server:debug:#{agent_id}")
+
+    test_pid = self()
+
+    # Mock LLM: parent's first call returns a task tool call; the sub-agent's
+    # first call sleeps 5s to simulate being stuck mid-LLM-call. If cancel
+    # doesn't kill the sub-agent, the full sleep elapses and the test times out.
+    ChatAnthropic
+    |> stub(:call, fn _model, messages, _tools ->
+      is_subagent_call =
+        Enum.any?(messages, fn
+          %Message{role: :system, content: parts} ->
+            text =
+              parts
+              |> List.wrap()
+              |> Enum.map_join("", fn
+                %{content: c} when is_binary(c) -> c
+                _ -> ""
+              end)
+
+            text =~ "research things slowly"
+
+          _ ->
+            false
+        end)
+
+      cond do
+        is_subagent_call ->
+          send(test_pid, :subagent_llm_started)
+          Process.sleep(5_000)
+          {:ok, [Message.new_assistant!(%{content: "done"})]}
+
+        true ->
+          msg =
+            Message.new_assistant!(%{
+              tool_calls: [
+                ToolCall.new!(%{
+                  call_id: "parent_tc_1",
+                  name: "task",
+                  arguments: %{
+                    "instructions" => "do slow research",
+                    "subagent_type" => "slow-researcher"
+                  }
+                })
+              ]
+            })
+
+          {:ok, [msg]}
+      end
+    end)
+
+    initial_state = State.new!(%{messages: [Message.new_user!("Research")]})
+
+    {:ok, _pid} =
+      AgentServer.start_link(
+        agent: agent,
+        initial_state: initial_state,
+        name: AgentServer.get_name(agent_id),
+        pubsub: {Phoenix.PubSub, :test_pubsub},
+        debug_pubsub: {Phoenix.PubSub, :test_pubsub}
+      )
+
+    assert :ok = AgentServer.execute(agent_id)
+
+    # Wait for the sub-agent's LLM call to actually start. This proves the
+    # sub-agent process is up and blocked inside Process.sleep(5_000).
+    assert_receive :subagent_llm_started, 2_000
+
+    # Find the sub-agent pid by enumerating the per-agent supervisor's children.
+    sup_pid = SubAgentsDynamicSupervisor.whereis(agent_id)
+    assert is_pid(sup_pid)
+
+    [{_, sub_pid, :worker, _}] = DynamicSupervisor.which_children(sup_pid)
+    assert is_pid(sub_pid)
+
+    ref = Process.monitor(sub_pid)
+
+    # Cancel the main agent.
+    assert :ok = AgentServer.cancel(agent_id)
+
+    # Assert 1: sub-agent process actually dies well before the 5s sleep would
+    # have completed naturally.
+    assert_receive {:DOWN, ^ref, :process, ^sub_pid, _reason}, 2_000
+
+    # Assert 2: observability — the terminal :subagent_cancelled event fired.
+    # Context is empty in this test because the sub-agent was blocked in an
+    # LLM call and the parent fallback-broadcasts without state -- the
+    # debugger already has the per-turn messages from its own stream.
+    assert_receive {:agent, {:debug, {:subagent, _sub_id, {:subagent_cancelled, ctx}}}},
+                   1_000
+
+    assert is_map(ctx)
+
+    # Assert 3: no :subagent_completed or :subagent_error fires after cancel.
+    # Drain the mailbox briefly and check nothing terminal-but-successful snuck through.
+    refute_receive {:agent, {:debug, {:subagent, _sub_id, {:subagent_completed, _}}}},
+                   300
+
+    refute_receive {:agent, {:debug, {:subagent, _sub_id, {:subagent_error, _}}}},
+                   0
+
+    # Assert 4: main agent is cancelled.
+    assert AgentServer.get_status(agent_id) == :cancelled
+
+    # Assert 5: the main agent's task tool call received a :cancelled status
+    # update so the chat UI can stop showing a spinner for the abandoned work.
+    assert_receive {:agent,
+                    {:tool_execution_update, :cancelled, %{call_id: "parent_tc_1", name: "task"}}},
+                   1_000
+  end
+end

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -1852,7 +1852,8 @@ defmodule Sagents.Middleware.SubAgentTest do
           parts when is_list(parts) -> Enum.map_join(parts, "", & &1.content)
         end
 
-      assert content_text =~ "SubAgent resume failed"
+      assert content_text =~ "SubAgent '"
+      assert content_text =~ "failed"
     end
   end
 

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -1855,4 +1855,223 @@ defmodule Sagents.Middleware.SubAgentTest do
       assert content_text =~ "SubAgent resume failed"
     end
   end
+
+  describe "boilerplate composition" do
+    test "Config with only instructions -> boilerplate + instructions" do
+      config =
+        SubAgent.Config.new!(%{
+          name: "kb",
+          description: "KB draft",
+          tools: [test_tool()],
+          instructions: "You are drafting a knowledge-base article."
+        })
+
+      prompt = SubAgent.compose_child_system_prompt(config)
+
+      assert prompt =~ "no user"
+      assert prompt =~ "You are drafting a knowledge-base article."
+    end
+
+    test "Config with only system_prompt (legacy) -> boilerplate + system_prompt" do
+      config =
+        SubAgent.Config.new!(%{
+          name: "legacy",
+          description: "Legacy",
+          tools: [test_tool()],
+          system_prompt: "Legacy prompt body"
+        })
+
+      prompt = SubAgent.compose_child_system_prompt(config)
+
+      assert prompt =~ "bounded task"
+      assert prompt =~ "Legacy prompt body"
+    end
+
+    test "system_prompt_override replaces boilerplate, instructions still appended" do
+      config =
+        SubAgent.Config.new!(%{
+          name: "overridden",
+          description: "Overridden",
+          tools: [test_tool()],
+          system_prompt_override: "Custom header only",
+          instructions: "Body content"
+        })
+
+      prompt = SubAgent.compose_child_system_prompt(config)
+
+      refute prompt =~ "bounded task"
+      assert prompt =~ "Custom header only"
+      assert prompt =~ "Body content"
+    end
+
+    test "boilerplate mentions the no-user framing so regressions are caught" do
+      boilerplate = SubAgent.task_subagent_boilerplate()
+      assert boilerplate =~ "no user"
+    end
+  end
+
+  describe "get_task_instructions tool" do
+    test "is absent when no subagent defines use_instructions" do
+      config =
+        SubAgent.Config.new!(%{
+          name: "plain",
+          description: "Plain",
+          tools: [test_tool()],
+          system_prompt: "plain prompt"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [config]
+        )
+
+      tool_names = SubAgentMiddleware.tools(middleware_config) |> Enum.map(& &1.name)
+      assert "task" in tool_names
+      refute "get_task_instructions" in tool_names
+    end
+
+    test "is present when at least one subagent defines use_instructions" do
+      cfg =
+        SubAgent.Config.new!(%{
+          name: "kb",
+          description: "KB draft",
+          tools: [test_tool()],
+          instructions: "draft",
+          use_instructions: "How to use kb"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [cfg]
+        )
+
+      tools = SubAgentMiddleware.tools(middleware_config)
+      assert Enum.any?(tools, &(&1.name == "get_task_instructions"))
+
+      getter = Enum.find(tools, &(&1.name == "get_task_instructions"))
+      assert getter.async == true
+      assert getter.parameters_schema.properties["subagent_type"].enum == ["kb"]
+    end
+
+    test "returns the use_instructions string for a known subagent" do
+      cfg =
+        SubAgent.Config.new!(%{
+          name: "kb",
+          description: "KB draft",
+          tools: [test_tool()],
+          instructions: "draft",
+          use_instructions: "Full KB usage guide"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [cfg]
+        )
+
+      getter =
+        SubAgentMiddleware.tools(middleware_config)
+        |> Enum.find(&(&1.name == "get_task_instructions"))
+
+      assert {:ok, "Full KB usage guide"} =
+               getter.function.(%{"subagent_type" => "kb"}, %{})
+    end
+  end
+
+  describe "task description hint" do
+    test "adds get_task_instructions hint for subagents with use_instructions" do
+      cfg =
+        SubAgent.Config.new!(%{
+          name: "kb",
+          description: "KB draft.",
+          tools: [test_tool()],
+          instructions: "draft",
+          use_instructions: "How to use kb"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [cfg]
+        )
+
+      [task_tool | _] = SubAgentMiddleware.tools(middleware_config)
+      assert task_tool.description =~ "get_task_instructions(\"kb\")"
+    end
+
+    test "omits hint for subagents without use_instructions" do
+      cfg =
+        SubAgent.Config.new!(%{
+          name: "plain",
+          description: "Plain desc.",
+          tools: [test_tool()],
+          system_prompt: "plain"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [cfg]
+        )
+
+      [task_tool | _] = SubAgentMiddleware.tools(middleware_config)
+      refute task_tool.description =~ "get_task_instructions"
+    end
+  end
+
+  describe "display_text callback" do
+    test "callbacks/1 returns empty map when no display_text is configured" do
+      cfg =
+        SubAgent.Config.new!(%{
+          name: "plain",
+          description: "Plain",
+          tools: [test_tool()],
+          system_prompt: "x"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [cfg]
+        )
+
+      assert SubAgentMiddleware.callbacks(middleware_config) == %{}
+    end
+
+    test "callbacks/1 registers on_tool_call_identified when display_text is set" do
+      cfg =
+        SubAgent.Config.new!(%{
+          name: "kb",
+          description: "KB",
+          tools: [test_tool()],
+          instructions: "x",
+          display_text: "Drafting KB article"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [cfg]
+        )
+
+      cbs = SubAgentMiddleware.callbacks(middleware_config)
+      assert is_function(cbs.on_tool_call_identified, 3)
+    end
+  end
 end

--- a/test/sagents/sub_agent_test.exs
+++ b/test/sagents/sub_agent_test.exs
@@ -99,7 +99,7 @@ defmodule Sagents.SubAgentTest do
       assert %{description: ["can't be blank"]} = errors_on(changeset)
     end
 
-    test "requires system_prompt field" do
+    test "requires at least one prompt source (system_prompt, instructions, or override)" do
       attrs = %{
         name: "test",
         description: "Test",
@@ -107,7 +107,41 @@ defmodule Sagents.SubAgentTest do
       }
 
       assert {:error, changeset} = SubAgentConfig.new(attrs)
-      assert %{system_prompt: ["can't be blank"]} = errors_on(changeset)
+      errors = errors_on(changeset)
+
+      assert errors[:system_prompt] == [
+               "at least one of :system_prompt, :instructions, or :system_prompt_override must be set"
+             ]
+    end
+
+    test "accepts instructions alone (no system_prompt)" do
+      attrs = %{
+        name: "test",
+        description: "Test",
+        tools: [test_tool()],
+        instructions: "Do the thing."
+      }
+
+      assert {:ok, config} = SubAgentConfig.new(attrs)
+      assert config.instructions == "Do the thing."
+      assert config.system_prompt == nil
+    end
+
+    test "accepts use_instructions, display_text, and system_prompt_override" do
+      attrs = %{
+        name: "test",
+        description: "Test",
+        tools: [test_tool()],
+        instructions: "Work body",
+        use_instructions: "How to use me",
+        display_text: "Running the thing",
+        system_prompt_override: "Custom header"
+      }
+
+      assert {:ok, config} = SubAgentConfig.new(attrs)
+      assert config.use_instructions == "How to use me"
+      assert config.display_text == "Running the thing"
+      assert config.system_prompt_override == "Custom header"
     end
 
     test "requires tools field" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -25,6 +25,6 @@ end
 {:ok, _} = Supervisor.start_link([Sagents.TestPresence], strategy: :one_for_one)
 
 Logger.configure(level: :warning)
-ExUnit.configure(exclude: [live_call: true, cluster: true])
+ExUnit.configure(exclude: [live_call: true, cluster: true, slow: true])
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
## Problem

Three related gaps in the sub-agent system were causing friction:

1. **Sub-agent configuration was awkward for reusable "skills."** The only way to frame a sub-agent was via a free-form `system_prompt`, which mixed universal boilerplate (no user, complete-or-fail) with task-specific detail and left no clean place to describe *how* the parent should invoke it. There was also no way to override the default boilerplate or to provide lazy-loaded usage docs.
2. **Cancelling the main agent left sub-agents orphaned.** A cancelled main agent would brutal-kill its own Task, but any in-flight `SubAgentServer` processes kept running (wasting tokens and time), the debugger never saw a terminal event, the chat UI kept spinning on the abandoned `task` tool call, and the rolling state was discarded on the premise that it was "inconsistent" — so page reload lost partial progress.
3. **GitHub Actions were version-tagged, not SHA-pinned** — flagged by `zizmor` as a supply-chain risk — and there was no dependabot coverage for actions.

## Solution

### Task-style sub-agent interface

Added four optional fields to [`SubAgent.Config`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent.ex#L719-L735): `instructions`, `system_prompt_override`, `use_instructions`, `display_text`. A new `compose_child_system_prompt/1` composes the child agent's base system prompt from (header = `system_prompt_override` or built-in boilerplate) + (body = `instructions` or legacy `system_prompt`). The boilerplate lives in [`task_subagent_boilerplate/0`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent.ex#L1090-L1100) and encodes the "no user, complete-or-fail, no clarifying questions" framing universally, so authors can focus on task specifics.

New behaviour at [`lib/sagents/sub_agent/task.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent/task.ex) formalises what a "task module" looks like — `task_name/0`, `description/0`, `instructions/0`, plus optional `use_instructions/0`, `display_text/0`, `model_override/0`. Host applications compile task modules into `SubAgent.Compiled` entries.

The [SubAgent middleware](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/middleware/sub_agent.ex) picks up two new capabilities:
- When any configured sub-agent has `use_instructions`, a second tool `get_task_instructions(subagent_type)` is exposed. Its description and the `task` tool's description both gain a hint telling the parent LLM to fetch the full usage guide before invoking. Lazy-loading keeps the parent's context window light.
- When any sub-agent has `display_text`, the middleware registers an `on_tool_call_identified` callback that re-fires the tool-call event with an overridden `display_text` once the `subagent_type` is known — so the UI shows "Drafting KB article" instead of the generic "Running task".

### Main-agent cancellation that actually unwinds

[`AgentServer.handle_call(:cancel)`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/agent_server.ex#L1500-L1540) now does a proper teardown:

1. **Kill sub-agents first.** The main Task may be blocked in a synchronous `GenServer.call` to a `SubAgentServer`; without killing sub-agents first, `Task.shutdown` wastes its full grace period waiting on a call that can never return.
2. **Two-phase Task shutdown** — 2s graceful, then brutal-kill — so callback-emitted turns have a chance to flush.
3. **Drain pending turn casts** from the mailbox so the rolling state captures every completed turn.
4. **Persist rolling state** via the new `:on_cancel` persistence context, so page reload recovers partial progress.
5. **Persist the cancellation display message** from AgentServer (single authoritative writer) instead of the LiveView — avoids duplicate rows when multiple tabs are subscribed.

Sub-agent cancellation uses a **best-effort-rich / guaranteed-minimal** broadcast pattern. [`SubAgentServer.handle_call(:prepare_cancel)`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent_server.ex#L474-L497) broadcasts terminal `:subagent_status_changed` + `:subagent_cancelled` events with `final_messages` and `turn_count` when reachable. If it's blocked mid-LLM-call and can't respond within 300ms, [`cancel_subagent_child`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/agent_server.ex#L2471-L2506) in the parent broadcasts a minimal fallback so observability is preserved either way.

New `execution_seq` counter on `ServerState` guards the rolling-state `handle_cast`, rejecting late messages from a cancelled or superseded run.

Failure broadcasts also carry more structure now — [`broadcast_subagent_failure/2`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent_server.ex#L563-L576) ships `{error, final_messages, turn_count}` so the debugger can render "Last N messages before failure" alongside the error term, and `format_subagent_error/2` preserves `LangChainError` type/message distinctions when surfacing errors to the parent LLM.

### CI & supply-chain

Pinned every action in [`.github/workflows/elixir.yml`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/.github/workflows/elixir.yml) to a full commit SHA with a trailing version comment (`checkout`, `setup-beam`, `cache`), added `persist-credentials: false` to checkout, and created [`.github/dependabot.yml`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/.github/dependabot.yml) to update actions weekly with a 7-day cooldown. Matches zizmor's unpinned-action and credential-persistence recommendations.

## Changes

**Core sub-agent interface**
- [`lib/sagents/sub_agent.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent.ex) — Added `instructions`, `system_prompt_override`, `use_instructions`, `display_text` to `Config` and `Compiled`. Added `compose_child_system_prompt/1`, `task_subagent_boilerplate/0`, `validate_prompt_source/1`.
- [`lib/sagents/sub_agent/task.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent/task.ex) — New behaviour defining the task-module contract.
- [`lib/sagents/middleware/sub_agent.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/middleware/sub_agent.ex) — Built `display_texts_map` and `use_instructions_map` in `init/1`. Added `get_task_instructions` tool, conditional system-prompt hint, `callbacks/1` returning `on_tool_call_identified`, and `format_subagent_error/2` preserving `LangChainError` structure.

**Cancellation & persistence**
- [`lib/sagents/agent_server.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/agent_server.ex) — `execution_seq` counter on `ServerState`; two-phase cancel with `cancel_all_subagents/1`, `cancel_subagent_child/3`, `broadcast_fallback_subagent_cancel/2`; `drain_turn_casts/1`; `:turn_state_update` cast for rolling state; `persist_cancel_as_display_message/1`; `safe_cast/2`.
- [`lib/sagents/sub_agent_server.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/sub_agent_server.ex) — `cancel/1` API, `:prepare_cancel` handler, `broadcast_subagent_failure/2` with `final_messages`/`turn_count`, `terminate_via_supervisor/1`, `tool_call_id` stashed in the process dictionary at `init/1`.
- [`lib/sagents/agent_persistence.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/agent_persistence.ex) — New `:on_cancel` persistence context documented and added to `@type context`.
- [`lib/sagents/display_message_persistence.ex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/lib/sagents/display_message_persistence.ex) — New `:cancelled` tool-status variant.

**Generator templates**
- [`priv/templates/agent_live_helpers.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/priv/templates/agent_live_helpers.ex.eex) — `handle_status_cancelled/1` no longer inserts the cancellation message itself (AgentServer persists it and the LiveView receives `:display_message_saved`).
- [`priv/templates/display_message_persistence.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/priv/templates/display_message_persistence.ex.eex) — Added `update_tool_status(:cancelled, ...)` clause.
- [`priv/templates/sagents.gen.persistence/context.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/priv/templates/sagents.gen.persistence/context.ex.eex) — New `cancel_tool_call/1` context function.
- [`priv/templates/sagents.gen.persistence/display_message.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/priv/templates/sagents.gen.persistence/display_message.ex.eex) — Schema support for the `:cancelled` status.

**Tests**
- [`test/sagents/agent_cancel_subagent_test.exs`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/test/sagents/agent_cancel_subagent_test.exs) — New `:slow`-tagged integration test mocking a 5s-blocked sub-agent LLM call and asserting the sub-agent dies within 2s of `cancel`, the `:subagent_cancelled` event fires on the debug topic, the `task` tool-call gets a `:cancelled` update, and the main agent ends in `:cancelled`.
- [`test/sagents/middleware/sub_agent_test.exs`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/test/sagents/middleware/sub_agent_test.exs) — Added coverage for boilerplate composition, `get_task_instructions` presence/absence, task-description hint wording, and the `display_text` callback.
- [`test/sagents/sub_agent_test.exs`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/test/sagents/sub_agent_test.exs) — Updated the "requires system_prompt" test to the new "requires at least one prompt source" rule; new tests for `instructions` alone and for `use_instructions`/`display_text`/`system_prompt_override`.
- [`test/test_helper.exs`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/test/test_helper.exs) — `:slow` excluded by default.
- [`mix.exs`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/mix.exs) — `mix precommit` runs `test --include cluster --include slow`. `Sagents.SubAgent.Task` added to the `SubAgents` doc group.

**CI / supply-chain**
- [`.github/workflows/elixir.yml`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/.github/workflows/elixir.yml) — SHA-pinned `actions/checkout@v5.0.1`, `erlef/setup-beam@v1.24.0`, `actions/cache@v4.3.0`; added `persist-credentials: false` to checkout.
- [`.github/dependabot.yml`](https://github.com/sagents-ai/sagents/blob/me-sub-agent-tasks/.github/dependabot.yml) — New file; weekly GitHub Actions updates with a 7-day cooldown.

## Testing

- `mix precommit` locally (compile with `--warnings-as-errors`, `deps.unlock --unused`, `format`, `test --include cluster --include slow`).
- New integration test exercises the real cancel path end-to-end: mocked `ChatAnthropic.call` with a 5s sleep in the sub-agent, `Process.monitor` on the sub-agent pid, assertions on both the main-topic and debug-topic broadcasts. Tagged `:slow` so default CI runs stay fast.
- Unit coverage across prompt composition, validation rules, tool presence/shape, and the display-text callback registration.
- Generator templates are exercised indirectly through the `agents_demo` app; no regression test for the EEx files themselves.