### PR TITLE
Add configurable max_runs to Agent and SubAgent

### DIFF
--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -73,6 +73,10 @@ defmodule Sagents.Agent do
     # LangChain.Chains.LLMChain.Mode behaviour. Defaults to
     # Sagents.Modes.AgentExecution when nil.
     field :mode, :any, virtual: true
+    # Maximum number of LLM calls per execution. Overrides the mode's default
+    # (50 for AgentExecution). Can also be overridden per-invocation via
+    # Agent.execute/3 opts.
+    field :max_runs, :integer, virtual: true
   end
 
   @type t :: %Agent{}
@@ -90,7 +94,8 @@ defmodule Sagents.Agent do
     :async_tool_timeout,
     :fallback_models,
     :before_fallback,
-    :mode
+    :mode,
+    :max_runs
   ]
   @required_fields [:agent_id, :model]
 
@@ -117,6 +122,9 @@ defmodule Sagents.Agent do
   - `:before_fallback` - Optional function to modify chain before each attempt (default: nil).
     Signature: `fn chain -> modified_chain end`.
     Useful for provider-specific system prompts or modifications
+  - `:max_runs` - Maximum number of LLM calls per execution (default: 50 for AgentExecution mode).
+    Agents with many tools or complex middleware may need higher values. Can also be overridden
+    per-invocation via `Agent.execute/3` opts: `Agent.execute(agent, state, max_runs: 100)`.
 
   ## Options
 
@@ -849,6 +857,7 @@ defmodule Sagents.Agent do
       |> Keyword.put(:mode, agent.mode || Sagents.Modes.AgentExecution)
       |> Keyword.put(:middleware, middleware)
       |> maybe_put_until_tool(opts)
+      |> maybe_put_max_runs(agent, opts)
 
     if is_raw_langchain_mode?(agent.mode) do
       Logger.warning(
@@ -871,6 +880,18 @@ defmodule Sagents.Agent do
       {:pause, chain} ->
         {:pause, chain}
 
+      {:error, _chain, %LangChainError{type: "exceeded_max_runs"} = reason} ->
+        Logger.warning(
+          "Agent #{agent.agent_id} exceeded max_runs limit (#{reason.message}). " <>
+            "Set :max_runs on the Agent struct or pass max_runs: N to Agent.execute/3 opts."
+        )
+
+        {:error,
+         %LangChainError{
+           reason
+           | message: "Max number of automated turns reached. You may continue if desired."
+         }}
+
       {:error, _chain, %LangChainError{} = reason} ->
         {:error, reason}
 
@@ -883,6 +904,13 @@ defmodule Sagents.Agent do
     case Keyword.get(opts, :until_tool) do
       nil -> mode_opts
       until_tool -> Keyword.put(mode_opts, :until_tool, until_tool)
+    end
+  end
+
+  defp maybe_put_max_runs(mode_opts, agent, opts) do
+    case Keyword.get(opts, :max_runs) || agent.max_runs do
+      nil -> mode_opts
+      max_runs -> Keyword.put(mode_opts, :max_runs, max_runs)
     end
   end
 

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -134,6 +134,10 @@ defmodule Sagents.SubAgent do
     # Until-tool termination: tool name (string) or list of tool names
     field :until_tool, :any, virtual: true
 
+    # Maximum number of LLM calls per execution. Overrides the mode's default
+    # (50 for AgentExecution). See Agent :max_runs for details.
+    field :max_runs, :integer, virtual: true
+
     # Metadata
     field :id, :string
     field :parent_agent_id, :string
@@ -260,6 +264,7 @@ defmodule Sagents.SubAgent do
     parent_tool_context = Keyword.get(opts, :parent_tool_context, %{})
     parent_metadata = Keyword.get(opts, :parent_metadata, %{})
     until_tool = Keyword.get(opts, :until_tool)
+    max_runs = Keyword.get(opts, :max_runs)
 
     sub_agent_id = "#{parent_agent_id}-sub-#{:erlang.unique_integer([:positive])}"
 
@@ -294,6 +299,7 @@ defmodule Sagents.SubAgent do
       chain: chain,
       interrupt_on: interrupt_on,
       until_tool: until_tool,
+      max_runs: max_runs,
       status: :idle,
       created_at: DateTime.utc_now()
     }
@@ -657,7 +663,11 @@ defmodule Sagents.SubAgent do
   end
 
   @doc false
-  def build_mode_opts(%SubAgent{interrupt_on: interrupt_on, until_tool: until_tool}) do
+  def build_mode_opts(%SubAgent{
+        interrupt_on: interrupt_on,
+        until_tool: until_tool,
+        max_runs: max_runs
+      }) do
     opts = [mode: Sagents.Modes.AgentExecution]
 
     opts =
