### PR TITLE
Fix FileSystemServer crash on linked port exit (trap_exit)

### DIFF
--- a/lib/sagents/file_system_server.ex
+++ b/lib/sagents/file_system_server.ex
@@ -639,6 +639,13 @@ defmodule Sagents.FileSystemServer do
   end
 
   @impl true
+  def handle_info({:EXIT, port, _reason}, state) when is_port(port) do
+    # With trap_exit, linked ports (e.g. from System.cmd in persistence) send
+    # {:EXIT, port, reason} when they close — ignore so the GenServer keeps running.
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info({:persist_file, path}, state) do
     new_state = FileSystemState.persist_file(state, path)
     {:noreply, new_state}

--- a/test/sagents/file_system_server_test.exs
+++ b/test/sagents/file_system_server_test.exs
@@ -1045,4 +1045,26 @@ defmodule Sagents.FileSystemServerTest do
       assert entry.path == "/test.txt"
     end
   end
+
+  describe "trap_exit and linked ports" do
+    test "ignores {:EXIT, port, _} when a linked port closes", %{agent_id: agent_id} do
+      sh = System.find_executable("sh")
+      assert sh, "sh executable required for this test"
+
+      {:ok, fs_pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
+
+      port =
+        Port.open({:spawn_executable, sh}, [
+          :binary,
+          args: ["-c", "exit 0"]
+        ])
+
+      assert is_port(port)
+      assert Port.connect(port, fs_pid)
+      Port.close(port)
+
+      assert Process.alive?(fs_pid)
+      assert {:ok, {:agent, ^agent_id}} = FileSystemServer.get_scope(fs_pid)
+    end
+  end
 end


### PR DESCRIPTION
FileSystemServer sets trap_exit in init so terminate/2 can flush pending writes. Any port opened in that process (for example via System.cmd/3 in persistence) is linked to the owner by default. When the subprocess finishes, the VM delivers `{:EXIT, port, reason}` to handle_info/2; but this message is not handled, crashing the process.

Made with [Cursor](https://cursor.com)