### PR TITLE
Use state returned from middleware on_server_start

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -1398,20 +1398,27 @@ defmodule Sagents.AgentServer do
 
   @impl true
   def handle_continue(:broadcast_initial_state, server_state) do
-    # Call on_server_start for each middleware
-    # This allows middleware to broadcast initial state, set up subscriptions, etc.
-    # E.g., TodoList middleware broadcasts initial todos for UI sync
-    Enum.each(server_state.agent.middleware, fn entry ->
-      case Middleware.apply_on_server_start(server_state.state, entry) do
-        {:ok, _state} ->
-          :ok
+    # Call on_server_start for each middleware, threading the returned state
+    # through subsequent middleware and persisting it on the server.
+    # This allows middleware to broadcast initial state, set up subscriptions,
+    # and also seed state (e.g., TodoList broadcasts initial todos, other
+    # middleware may populate metadata for the first before_model call).
+    updated_state =
+      Enum.reduce(server_state.agent.middleware, server_state.state, fn entry, state_acc ->
+        case Middleware.apply_on_server_start(state_acc, entry) do
+          {:ok, new_state} ->
+            new_state
 
-        {:error, reason} ->
-          Logger.error(
-            "Middleware #{inspect(entry.module)} on_server_start failed: #{inspect(reason)}"
-          )
-      end
-    end)
+          {:error, reason} ->
+            Logger.error(
+              "Middleware #{inspect(entry.module)} on_server_start failed: #{inspect(reason)}"
+            )
+
+            state_acc
+        end
+      end)
+
+    server_state = %{server_state | state: updated_state}
 
     # If this server was restored from persisted state (e.g., Horde migration),
     # broadcast a node_transferred event so observers know it landed here

--- a/test/sagents/agent_server_test.exs
+++ b/test/sagents/agent_server_test.exs
@@ -119,6 +119,87 @@ defmodule Sagents.AgentServerTest do
       # Agent should still be running despite middleware failure
       assert AgentServer.get_status(agent_id) == :idle
     end
+
+    test "state returned from on_server_start is used in subsequent agent state" do
+      # Middleware that mutates state in on_server_start by setting metadata.
+      # The AgentServer must persist this returned state so later reads see it.
+      defmodule StateMutatingStartMiddleware do
+        @behaviour Sagents.Middleware
+
+        @impl true
+        def init(_opts), do: {:ok, %{}}
+
+        @impl true
+        def on_server_start(state, _config) do
+          {:ok, State.put_metadata(state, "server_started", true)}
+        end
+      end
+
+      agent = create_test_agent(middleware: [StateMutatingStartMiddleware])
+      agent_id = agent.agent_id
+
+      {:ok, _pid} =
+        AgentServer.start_link(
+          agent: agent,
+          name: AgentServer.get_name(agent_id),
+          pubsub: nil
+        )
+
+      # get_state/1 is a GenServer.call, which also synchronizes with the
+      # preceding handle_continue that runs on_server_start callbacks.
+      state = AgentServer.get_state(agent_id)
+
+      assert State.get_metadata(state, "server_started") == true
+    end
+
+    test "state mutations from multiple middleware on_server_start accumulate" do
+      # Two middleware modules that both mutate state in on_server_start.
+      # Each must see the previous middleware's changes and its own change must
+      # be preserved in the final AgentServer state.
+      defmodule FirstStartMiddleware do
+        @behaviour Sagents.Middleware
+
+        @impl true
+        def init(_opts), do: {:ok, %{}}
+
+        @impl true
+        def on_server_start(state, _config) do
+          {:ok, State.put_metadata(state, "first", "one")}
+        end
+      end
+
+      defmodule SecondStartMiddleware do
+        @behaviour Sagents.Middleware
+
+        @impl true
+        def init(_opts), do: {:ok, %{}}
+
+        @impl true
+        def on_server_start(state, _config) do
+          assert State.get_metadata(state, "first") == "one",
+                 "second middleware should observe state from first middleware"
+
+          {:ok, State.put_metadata(state, "second", "two")}
+        end
+      end
+
+      agent =
+        create_test_agent(middleware: [FirstStartMiddleware, SecondStartMiddleware])
+
+      agent_id = agent.agent_id
+
+      {:ok, _pid} =
+        AgentServer.start_link(
+          agent: agent,
+          name: AgentServer.get_name(agent_id),
+          pubsub: nil
+        )
+
+      state = AgentServer.get_state(agent_id)
+
+      assert State.get_metadata(state, "first") == "one"
+      assert State.get_metadata(state, "second") == "two"
+    end
   end
 
   describe "get_state/1" do


### PR DESCRIPTION
The on_server_start/2 middleware callback documents that it can return an updated state, but AgentServer was discarding that state. The state was also re-fetched fresh for each middleware in the chain, so middleware couldn't observe each other's changes either.

This changes handle_continue(:broadcast_initial_state, ...) to thread the state through middleware with Enum.reduce and assign the accumulated result back onto server_state before the rest of startup runs (presence tracking, status broadcast, etc.).

Made with [Cursor](https://cursor.com)