@@ -683,6 +693,12 @@ defmodule Sagents.SubAgent do
       case until_tool do
         nil -> opts
         ut -> Keyword.put(opts, :until_tool, ut)
+      end
+
+    opts =
+      case max_runs do
+        nil -> opts
+        mr -> Keyword.put(opts, :max_runs, mr)
       end
 
     opts
@@ -728,6 +744,7 @@ defmodule Sagents.SubAgent do
       field :middleware, {:array, :any}, default: [], virtual: true
       field :interrupt_on, :map
       field :until_tool, :any, virtual: true
+      field :max_runs, :integer, virtual: true
     end
 
     @type t :: %Config{
@@ -742,7 +759,8 @@ defmodule Sagents.SubAgent do
             model: term() | nil,
             middleware: list(),
             interrupt_on: map() | nil,
-            until_tool: String.t() | [String.t()] | nil
+            until_tool: String.t() | [String.t()] | nil,
+            max_runs: integer() | nil
           }
 
     def new(attrs) do
@@ -759,7 +777,8 @@ defmodule Sagents.SubAgent do
         :model,
         :middleware,
         :interrupt_on,
-        :until_tool
+        :until_tool,
+        :max_runs
       ])
       |> validate_required([:name, :description, :tools])
       |> validate_length(:name, min: 1, max: 100)

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -304,6 +304,16 @@ defmodule Sagents.AgentTest do
         )
       end
     end
+
+    test "creates agent with max_runs" do
+      {:ok, agent} = Agent.new(%{model: mock_model(), max_runs: 100})
+      assert agent.max_runs == 100
+    end
+
+    test "max_runs defaults to nil" do
+      {:ok, agent} = Agent.new(%{model: mock_model()})
+      assert agent.max_runs == nil
+    end
   end
 
   describe "execute/2" do
@@ -420,6 +430,136 @@ defmodule Sagents.AgentTest do
       assert %State{} = paused_state
       # Original message preserved, no assistant response added (paused before completion)
       assert [%{role: :user}] = paused_state.messages
+    end
+
+    test "forwards max_runs from agent struct to mode" do
+      # Agent with max_runs: 1 should error after a single LLM call that triggers tool use
+      tool =
+        LangChain.Function.new!(%{
+          name: "test_tool",
+          description: "A test tool",
+          function: fn _args, _context -> {:ok, "done"} end
+        })
+
+      # LLM always requests tool call, forcing a loop
+      stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           Message.new_assistant!(%{
+             tool_calls: [
+               ToolCall.new!(%{
+                 call_id: "call_#{:erlang.unique_integer([:positive])}",
+                 name: "test_tool",
+                 arguments: %{}
+               })
+             ]
+           })
+         ]}
+      end)
+
+      {:ok, agent} =
+        Agent.new(
+          %{
+            model: mock_model(),
+            tools: [tool],
+            max_runs: 1
+          },
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      assert {:error, %LangChainError{type: "exceeded_max_runs"}} =
+               Agent.execute(agent, initial_state)
+    end
+
+    test "max_runs in execute opts overrides agent struct" do
+      # Agent struct has max_runs: 100 but execute opts set max_runs: 1
+      tool =
+        LangChain.Function.new!(%{
+          name: "test_tool",
+          description: "A test tool",
+          function: fn _args, _context -> {:ok, "done"} end
+        })
+
+      stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           Message.new_assistant!(%{
+             tool_calls: [
+               ToolCall.new!(%{
+                 call_id: "call_#{:erlang.unique_integer([:positive])}",
+                 name: "test_tool",
+                 arguments: %{}
+               })
+             ]
+           })
+         ]}
+      end)
+
+      {:ok, agent} =
+        Agent.new(
+          %{
+            model: mock_model(),
+            tools: [tool],
+            max_runs: 100
+          },
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      # Override with a low limit via execute opts
+      assert {:error, %LangChainError{type: "exceeded_max_runs"}} =
+               Agent.execute(agent, initial_state, max_runs: 1)
+    end
+
+    test "max_runs exceeded logs warning and returns user-friendly message" do
+      tool =
+        LangChain.Function.new!(%{
+          name: "test_tool",
+          description: "A test tool",
+          function: fn _args, _context -> {:ok, "done"} end
+        })
+
+      stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:ok,
+         [
+           Message.new_assistant!(%{
+             tool_calls: [
+               ToolCall.new!(%{
+                 call_id: "call_#{:erlang.unique_integer([:positive])}",
+                 name: "test_tool",
+                 arguments: %{}
+               })
+             ]
+           })
+         ]}
+      end)
+
+      {:ok, agent} =
+        Agent.new(
+          %{
+            model: mock_model(),
+            tools: [tool],
+            max_runs: 1
+          },
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      log =
+        capture_log(fn ->
+          assert {:error, %LangChainError{type: "exceeded_max_runs"} = error} =
+                   Agent.execute(agent, initial_state)
+
+          assert error.message ==
+                   "Max number of automated turns reached. You may continue if desired."
+        end)
+
+      assert log =~ "exceeded max_runs limit"
+      assert log =~ "Set :max_runs on the Agent struct"
     end
   end
 

--- a/test/sagents/modes/agent_execution_test.exs
+++ b/test/sagents/modes/agent_execution_test.exs
@@ -259,7 +259,7 @@ defmodule Sagents.Modes.AgentExecutionTest do
       result = AgentExecution.run(chain, until_tool: "submit_report", max_runs: 3)
 
       assert {:error, %LLMChain{}, %LangChainError{type: "exceeded_max_runs"} = error} = result
-      assert error.message =~ "Exceeded maximum number of runs"
+      assert error.message =~ "Exceeded maximum number of runs (3/3)"
     end
   end
 

--- a/test/sagents/sub_agent_test.exs
+++ b/test/sagents/sub_agent_test.exs
@@ -1650,6 +1650,39 @@ defmodule Sagents.SubAgentTest do
 
       refute Keyword.has_key?(opts, :middleware)
     end
+
+    test "returns opts with max_runs when set" do
+      agent_config = test_agent()
+
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "test-parent",
+          instructions: "Do something",
+          agent_config: agent_config,
+          parent_state: %{messages: []},
+          max_runs: 100
+        )
+
+      opts = SubAgent.build_mode_opts(subagent)
+
+      assert Keyword.get(opts, :max_runs) == 100
+    end
+
+    test "does not include max_runs when not set" do
+      agent_config = test_agent()
+
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "test-parent",
+          instructions: "Do something",
+          agent_config: agent_config,
+          parent_state: %{messages: []}
+        )
+
+      opts = SubAgent.build_mode_opts(subagent)
+
+      refute Keyword.has_key?(opts, :max_runs)
+    end
   end
 
   # Helper function to extract errors from changeset


