### PR TITLE
Fix generated load_display_messages truncating long conversations

### DIFF
--- a/priv/templates/sagents.gen.persistence/context.ex.eex
+++ b/priv/templates/sagents.gen.persistence/context.ex.eex
@@ -223,23 +223,25 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Loads all display messages for a conversation.
+  Loads display messages for a conversation, ordered chronologically.
 
   ## Options
 
-    * `:limit` - Maximum number of messages to return (default: 100)
-    * `:offset` - Number of messages to skip (default: 0)
+    * `:limit` - Maximum number of messages to return (default: all)
   """
   def load_display_messages(conversation_id, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 100)
-    offset = Keyword.get(opts, :offset, 0)
+    query =
+      DisplayMessage
+      |> where([m], m.conversation_id == ^conversation_id)
+      |> order_by([m], [asc: m.inserted_at, asc: m.sequence])
 
-    DisplayMessage
-    |> where([m], m.conversation_id == ^conversation_id)
-    |> order_by([m], asc: m.inserted_at, asc: m.sequence)
-    |> limit(^limit)
-    |> offset(^offset)
-    |> Repo.all()
+    query =
+      case Keyword.get(opts, :limit) do
+        nil -> query
+        limit -> limit(query, ^limit)
+      end
+
+    Repo.all(query)
   end
 
   #


### PR DESCRIPTION
## Problem

The generated `load_display_messages/2` function in the persistence context template defaulted to `limit: 100`. Conversations with more than 100 display messages silently dropped newer messages, so they never appeared in the UI.

## Solution

Remove the hardcoded default limit so all messages are returned by default. The `:limit` option is still available for callers that want pagination, but defaults to returning everything. The unused `:offset` option is also removed.

## Changes

- `priv/templates/sagents.gen.persistence/context.ex.eex` -- Changed `load_display_messages/2` to return all messages by default instead of capping at 100. Removed `:offset` option. Built the query conditionally so `:limit` is only applied when explicitly passed.

## Testing

Verified the template renders correct Elixir code. The fix addresses a production issue observed in the agents_demo app where longer conversations stopped displaying new messages.