### PR DESCRIPTION
## Problem

The `max_runs` limit (maximum LLM calls per execution) is hardcoded at 50 in `AgentExecution` mode. Agents with many tools and complex middleware (e.g., TodoList, FileSystem, SubAgent) routinely need more than 50 round-trips, but there is no way for library consumers to configure this limit. When hit, the error message gives no guidance on how to fix it.

Companion PR in LangChain: https://github.com/brainlid/langchain/pull/519

## Solution

Add `:max_runs` as a configurable field on both `Agent` and `SubAgent`, with three levels of precedence:

1. **Per-invocation** -- `Agent.execute(agent, state, max_runs: 200)` (highest priority)
2. **Per-agent** -- `Agent.new(%{max_runs: 100})` (default for all executions of this agent)
3. **Mode default** -- `AgentExecution`'s `Keyword.put_new(opts, :max_runs, 50)` (unchanged fallback)

When the limit is hit, `execute_chain/4` intercepts the `exceeded_max_runs` error, logs a `Logger.warning` with developer-facing instructions ("Set :max_runs on the Agent struct or pass max_runs: N to Agent.execute/3 opts"), and replaces the error message with a user-friendly one suitable for UI display: "Max number of automated turns reached. You may continue if desired."

## Changes

- `lib/sagents/agent.ex` -- Added `:max_runs` field to struct, `@create_fields`, and `@doc`; added `maybe_put_max_runs/3` to forward the value through `execute_chain/4`; added `exceeded_max_runs` intercept clause with Logger.warning and user-friendly message replacement
- `lib/sagents/sub_agent.ex` -- Added `:max_runs` field to `SubAgent`, `SubAgent.Config`, and `build_mode_opts/1`; forward through `build_subagent/3`
- `test/sagents/agent_test.exs` -- Tests for `Agent.new` with `:max_runs`, struct-level forwarding, opts-level override, and Logger.warning + user-friendly message verification
- `test/sagents/sub_agent_test.exs` -- Tests for `build_mode_opts/1` with and without `:max_runs`
- `test/sagents/modes/agent_execution_test.exs` -- Updated assertion to match new LangChain error message format (includes count/limit)

## Testing

All 1225 tests pass (1 skipped, 2 excluded). Tested struct-level config, per-invocation override, default fallback behavior, Logger.warning output, and user-facing error message content.