### PR TITLE
Make scope a first-class argument across callbacks and tools

### DIFF
--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -59,6 +59,10 @@ defmodule Sagents.Agent do
     field :middleware, {:array, :any}, default: [], virtual: true
     field :name, :string
     field :filesystem_scope, :any, virtual: true
+    # Integrator-defined scope struct (e.g., MyApp.Accounts.Scope). Opaque to
+    # sagents. NOT serialized — scope is session state that belongs to the
+    # caller starting the agent, not to persisted conversations.
+    field :scope, :any, virtual: true, default: nil
     # Caller-supplied context merged into LLMChain.custom_context for tool functions.
     field :tool_context, :map, default: %{}, virtual: true
     # Timeout for async tool execution. Integer (ms) or :infinity.
@@ -90,6 +94,7 @@ defmodule Sagents.Agent do
     :middleware,
     :name,
     :filesystem_scope,
+    :scope,
     :tool_context,
     :async_tool_timeout,
     :fallback_models,
@@ -111,10 +116,17 @@ defmodule Sagents.Agent do
   - `:middleware` - List of middleware modules/configs (default: [])
   - `:name` - Agent name for identification (default: nil)
   - `:filesystem_scope` - Optional scope key for referencing an independently-running filesystem (e.g., `{:user, 123}`, `{:project, 456}`)
+  - `:scope` - Integrator-defined scope struct (e.g., `%MyApp.Accounts.Scope{}`). Opaque
+    to Sagents — propagated as the first positional argument to persistence callbacks
+    (`AgentPersistence`, `DisplayMessagePersistence`, `FileSystemCallbacks`) and auto-merged
+    into tool-call `custom_context` under the canonical `:scope` key. Default: `nil`.
+    Note: **not serialized** — scope is session/runtime state belonging to the caller
+    starting the agent, not to persisted conversations. On restore, scope comes from the
+    fresh Coordinator invocation that starts the agent.
   - `:tool_context` - Map of caller-supplied data merged into `LLMChain.custom_context`
     so every tool function receives it as part of its second argument. Internal keys
-    (`:state`, `:parent_middleware`, `:parent_tools`) always take precedence on collision.
-    (default: `%{}`)
+    (`:state`, `:parent_middleware`, `:parent_tools`, `:scope`) always take precedence on
+    collision. (default: `%{}`)
   - `:async_tool_timeout` - Timeout for parallel tool execution. Integer (milliseconds) or
     `:infinity`. Overrides application-level config. See LLMChain module docs for details.
     (default: uses application config or `:infinity`)
@@ -756,7 +768,10 @@ defmodule Sagents.Agent do
             # Preserve the original tool_context map as an explicit key so
             # SubAgent middleware can extract it cleanly without reconstructing
             # it.
-            tool_context: agent.tool_context || %{}
+            tool_context: agent.tool_context || %{},
+            # First-class scope channel: tool functions read `context.scope`. If
+            # tool_context contained `:scope`, it's overridden here.
+            scope: agent.scope
           }
         )
     }

--- a/lib/sagents/agent_persistence.ex
+++ b/lib/sagents/agent_persistence.ex
@@ -6,12 +6,19 @@ defmodule Sagents.AgentPersistence do
   state persistence at key lifecycle points. If no persistence module
   is configured, AgentServer operates entirely in-memory.
 
+  ## Scope-first contract
+
+  Every callback takes the integrator's scope struct as its first positional argument.
+
+  Scope is opaque to sagents (`term() | nil`). Implementations can pattern-match on
+  their own Scope struct (`%MyApp.Accounts.Scope{} = scope`) in the callback head.
+
   ## Lifecycle Contexts
 
-  The `context` parameter indicates why persistence was triggered:
+  The `context.lifecycle` key indicates why persistence was triggered:
 
-  | Context | When | Notes |
-  |---------|------|-------|
+  | Lifecycle | When | Notes |
+  |-----------|------|-------|
   | `:on_completion` | Agent execution completes successfully (status → :idle) | Most common persistence point |
   | `:on_cancel` | Execution cancelled by user | Preserves rolling state up to cancel point |
   | `:on_error` | Agent execution fails (status → :error) | Preserves state up to the error |
@@ -32,7 +39,7 @@ defmodule Sagents.AgentPersistence do
   No configuration = no persistence. AgentServer works fine without it.
   """
 
-  @type context ::
+  @type lifecycle ::
           :on_completion
           | :on_cancel
           | :on_error
@@ -40,25 +47,56 @@ defmodule Sagents.AgentPersistence do
           | :on_title_generated
           | :on_shutdown
 
+  @typedoc """
+  Context map passed to `persist_state/3`. Contains the agent and conversation
+  identifiers plus the lifecycle reason for this persistence call.
+  """
+  @type persist_context :: %{
+          required(:agent_id) => String.t(),
+          required(:conversation_id) => String.t() | nil,
+          required(:lifecycle) => lifecycle()
+        }
+
+  @typedoc """
+  Context map passed to `load_state/2`. Contains the agent and conversation
+  identifiers.
+  """
+  @type load_context :: %{
+          required(:agent_id) => String.t(),
+          required(:conversation_id) => String.t() | nil
+        }
+
   @doc """
   Called when the agent should persist its current state.
 
-  `agent_id` is the agent's identifier.
+  `scope` is the integrator-defined scope struct (or `nil` for unscoped callers
+  like admin tools). Use it to filter tenant-isolated DB writes.
+
   `state_data` is the serialized state map (string keys, JSON-compatible)
-    as returned by `StateSerializer.serialize_server_state/2`.
-  `context` indicates why persistence was triggered.
+  as returned by `StateSerializer.serialize_server_state/2`.
+
+  `context` carries `:agent_id`, `:conversation_id`, and `:lifecycle` (why
+  persistence was triggered).
 
   Return `:ok` on success. Errors are logged but do not affect agent operation.
   """
-  @callback persist_state(agent_id :: String.t(), state_data :: map(), context :: context()) ::
-              :ok | {:error, term()}
+  @callback persist_state(
+              scope :: term() | nil,
+              state_data :: map(),
+              context :: persist_context()
+            ) :: :ok | {:error, term()}
 
   @doc """
   Called to load a previously persisted state when starting an agent.
 
+  `scope` is the integrator-defined scope struct. Use it to verify that the
+  requested conversation belongs to the caller before returning state.
+
+  `context` carries `:agent_id` and `:conversation_id`.
+
   Returns the serialized state map, or `{:error, :not_found}` if no
   saved state exists (normal for first-time agents).
   """
-  @callback load_state(agent_id :: String.t()) ::
+  @callback load_state(scope :: term() | nil, context :: load_context()) ::
               {:ok, map()} | {:error, :not_found | term()}
 end

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -2587,8 +2587,21 @@ defmodule Sagents.AgentServer do
     end
   end
 
+  # Extract the integrator-defined scope from the Agent struct. Source of truth
+  # for all scope-bearing callback invocations below.
+  defp current_scope(%ServerState{agent: %{scope: scope}}), do: scope
+
+  # Build the shared callback context map — agent_id + conversation_id. Scope is
+  # passed separately as the first positional argument to each callback.
+  defp callback_context(%ServerState{} = s) do
+    %{
+      agent_id: s.agent.agent_id,
+      conversation_id: s.conversation_id
+    }
+  end
+
   # Persist agent state via the AgentPersistence behaviour (if configured)
-  defp maybe_persist_state(%ServerState{} = server_state, context) do
+  defp maybe_persist_state(%ServerState{} = server_state, lifecycle) do
     case server_state.agent_persistence do
       nil ->
         :ok
@@ -2600,13 +2613,16 @@ defmodule Sagents.AgentServer do
             server_state.state
           )
 
-        case module.persist_state(server_state.agent.agent_id, state_data, context) do
+        scope = current_scope(server_state)
+        context = Map.put(callback_context(server_state), :lifecycle, lifecycle)
+
+        case module.persist_state(scope, state_data, context) do
           :ok ->
             :ok
 
           {:error, reason} ->
             Logger.error(
-              "Agent persistence failed for #{server_state.agent.agent_id} (#{context}): #{inspect(reason)}"
+              "Agent persistence failed for #{server_state.agent.agent_id} (#{lifecycle}): #{inspect(reason)}"
             )
 
             :ok
@@ -2621,7 +2637,15 @@ defmodule Sagents.AgentServer do
 
     # Persist if configured
     if server_state.display_message_persistence do
-      case server_state.display_message_persistence.update_tool_status(status, tool_info) do
+      scope = current_scope(server_state)
+      context = callback_context(server_state)
+
+      case server_state.display_message_persistence.update_tool_status(
+             scope,
+             status,
+             tool_info,
+             context
+           ) do
         {:ok, updated_msg} ->
           broadcast_event(server_state, {:display_message_updated, updated_msg})
 
@@ -2736,8 +2760,11 @@ defmodule Sagents.AgentServer do
   defp maybe_resolve_tool_result(%ServerState{} = server_state, tool_call_id, result_content) do
     module = server_state.display_message_persistence
 
-    if module && function_exported?(module, :resolve_tool_result, 2) do
-      case module.resolve_tool_result(tool_call_id, result_content) do
+    if module && function_exported?(module, :resolve_tool_result, 4) do
+      scope = current_scope(server_state)
+      context = callback_context(server_state)
+
+      case module.resolve_tool_result(scope, tool_call_id, result_content, context) do
         {:ok, updated_msg} ->
           broadcast_event(server_state, {:display_message_updated, updated_msg})
 
@@ -2754,15 +2781,17 @@ defmodule Sagents.AgentServer do
   end
 
   defp run_message_preprocessor(%ServerState{} = server_state, message) do
+    scope = current_scope(server_state)
+
     context = %{
       agent_id: server_state.agent.agent_id,
       conversation_id: server_state.conversation_id,
-      tool_context: server_state.agent.tool_context,
+      tool_context: server_state.agent.tool_context || %{},
       state: server_state.state
     }
 
     try do
-      server_state.message_preprocessor.preprocess(message, context)
+      server_state.message_preprocessor.preprocess(scope, message, context)
     rescue
       exception ->
         Logger.error(
@@ -2777,9 +2806,11 @@ defmodule Sagents.AgentServer do
   defp maybe_save_and_broadcast_message(server_state, message) do
     if server_state.display_message_persistence && server_state.conversation_id do
       module = server_state.display_message_persistence
+      scope = current_scope(server_state)
+      context = callback_context(server_state)
 
       try do
-        case module.save_message(server_state.conversation_id, message) do
+        case module.save_message(scope, message, context) do
           {:ok, display_messages} when is_list(display_messages) ->
             Enum.each(display_messages, fn display_msg ->
               broadcast_event(server_state, {:display_message_saved, display_msg})

--- a/lib/sagents/agent_supervisor.ex
+++ b/lib/sagents/agent_supervisor.ex
@@ -396,11 +396,8 @@ defmodule Sagents.AgentSupervisor do
 
   # Resolve the initial state for the AgentServer.
   #
-  # When agent_persistence is configured, attempts to load fresh state from the
-  # database. This is critical for Horde redistribution: when a node departs and
-  # Horde replays the child spec on a surviving node, the initial_state in the
-  # child spec is stale (captured at first startup). Loading from DB gets the
-  # latest persisted state including all messages and middleware state.
+  # When agent_persistence is configured, loads fresh state from the DB rather
+  # than using the `initial_state` captured in the child spec
   #
   # Returns {state, restored} where restored is true if state was loaded from DB.
   defp resolve_initial_state(config, agent) do
@@ -408,7 +405,14 @@ defmodule Sagents.AgentSupervisor do
     fallback_state = Keyword.get(config, :initial_state, State.new!(%{agent_id: agent.agent_id}))
 
     if agent_persistence do
-      case agent_persistence.load_state(agent.agent_id) do
+      conversation_id = Keyword.get(config, :conversation_id)
+
+      context = %{
+        agent_id: agent.agent_id,
+        conversation_id: conversation_id
+      }
+
+      case agent_persistence.load_state(agent.scope, context) do
         {:ok, exported_state} ->
           case StateSerializer.deserialize_state(agent.agent_id, exported_state["state"]) do
             {:ok, state} ->

--- a/lib/sagents/display_message_persistence.ex
+++ b/lib/sagents/display_message_persistence.ex
@@ -6,6 +6,10 @@ defmodule Sagents.DisplayMessagePersistence do
   text messages, tool call cards, thinking blocks, error notifications, etc.
   They are separate from the agent's internal state and optimized for rendering.
 
+  ## Scope-first contract
+
+  Every callback takes the integrator's scope struct as its first positional argument.
+
   ## When callbacks are invoked
 
   All callbacks are invoked from within the AgentServer process, ensuring
@@ -13,7 +17,7 @@ defmodule Sagents.DisplayMessagePersistence do
 
   ### Message saving
 
-  `save_message/2` is called when a new LangChain Message is processed.
+  `save_message/3` is called when a new LangChain Message is processed.
   A single Message can produce multiple display messages (e.g., text + tool_calls).
   The implementation should return the saved records so AgentServer can
   broadcast `{:display_message_saved, msg}` events to connected LiveViews.
@@ -22,9 +26,9 @@ defmodule Sagents.DisplayMessagePersistence do
 
   Tool execution status updates reflect the lifecycle of tool calls:
 
-  1. Tool call identified → message saved with status "pending" (via `save_message/2`)
-  2. Tool execution starts → `update_tool_status/2` with status `:executing`
-  3. Tool execution ends → `update_tool_status/2` with status `:completed` or `:failed`
+  1. Tool call identified → message saved with status "pending" (via `save_message/3`)
+  2. Tool execution starts → `update_tool_status/4` with status `:executing`
+  3. Tool execution ends → `update_tool_status/4` with status `:completed` or `:failed`
 
   ## Configuration
 
@@ -42,6 +46,17 @@ defmodule Sagents.DisplayMessagePersistence do
   messages from events alone without persistence.
   """
 
+  @typedoc """
+  Context map passed to every callback. Carries cross-cutting identifiers that
+  every implementation needs but don't benefit from positional visibility.
+  """
+  @type callback_context :: %{
+          required(:agent_id) => String.t(),
+          required(:conversation_id) => String.t() | nil
+        }
+
+  @type tool_status :: :executing | :completed | :failed | :interrupted | :cancelled
+
   @doc """
   Save a LangChain Message as one or more display messages.
 
@@ -51,7 +66,7 @@ defmodule Sagents.DisplayMessagePersistence do
 
   The implementation should:
   1. Convert the Message into display message records
-  2. Persist them to the database
+  2. Persist them to the database (scoped via `scope`)
   3. Return the list of saved records
 
   AgentServer broadcasts `{:display_message_saved, msg}` for each
@@ -59,18 +74,20 @@ defmodule Sagents.DisplayMessagePersistence do
 
   ## Parameters
 
-  - `conversation_id` — Identifier for the conversation
+  - `scope` — Integrator-defined scope struct (or `nil`). Use to filter DB writes.
   - `message` — The `LangChain.Message` struct to persist
+  - `context` — Map with `:agent_id` and `:conversation_id`
 
   ## Returns
 
   - `{:ok, [saved_messages]}` — List of persisted display message records
   - `{:error, reason}` — Persistence failed (logged, does not affect agent)
   """
-  @callback save_message(conversation_id :: String.t(), message :: LangChain.Message.t()) ::
-              {:ok, list()} | {:error, term()}
-
-  @type tool_status :: :executing | :completed | :failed | :interrupted | :cancelled
+  @callback save_message(
+              scope :: term() | nil,
+              message :: LangChain.Message.t(),
+              context :: callback_context()
+            ) :: {:ok, list()} | {:error, term()}
 
   @doc """
   Update the status of a persisted tool call display message.
@@ -80,7 +97,8 @@ defmodule Sagents.DisplayMessagePersistence do
 
   ## Parameters
 
-  - `status` — The new status: `:executing`, `:completed`, `:failed`, or `:interrupted`
+  - `scope` — Integrator-defined scope struct (or `nil`). Use to filter DB writes.
+  - `status` — The new status: `:executing`, `:completed`, `:failed`, `:interrupted`, or `:cancelled`
   - `tool_info` — Map with at minimum `:call_id`, plus status-specific fields:
 
     | Status | Fields |
@@ -91,13 +109,19 @@ defmodule Sagents.DisplayMessagePersistence do
     | `:interrupted` | `%{call_id: "...", display_text: "..."}` |
     | `:cancelled` | `%{call_id: "...", name: "..."}` |
 
+  - `context` — Map with `:agent_id` and `:conversation_id`
+
   ## Returns
 
   - `{:ok, updated_message}` — Updated record, broadcast to LiveViews as `{:display_message_updated, msg}`
   - `{:error, :not_found}` — No matching tool call exists (normal if persistence wasn't configured when call was saved)
   """
-  @callback update_tool_status(status :: tool_status(), tool_info :: map()) ::
-              {:ok, term()} | {:error, :not_found | term()}
+  @callback update_tool_status(
+              scope :: term() | nil,
+              status :: tool_status(),
+              tool_info :: map(),
+              context :: callback_context()
+            ) :: {:ok, term()} | {:error, :not_found | term()}
 
   @doc """
   Resolve an interrupted tool result display message with actual result content.
@@ -110,16 +134,22 @@ defmodule Sagents.DisplayMessagePersistence do
 
   ## Parameters
 
+  - `scope` — Integrator-defined scope struct (or `nil`). Use to filter DB writes.
   - `tool_call_id` — The tool call ID matching the interrupted tool result
   - `result_content` — The actual result content string
+  - `context` — Map with `:agent_id` and `:conversation_id`
 
   ## Returns
 
   - `{:ok, updated_message}` — Updated record, broadcast to LiveViews
   - `{:error, :not_found}` — No matching interrupted tool result exists
   """
-  @callback resolve_tool_result(tool_call_id :: String.t(), result_content :: String.t()) ::
-              {:ok, term()} | {:error, :not_found | term()}
+  @callback resolve_tool_result(
+              scope :: term() | nil,
+              tool_call_id :: String.t(),
+              result_content :: String.t(),
+              context :: callback_context()
+            ) :: {:ok, term()} | {:error, :not_found | term()}
 
-  @optional_callbacks [resolve_tool_result: 2]
+  @optional_callbacks [resolve_tool_result: 4]
 end

--- a/lib/sagents/file_system_callbacks.ex
+++ b/lib/sagents/file_system_callbacks.ex
@@ -3,72 +3,47 @@ defmodule Sagents.FileSystemCallbacks do
   Behavior for file system persistence callbacks.
 
   Implement this behavior to provide custom persistence for filesystem operations.
-  All callbacks are optional - implement only what you need.
+  All callbacks are optional — implement only what you need.
+
+  ## Scope-first contract
+
+  Every callback takes the integrator's scope struct as its first positional argument.
 
   ## Example Implementation
 
       defmodule MyApp.FilesystemPersistence do
-        @behaviour Sagents.FilesystemCallbacks
+        @behaviour Sagents.FileSystemCallbacks
 
         @impl true
-        def on_write(file_path, content, context) do
-          # Save to database
-          case MyApp.Files.create_or_update(context.user_id, file_path, content) do
+        def on_write(%MyApp.Accounts.Scope{user: user}, file_path, content, _context) do
+          case MyApp.Files.create_or_update(user.id, file_path, content) do
             {:ok, file} -> {:ok, %{id: file.id}}
             {:error, reason} -> {:error, reason}
           end
         end
 
         @impl true
-        def on_read(file_path, context) do
-          case MyApp.Files.get(context.user_id, file_path) do
+        def on_read(%MyApp.Accounts.Scope{user: user}, file_path, _context) do
+          case MyApp.Files.get(user.id, file_path) do
             nil -> {:error, :not_found}
             file -> {:ok, file.content}
           end
         end
 
         @impl true
-        def on_delete(file_path, context) do
-          case MyApp.Files.delete(context.user_id, file_path) do
+        def on_delete(%MyApp.Accounts.Scope{user: user}, file_path, _context) do
+          case MyApp.Files.delete(user.id, file_path) do
             {:ok, _} -> {:ok, %{}}
             {:error, reason} -> {:error, reason}
           end
         end
 
         @impl true
-        def on_list(context) do
-          files = MyApp.Files.list_for_user(context.user_id)
+        def on_list(%MyApp.Accounts.Scope{user: user}, _context) do
+          files = MyApp.Files.list_for_user(user.id)
           {:ok, Enum.map(files, & &1.path)}
         end
       end
-
-  ## Configuration
-
-      {:ok, agent} = Agents.new(
-        model: model,
-        filesystem_opts: [
-          persistence: MyApp.FilesystemPersistence,
-          context: %{user_id: user_id, session_id: session_id}
-        ]
-      )
-
-  ## Alternative: Function-based Callbacks
-
-      {:ok, agent} = Agents.new(
-        model: model,
-        filesystem_opts: [
-          on_write: fn file_path, content, context ->
-            MyApp.Files.save(context.user_id, file_path, content)
-          end,
-          on_read: fn file_path, context ->
-            case MyApp.Files.get(context.user_id, file_path) do
-              nil -> {:error, :not_found}
-              file -> {:ok, file.content}
-            end
-          end,
-          context: %{user_id: user_id}
-        ]
-      )
   """
 
   @type file_path :: String.t()
@@ -80,15 +55,16 @@ defmodule Sagents.FileSystemCallbacks do
   Called when a file is created or overwritten.
 
   ## Parameters
+  - `scope` - Integrator-defined scope struct (or `nil`). Use to filter DB writes.
   - `file_path` - Path of the file being written
   - `content` - Full content of the file
-  - `context` - Additional context (user_id, session_id, etc.)
+  - `context` - Filesystem-specific fields (agent_id, session_id, etc.)
 
   ## Returns
   - `{:ok, metadata}` - Success, optionally with metadata
   - `{:error, reason}` - Failure reason
   """
-  @callback on_write(file_path, content, context) :: result()
+  @callback on_write(scope :: term() | nil, file_path, content, context) :: result()
 
   @doc """
   Called when a file is read.
@@ -97,42 +73,47 @@ defmodule Sagents.FileSystemCallbacks do
   in-memory state. This enables lazy-loading from persistent storage.
 
   ## Parameters
+  - `scope` - Integrator-defined scope struct (or `nil`)
   - `file_path` - Path of the file being read
-  - `context` - Additional context (user_id, session_id, etc.)
+  - `context` - Filesystem-specific fields
 
   ## Returns
   - `{:ok, content}` - File content from storage
   - `{:error, :not_found}` - File doesn't exist in storage
   - `{:error, reason}` - Other error
   """
-  @callback on_read(file_path, context) :: {:ok, content} | {:error, term()}
+  @callback on_read(scope :: term() | nil, file_path, context) ::
+              {:ok, content} | {:error, term()}
 
   @doc """
   Called when a file is deleted.
 
   ## Parameters
+  - `scope` - Integrator-defined scope struct (or `nil`)
   - `file_path` - Path of the file being deleted
-  - `context` - Additional context (user_id, session_id, etc.)
+  - `context` - Filesystem-specific fields
 
   ## Returns
   - `{:ok, metadata}` - Success
   - `{:error, reason}` - Failure reason
   """
-  @callback on_delete(file_path, context) :: result()
+  @callback on_delete(scope :: term() | nil, file_path, context) :: result()
 
   @doc """
   Called to list all files in persistent storage.
 
-  Optional - if not implemented, only in-memory files are listed.
+  Optional — if not implemented, only in-memory files are listed.
 
   ## Parameters
-  - `context` - Additional context (user_id, session_id, etc.)
+  - `scope` - Integrator-defined scope struct (or `nil`)
+  - `context` - Filesystem-specific fields
 
   ## Returns
   - `{:ok, [file_path]}` - List of file paths
   - `{:error, reason}` - Failure reason
   """
-  @callback on_list(context) :: {:ok, [file_path]} | {:error, term()}
+  @callback on_list(scope :: term() | nil, context) ::
+              {:ok, [file_path]} | {:error, term()}
 
-  @optional_callbacks [on_write: 3, on_read: 2, on_delete: 2, on_list: 1]
+  @optional_callbacks [on_write: 4, on_read: 3, on_delete: 3, on_list: 2]
 end

--- a/lib/sagents/message_preprocessor.ex
+++ b/lib/sagents/message_preprocessor.ex
@@ -11,6 +11,10 @@ defmodule Sagents.MessagePreprocessor do
      For example, `@ProjectBrief` might be expanded to include the full document content
      so the model can reason over it.
 
+  ## Scope-first contract
+
+  The `preprocess/3` callback takes the integrator's scope struct as its first positional argument.
+
   ## When this runs
 
   Called inside `AgentServer.handle_call({:add_message, ...})` **before** the message
@@ -42,21 +46,28 @@ defmodule Sagents.MessagePreprocessor do
   If not configured, messages flow through unchanged to both paths.
   """
 
+  @typedoc """
+  Context map passed to `preprocess/3`. Contains identifiers plus the caller's
+  `tool_context` (for integrator-defined tool-parameter data, no longer a transport
+  for scope) and the current agent state.
+  """
+  @type preprocessor_context :: %{
+          required(:agent_id) => String.t(),
+          required(:conversation_id) => String.t() | nil,
+          required(:tool_context) => map(),
+          required(:state) => Sagents.State.t()
+        }
+
   @doc """
   Transform a user-submitted message into separate display and LLM representations.
 
-  ## Context
+  ## Parameters
 
-  The `context` map provides:
-
-  - `:agent_id` — The agent identifier string
-  - `:conversation_id` — The conversation identifier (may be nil)
-  - `:tool_context` — The caller-supplied context map from the Agent struct.
-    Contains `:current_scope` (the Phoenix Scope with the current user),
-    injected by the Coordinator at session start. Use this to scope document
-    lookups, permission checks, etc.
-  - `:state` — The current `Sagents.State` (messages, metadata). Useful for
-    context-aware preprocessing (e.g., referencing prior messages).
+  - `scope` — Integrator-defined scope struct (or `nil`). Use for document lookups,
+    permission checks, etc.
+  - `message` — The `LangChain.Message` being submitted
+  - `context` — Map with `:agent_id`, `:conversation_id`, `:tool_context`
+    (integrator's non-scope tool-parameter data), and `:state` (current `Sagents.State`).
 
   ## Returns
 
@@ -64,7 +75,11 @@ defmodule Sagents.MessagePreprocessor do
     For passthrough, return the same message for both.
   - `{:error, reason}` — Reject the message. AgentServer replies with `{:error, reason}`.
   """
-  @callback preprocess(message :: LangChain.Message.t(), context :: map()) ::
+  @callback preprocess(
+              scope :: term() | nil,
+              message :: LangChain.Message.t(),
+              context :: preprocessor_context()
+            ) ::
               {:ok, display_message :: LangChain.Message.t(),
                llm_message :: LangChain.Message.t()}
               | {:error, term()}

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -572,11 +572,12 @@ defmodule Sagents.Middleware.SubAgent do
         until_tool_map = Map.get(config, :until_tool_map, %{})
         until_tool = Map.get(until_tool_map, subagent_type)
 
-        # Extract parent's tool_context and metadata so SubAgent tools see the
+        # Extract parent's tool_context, metadata, and scope so SubAgent tools see the
         # same context as parent tools. Agent.build_chain stores the original
-        # tool_context map as an explicit :tool_context key in custom_context.
-        # Metadata is nested in state and copied into the SubAgent's fresh State.
-        {parent_tool_context, parent_metadata} = extract_parent_context(context)
+        # tool_context map as an explicit :tool_context key in custom_context, and
+        # scope under the canonical :scope key. Metadata is nested in state and copied
+        # into the SubAgent's fresh State.
+        {parent_tool_context, parent_metadata, parent_scope} = extract_parent_context(context)
 
         # Create SubAgent struct from pre-configured agent
         # Check if it's a Compiled struct (with initial_messages) or just an Agent
@@ -591,7 +592,8 @@ defmodule Sagents.Middleware.SubAgent do
                 initial_messages: compiled.initial_messages || [],
                 until_tool: until_tool,
                 parent_tool_context: parent_tool_context,
-                parent_metadata: parent_metadata
+                parent_metadata: parent_metadata,
+                scope: parent_scope
               )
 
             agent ->
@@ -602,7 +604,8 @@ defmodule Sagents.Middleware.SubAgent do
                 agent_config: agent,
                 until_tool: until_tool,
                 parent_tool_context: parent_tool_context,
-                parent_metadata: parent_metadata
+                parent_metadata: parent_metadata,
+                scope: parent_scope
               )
           end
 
@@ -682,8 +685,8 @@ defmodule Sagents.Middleware.SubAgent do
             interrupt_on: nil
           )
 
-        # Extract parent's tool_context and metadata for SubAgent inheritance
-        {parent_tool_context, parent_metadata} = extract_parent_context(context)
+        # Extract parent's tool_context, metadata, and scope for SubAgent inheritance
+        {parent_tool_context, parent_metadata, parent_scope} = extract_parent_context(context)
 
         # Create SubAgent struct with parent context
         subagent =
@@ -692,7 +695,8 @@ defmodule Sagents.Middleware.SubAgent do
             instructions: instructions,
             agent_config: agent_config,
             parent_tool_context: parent_tool_context,
-            parent_metadata: parent_metadata
+            parent_metadata: parent_metadata,
+            scope: parent_scope
           )
 
         # Get supervisor and start SubAgent (same as pre-configured)
@@ -724,18 +728,19 @@ defmodule Sagents.Middleware.SubAgent do
     end
   end
 
-  # Extract parent's tool_context and state.metadata from the runtime context.
+  # Extract parent's tool_context, state.metadata, and scope from the runtime context.
   #
   # Agent.build_chain stores the original tool_context map as an explicit
-  # :tool_context key in custom_context, so we read it directly rather than
-  # trying to reconstruct it by removing internal keys.
+  # :tool_context key in custom_context, and the parent's scope under the
+  # canonical :scope key. We read both directly.
   # Metadata lives nested inside context.state.metadata.
   #
-  # Returns {tool_context_map, metadata_map}.
+  # Returns {tool_context_map, metadata_map, scope}.
   defp extract_parent_context(context) do
     parent_tool_context = Map.get(context, :tool_context, %{})
     parent_metadata = get_in(context, [:state, Access.key(:metadata)]) || %{}
-    {parent_tool_context, parent_metadata}
+    parent_scope = Map.get(context, :scope)
+    {parent_tool_context, parent_metadata, parent_scope}
   end
 
   defp default_general_purpose_prompt() do

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -171,11 +171,14 @@ defmodule Sagents.SubAgent do
   - `:instructions` - Task description (required)
   - `:agent_config` - Agent struct with tools, model, middleware (required)
   - `:parent_tool_context` - Parent's tool_context map to inherit (optional).
-    Static, caller-supplied data (e.g., `user_id`, `current_scope`) that tools
+    Static, caller-supplied data (e.g., `user_id`, feature flags) that tools
     access as flat top-level keys on context. Defaults to `%{}`.
   - `:parent_metadata` - Parent's state metadata map to inherit (optional).
     Dynamic, middleware-managed data (e.g., `conversation_title`) that tools
     access via `context.state.metadata`. Defaults to `%{}`.
+  - `:scope` - Scope struct to inherit from the parent (optional). Propagated to
+    the SubAgent's `custom_context.scope` so sub-agent tools and persistence callbacks
+    see the same tenant context as the parent. Defaults to `agent_config.scope`.
 
   ## Examples
 
@@ -184,7 +187,8 @@ defmodule Sagents.SubAgent do
         instructions: "Research renewable energy impacts",
         agent_config: agent_struct,
         parent_tool_context: %{user_id: 42, tenant: "acme"},
-        parent_metadata: %{"conversation_title" => "Research"}
+        parent_metadata: %{"conversation_title" => "Research"},
+        scope: %MyApp.Accounts.Scope{user: user}
       )
   """
   def new_from_config(opts) do
@@ -209,11 +213,14 @@ defmodule Sagents.SubAgent do
   - `:compiled_agent` - Pre-built Agent struct (required)
   - `:initial_messages` - Optional initial message sequence (default: [])
   - `:parent_tool_context` - Parent's tool_context map to inherit (optional).
-    Static, caller-supplied data (e.g., `user_id`, `current_scope`) that tools
+    Static, caller-supplied data (e.g., `user_id`, feature flags) that tools
     access as flat top-level keys on context. Defaults to `%{}`.
   - `:parent_metadata` - Parent's state metadata map to inherit (optional).
     Dynamic, middleware-managed data (e.g., `conversation_title`) that tools
     access via `context.state.metadata`. Defaults to `%{}`.
+  - `:scope` - Scope struct to inherit from the parent (optional). Propagated to
+    the SubAgent's `custom_context.scope` so sub-agent tools and persistence callbacks
+    see the same tenant context as the parent. Defaults to `compiled_agent.scope`.
 
   ## Examples
 
@@ -263,6 +270,10 @@ defmodule Sagents.SubAgent do
     parent_agent_id = Keyword.fetch!(opts, :parent_agent_id)
     parent_tool_context = Keyword.get(opts, :parent_tool_context, %{})
     parent_metadata = Keyword.get(opts, :parent_metadata, %{})
+    # Scope propagates from parent to SubAgent so sub-agent tools and callbacks
+    # see the same tenant context. Fall back to the compiled/config agent's own
+    # `:scope` field if the caller didn't pass one (e.g., direct new_from_compiled).
+    scope = Keyword.get(opts, :scope, agent.scope)
     until_tool = Keyword.get(opts, :until_tool)
     max_runs = Keyword.get(opts, :max_runs)
 
@@ -280,7 +291,9 @@ defmodule Sagents.SubAgent do
         parent_middleware: agent.middleware,
         # Preserve the tool_context as an explicit key so nested SubAgents
         # can extract it cleanly (same as Agent.build_chain).
-        tool_context: parent_tool_context
+        tool_context: parent_tool_context,
+        # First-class scope channel, same canonical key as Agent.build_chain.
+        scope: scope
       })
 
     chain =

--- a/priv/templates/agent_live_helpers.ex.eex
+++ b/priv/templates/agent_live_helpers.ex.eex
@@ -211,10 +211,10 @@ defmodule <%= module %> do
       # Subscribe to agent events and track presence
       socket = maybe_subscribe_and_track(socket, conversation_id, user_id)
 
-      # Load display messages and todos
-      display_messages = conversations.load_display_messages(conversation_id)
+      # Load display messages and todos (scoped)
+      display_messages = conversations.load_display_messages(scope, conversation_id)
       has_messages = !Enum.empty?(display_messages)
-      saved_todos = conversations.load_todos(conversation_id)
+      saved_todos = conversations.load_todos(scope, conversation_id)
 
       # Check if agent is already running
       agent_status = AgentServer.get_status(agent_id)
@@ -472,7 +472,7 @@ defmodule <%= module %> do
   """
   def handle_display_message_saved(socket, display_msg) do
     socket =
-      if socket.assigns[:conversation_id] do
+      if socket.assigns[:conversation_id] && socket.assigns[:current_scope] do
         # Clear streaming_delta - persisted messages are now the authoritative display.
         # All display messages are saved to DB before broadcasting, so reload gets them all.
         socket
@@ -619,8 +619,13 @@ defmodule <%= module %> do
   Uses reset: true to ensure proper ordering and clean state.
   """
   def reload_messages_from_db(socket) do
-    if socket.assigns[:conversation_id] do
-      messages = <%= conversations_alias %>.load_display_messages(socket.assigns.conversation_id)
+    if socket.assigns[:conversation_id] && socket.assigns[:current_scope] do
+      messages =
+        <%= conversations_alias %>.load_display_messages(
+          socket.assigns.current_scope,
+          socket.assigns.conversation_id
+        )
+
       stream(socket, :messages, messages, reset: true)
     else
       socket
@@ -635,8 +640,9 @@ defmodule <%= module %> do
   Returns the message map (not the socket).
   """
   def create_or_persist_message(socket, message_type, text) do
-    if socket.assigns[:conversation_id] do
+    if socket.assigns[:conversation_id] && socket.assigns[:current_scope] do
       case <%= conversations_alias %>.append_text_message(
+             socket.assigns.current_scope,
              socket.assigns.conversation_id,
              message_type,
              text
@@ -740,8 +746,12 @@ defmodule <%= module %> do
         _ -> tool[:tool_call_id]
       end
 
-    if call_id do
-      <%= conversations_alias %>.record_hitl_decision(call_id, decision)
+    if call_id && socket.assigns[:current_scope] do
+      <%= conversations_alias %>.record_hitl_decision(
+        socket.assigns.current_scope,
+        call_id,
+        decision
+      )
     end
   end
 

--- a/priv/templates/agent_persistence.ex.eex
+++ b/priv/templates/agent_persistence.ex.eex
@@ -3,7 +3,7 @@ defmodule <%= module %> do
   Implements `Sagents.AgentPersistence` for state snapshots.
 
   Persists full agent state (messages, todos, metadata) to the database
-  via `<%= conversations_module %>.save_agent_state/2`.
+  via `<%= conversations_module %>.save_agent_state/3`.
   """
 
   @behaviour Sagents.AgentPersistence
@@ -11,26 +11,48 @@ defmodule <%= module %> do
   require Logger
 
   @impl true
-  def persist_state(agent_id, state_data, context) do
-    conversation_id = extract_conversation_id(agent_id)
+  def persist_state(scope, state_data, context) do
+    conversation_id = extract_conversation_id(context.agent_id)
 
-    case <%= conversations_module %>.save_agent_state(conversation_id, state_data) do
+    case <%= conversations_module %>.save_agent_state(scope, conversation_id, state_data) do
       {:ok, _} ->
-        Logger.debug("Persisted agent state for #{agent_id} (#{context})")
+        Logger.debug("Persisted agent state for #{context.agent_id} (#{context.lifecycle})")
         :ok
 
-      {:error, reason} ->
-        {:error, reason}
+      {:error, %Ecto.Changeset{errors: errors}} = error ->
+        if conversation_deleted?(errors) do
+          Logger.warning(
+            "Skipping agent state persistence for #{context.agent_id} (#{context.lifecycle}): conversation no longer exists"
+          )
+
+          :ok
+        else
+          error
+        end
+
+      {:error, :not_found} ->
+        Logger.warning(
+          "Skipping agent state persistence for #{context.agent_id} (#{context.lifecycle}): conversation not accessible in scope"
+        )
+
+        :ok
     end
   end
 
   @impl true
-  def load_state(agent_id) do
-    conversation_id = extract_conversation_id(agent_id)
-    <%= conversations_module %>.load_agent_state(conversation_id)
+  def load_state(scope, context) do
+    conversation_id = extract_conversation_id(context.agent_id)
+    <%= conversations_module %>.load_agent_state(scope, conversation_id)
   end
 
   defp extract_conversation_id(agent_id) do
     String.replace_prefix(agent_id, "conversation-", "")
+  end
+
+  defp conversation_deleted?(changeset_errors) do
+    Enum.any?(changeset_errors, fn
+      {:conversation_id, {_msg, opts}} -> Keyword.get(opts, :constraint) == :foreign
+      _ -> false
+    end)
   end
 end

--- a/priv/templates/coordinator.ex.eex
+++ b/priv/templates/coordinator.ex.eex
@@ -120,13 +120,17 @@ defmodule <%= module %> do
   ## Options
 
   - `:filesystem_scope` - Required. Filesystem scope tuple (e.g., `{:<%= owner_type %>, <%= owner_field %>}`)
-  - `:user_scope` - Optional. The Phoenix scope (e.g., `current_scope`). Automatically
-    injected into `tool_context` as `:current_scope`, so tool functions receive `context.current_scope`.
+  - `:scope` - The Phoenix scope (e.g., `current_scope`). In production this should
+    come from the caller's session (e.g., a LiveView's `socket.assigns.current_scope`).
+    `nil` is allowed for tests, admin scripts, or background jobs, but tenant-scoped
+    queries downstream will have no owner to filter by. Set on the agent's `:scope`
+    field via the Factory; sagents propagates it as the first positional argument to
+    persistence callbacks and as `context.scope` to tool functions.
   - `:inactivity_timeout` - Milliseconds before agent stops (default: 10 minutes)
-  - `:tool_context` - Map of additional caller-supplied data that will be available to
-    all tool functions as their second argument. Defaults to `%{}`.
-    Note: `:user_scope` is automatically injected as `:current_scope` in `tool_context`,
-    so tool functions always have access to `context.current_scope`.
+  - `:tool_context` - Map of caller-supplied data. Its entries become keys on
+    the `context` map passed as the tool function's second argument. For example,
+    `%{feature_flags: flags}` here lets tools read `context.feature_flags`.
+    Defaults to `%{}`.
   - `:factory_opts` - Additional options passed to your Factory module (e.g., `:timezone` for custom middleware)
 
   ## Returns
@@ -422,25 +426,24 @@ defmodule <%= module %> do
 
     # 1. Extract options
     factory_opts = Keyword.get(opts, :factory_opts, [])
-
-    # 2. Create agent from factory (configuration from code)
-    # Auto-merge user_scope into tool_context so tool functions always receive
-    # the scope as context.current_scope.
-    user_scope = Keyword.get(opts, :user_scope)
+    scope = Keyword.get(opts, :scope)
     tool_context = Keyword.get(opts, :tool_context, %{})
-    tool_context = Map.put(tool_context, :current_scope, user_scope)
 
+    # 2. Create agent from factory (configuration from code).
+    # Scope is passed as a dedicated :scope option. Sagents auto-merges it into
+    # custom_context under the canonical :scope key and threads it through
+    # persistence callbacks as the first positional argument.
     merged_factory_opts =
       factory_opts
       |> Keyword.put(:agent_id, agent_id)
       |> Keyword.put(:filesystem_scope, filesystem_scope)
-      |> Keyword.put(:user_scope, user_scope)
+      |> Keyword.put(:scope, scope)
       |> Keyword.put(:tool_context, tool_context)
 
     {:ok, agent} = <%= factory_module %>.create_agent(merged_factory_opts)
 
-    # 3. Load or create state (data from database)
-    {:ok, state} = create_conversation_state(conversation_id)
+    # 3. Load or create state (data from database, scoped to the caller)
+    {:ok, state} = create_conversation_state(conversation_id, scope)
 
     # 4. Extract configuration from options
     inactivity_timeout = Keyword.get(opts, :inactivity_timeout, :timer.minutes(@inactivity_timeout_minutes))
@@ -499,10 +502,14 @@ defmodule <%= module %> do
     end
   end
 
-  defp create_conversation_state(conversation_id) do
+  defp create_conversation_state(conversation_id, scope) do
     agent_id = conversation_agent_id(conversation_id)
 
-    load_result = <%= agent_persistence_module %>.load_state(agent_id)
+    load_result =
+      <%= agent_persistence_module %>.load_state(scope, %{
+        agent_id: agent_id,
+        conversation_id: conversation_id
+      })
 
     case load_result do
       {:ok, exported_state} ->

--- a/priv/templates/display_message_persistence.ex.eex
+++ b/priv/templates/display_message_persistence.ex.eex
@@ -15,7 +15,7 @@ defmodule <%= module %> do
   alias LangChain.Message
 
   @impl true
-  def save_message(conversation_id, %Message{} = message) do
+  def save_message(scope, %Message{} = message, context) do
     display_items = DisplayHelpers.extract_display_items(message)
 
     if Enum.empty?(display_items) do
@@ -36,7 +36,7 @@ defmodule <%= module %> do
             attrs
           end
 
-        case <%= conversations_module %>.append_display_message(conversation_id, attrs) do
+        case <%= conversations_module %>.append_display_message(scope, context.conversation_id, attrs) do
           {:ok, display_msg} ->
             {:cont, {:ok, acc ++ [display_msg]}}
 
@@ -52,11 +52,11 @@ defmodule <%= module %> do
   end
 
   @impl true
-  def update_tool_status(:executing, %{call_id: call_id}) do
-    <%= conversations_module %>.mark_tool_executing(call_id)
+  def update_tool_status(scope, :executing, %{call_id: call_id}, _context) do
+    <%= conversations_module %>.mark_tool_executing(scope, call_id)
   end
 
-  def update_tool_status(:completed, %{call_id: call_id, result: result} = tool_info) do
+  def update_tool_status(scope, :completed, %{call_id: call_id, result: result} = tool_info, _context) do
     metadata = %{"result" => result}
 
     metadata =
@@ -65,19 +65,19 @@ defmodule <%= module %> do
         text -> Map.put(metadata, "display_text", text)
       end
 
-    <%= conversations_module %>.complete_tool_call(call_id, metadata)
+    <%= conversations_module %>.complete_tool_call(scope, call_id, metadata)
   end
 
-  def update_tool_status(:failed, %{call_id: call_id, error: error}) do
-    <%= conversations_module %>.fail_tool_call(call_id, %{"error" => error})
+  def update_tool_status(scope, :failed, %{call_id: call_id, error: error}, _context) do
+    <%= conversations_module %>.fail_tool_call(scope, call_id, %{"error" => error})
   end
 
-  def update_tool_status(:interrupted, %{call_id: call_id, display_text: display_text}) do
-    <%= conversations_module %>.interrupt_tool_call(call_id, %{"display_text" => display_text})
+  def update_tool_status(scope, :interrupted, %{call_id: call_id, display_text: display_text}, _context) do
+    <%= conversations_module %>.interrupt_tool_call(scope, call_id, %{"display_text" => display_text})
   end
 
-  def update_tool_status(:cancelled, %{call_id: call_id}) do
-    <%= conversations_module %>.cancel_tool_call(call_id)
+  def update_tool_status(scope, :cancelled, %{call_id: call_id}, _context) do
+    <%= conversations_module %>.cancel_tool_call(scope, call_id)
   end
 
   @doc """
@@ -85,7 +85,7 @@ defmodule <%= module %> do
   Called after a sub-agent resumes and completes.
   """
   @impl true
-  def resolve_tool_result(tool_call_id, result_content) do
-    <%= conversations_module %>.resolve_interrupted_tool_result(tool_call_id, result_content)
+  def resolve_tool_result(scope, tool_call_id, result_content, _context) do
+    <%= conversations_module %>.resolve_interrupted_tool_result(scope, tool_call_id, result_content)
   end
 end

--- a/priv/templates/factory.ex.eex
+++ b/priv/templates/factory.ex.eex
@@ -98,10 +98,17 @@ defmodule <%= module %> do
   - `:filesystem_scope` - Required. Scope tuple for filesystem isolation.
     Examples: `{:<%= owner_type %>, <%= owner_field %>}`, `{:project, 456}`, `{:team, 789}`.
     Pass `nil` for agent-scoped (isolated per conversation).
+  - `:scope` - Integrator-defined scope struct (e.g., `%MyApp.Accounts.Scope{}`).
+    In production this should be passed by the Coordinator from the caller's session.
+    `nil` is allowed (for tests, admin scripts, or background jobs without a user
+    context) but tenant-scoped queries downstream will have no owner to filter by.
+    Set on `agent.scope`; sagents propagates to persistence callbacks (arg #1) and
+    to tool `context.scope`.
   - `:interrupt_on` - Optional. Map of tool names requiring approval.
     Pass `nil` to disable HITL entirely.
   - `:tool_context` - Optional. Map of caller-supplied data passed to tool functions
     via `LLMChain.custom_context`. Defaults to `%{}`. Example: `%{user_id: 42}`.
+    Scope is NOT stuffed here — it has its own `:scope` channel.
 
   ## Examples
 
@@ -138,6 +145,7 @@ defmodule <%= module %> do
   def create_agent(opts \\ []) do
     agent_id = Keyword.fetch!(opts, :agent_id)
     filesystem_scope = Keyword.fetch!(opts, :filesystem_scope)
+    scope = Keyword.get(opts, :scope)
     interrupt_on = Keyword.get(opts, :interrupt_on, default_interrupt_on())
     tool_context = Keyword.get(opts, :tool_context, %{})
 
@@ -151,7 +159,8 @@ defmodule <%= module %> do
         before_fallback: get_before_fallback(),
         # Add any custom tools here (tools not provided by middleware)
         tools: [],
-        tool_context: tool_context
+        tool_context: tool_context,
+        scope: scope
       },
       # Since we specify the full middleware stack, don't add defaults
       replace_default_middleware: true

--- a/priv/templates/sagents.gen.persistence/context.ex.eex
+++ b/priv/templates/sagents.gen.persistence/context.ex.eex
@@ -2,47 +2,21 @@ defmodule <%= @context_module %> do
   @moduledoc """
   Context for conversation persistence with multi-content type support.
 
-  This module provides scoped access to conversations, agent states, and display messages.
-
   ## Scope-Based Security
 
-  All conversation operations require a scope struct (`<%= @scope_module %>`)
-  as the first argument. This ensures queries are automatically filtered to
-  the appropriate user, organization, or team context.
+  Every public function takes a `<%= @scope_module %>` as its first argument.
+  Use it to limit access and actions to the caller's authorized data.
+  Wrong-scope callers receive `{:error, :not_found}`.
 
   ## Customization Required
 
-  **IMPORTANT**: The generated code uses generic scope filtering. You must
-  customize the query filters to match your scope struct fields:
-
-  ```elixir
-  # Example: If your scope has :current_user_id
-  defp scope_query(query, %Scope{current_user_id: user_id}) do
-    from q in query, where: q.<%= @owner_field %> == ^user_id
-  end
-
-  # Example: If your scope has :organization_id (multi-tenant)
-  defp scope_query(query, %Scope{organization_id: org_id}) do
-    from q in query, where: q.organization_id == ^org_id
-  end
-  ```
-
-  Update `scope_query/2` and related functions based on YOUR scope structure.
+  The generated code uses generic scope filtering. Customize `scope_query/2`,
+  `scope_conversation_query/2`, and `get_owner_id/1` to match your Scope struct.
 
   ## Multi-Content Type Support
 
   Display messages support multiple content types (text, thinking, images, files, etc.).
-  Use the provided helper functions to create messages with proper structure:
-
-  - `append_text_message/3` - Standard text content
-  - `append_thinking_message/2` - AI reasoning blocks
-  - `append_image_message/3` - Images with URL or base64 data
-  - `append_file_message/4` - File references
-  - `append_structured_data_message/4` - Tables, JSON, etc.
-  - `append_notification_message/3` - System notifications
-  - `append_error_message/3` - Error messages
-
-  **IMPORTANT**: All content keys are strings (not atoms) due to JSONB storage.
+  All content keys are strings (not atoms) due to JSONB storage.
   """
 
   import Ecto.Query, warn: false
@@ -135,47 +109,57 @@ defmodule <%= @context_module %> do
   # Agent State Persistence
   #
 
-  def save_agent_state(conversation_id, state) do
-    attrs = %{
-      conversation_id: conversation_id,
-      state_data: state,
-      version: state["version"] || 1
-    }
+  @doc """
+  Saves (upsert) the serialized agent state for a conversation.
 
-    case get_agent_state(conversation_id) do
-      nil ->
-        %AgentState{}
-        |> AgentState.changeset(attrs)
-        |> Repo.insert()
+  Verifies the conversation belongs to `scope` before writing. Returns
+  `{:error, :not_found}` if the conversation doesn't belong to the caller.
+  """
+  def save_agent_state(%Scope{} = scope, conversation_id, state) do
+    with :ok <- authorize_conversation(scope, conversation_id) do
+      attrs = %{
+        conversation_id: conversation_id,
+        state_data: state,
+        version: state["version"] || 1
+      }
 
-      existing ->
-        existing
-        |> AgentState.changeset(attrs)
-        |> Repo.update()
+      case get_agent_state(scope, conversation_id) do
+        nil ->
+          %AgentState{}
+          |> AgentState.changeset(attrs)
+          |> Repo.insert()
+
+        existing ->
+          existing
+          |> AgentState.changeset(attrs)
+          |> Repo.update()
+      end
     end
   end
 
-  def load_agent_state(conversation_id) do
-    case get_agent_state(conversation_id) do
+  @doc """
+  Loads the serialized agent state for a conversation, filtered by scope.
+
+  Returns `{:ok, state_data}` on success or `{:error, :not_found}` if no state
+  exists or the conversation doesn't belong to the caller.
+  """
+  def load_agent_state(%Scope{} = scope, conversation_id) do
+    case get_agent_state(scope, conversation_id) do
       nil -> {:error, :not_found}
       state -> {:ok, state.state_data}
     end
   end
 
   @doc """
-  Loads just the TODOs from a saved agent state.
+  Loads just the TODOs from a saved agent state, filtered by scope.
 
-  This is useful for displaying TODOs in the UI when browsing historical
-  conversations without starting the agent. Returns an empty list if no
-  state exists or if there are no todos.
-
-  Reuses the same deserialization logic as full state restoration via
-  `Sagents.Todo.from_map/1`.
+  Useful for displaying TODOs in the UI when browsing historical conversations
+  without starting the agent. Returns an empty list if no state exists, no todos
+  are present, or the conversation doesn't belong to the caller.
   """
-  def load_todos(conversation_id) do
-    case load_agent_state(conversation_id) do
+  def load_todos(%Scope{} = scope, conversation_id) do
+    case load_agent_state(scope, conversation_id) do
       {:ok, %{"state" => %{"todos" => todos}}} when is_list(todos) ->
-        # Reuse Todo.from_map/1 - same logic as StateSerializer.deserialize_state/2
         todos
         |> Enum.map(fn todo_map ->
           case Todo.from_map(todo_map) do
@@ -186,18 +170,22 @@ defmodule <%= @context_module %> do
         |> Enum.reject(&is_nil/1)
 
       {:ok, _} ->
-        # State exists but no todos field
         []
 
       {:error, :not_found} ->
-        # No saved state
         []
     end
   end
 
-  defp get_agent_state(conversation_id) do
-    AgentState
-    |> where([a], a.conversation_id == ^conversation_id)
+  # Scoped agent-state lookup. Joins to Conversation so we inherit the same
+  # tenant filter as `scope_query/2` applies to conversations.
+  defp get_agent_state(%Scope{} = scope, conversation_id) do
+    from(s in AgentState,
+      join: c in Conversation,
+      on: s.conversation_id == c.id,
+      where: s.conversation_id == ^conversation_id
+    )
+    |> scope_conversation_query(scope)
     |> Repo.one()
   end
 
@@ -206,42 +194,46 @@ defmodule <%= @context_module %> do
   #
 
   @doc """
-  Appends a display message to the conversation.
+  Appends a display message to a conversation, filtered by scope.
 
-  The message should be a map with keys:
-  - `message_type` - "user", "assistant", "tool", "system"
-  - `content_type` - Type of content for rendering
-  - `content` - Map with structure based on content_type
-  - `metadata` - Optional metadata
-
-  For easier usage, consider using the content-type-specific helper functions.
+  Verifies the conversation belongs to `scope` before inserting.
   """
-  def append_display_message(conversation_id, attrs) do
-    conversation_id
-    |> DisplayMessage.create_changeset(attrs)
-    |> Repo.insert()
+  def append_display_message(%Scope{} = scope, conversation_id, attrs) do
+    with :ok <- authorize_conversation(scope, conversation_id) do
+      conversation_id
+      |> DisplayMessage.create_changeset(attrs)
+      |> Repo.insert()
+    end
   end
 
   @doc """
   Loads display messages for a conversation, ordered chronologically.
 
+  Verifies the conversation belongs to `scope` before querying.
+
   ## Options
 
     * `:limit` - Maximum number of messages to return (default: all)
   """
-  def load_display_messages(conversation_id, opts \\ []) do
-    query =
-      DisplayMessage
-      |> where([m], m.conversation_id == ^conversation_id)
-      |> order_by([m], [asc: m.inserted_at, asc: m.sequence])
+  def load_display_messages(%Scope{} = scope, conversation_id, opts \\ []) do
+    case authorize_conversation(scope, conversation_id) do
+      :ok ->
+        query =
+          DisplayMessage
+          |> where([m], m.conversation_id == ^conversation_id)
+          |> order_by([m], [asc: m.inserted_at, asc: m.sequence])
 
-    query =
-      case Keyword.get(opts, :limit) do
-        nil -> query
-        limit -> limit(query, ^limit)
-      end
+        query =
+          case Keyword.get(opts, :limit) do
+            nil -> query
+            limit -> limit(query, ^limit)
+          end
 
-    Repo.all(query)
+        Repo.all(query)
+
+      {:error, :not_found} ->
+        []
+    end
   end
 
   #
@@ -251,54 +243,35 @@ defmodule <%= @context_module %> do
   #
 
   @doc """
-  Appends a text message to the conversation.
-
-  ## Parameters
-
-    * `conversation_id` - The conversation ID
-    * `message_type` - The message type ("user", "assistant", "tool", "system")
-    * `text` - The text content
-
-  ## Examples
-
-      append_text_message(convo_id, "user", "Hello!")
-      append_text_message(convo_id, "assistant", "How can I help?")
+  Appends a text message to the conversation, filtered by scope.
   """
-  def append_text_message(conversation_id, message_type, text) do
-    append_display_message(conversation_id, %{
+  def append_text_message(%Scope{} = scope, conversation_id, message_type, text) do
+    append_display_message(scope, conversation_id, %{
       message_type: message_type,
       content_type: "text",
       content: %{"text" => text}
     })
   end
 
+  #
+  # Tool call lifecycle
+  #
+
   @doc """
-  Updates a pending tool call message to "executing" status.
+  Updates a pending tool call message to "executing" status, scoped.
 
-  This is called when a tool begins execution, transitioning from "pending" to "executing".
-
-  ## Parameters
-    - call_id: The tool call ID (from content.call_id)
-
-  ## Returns
-    - {:ok, %DisplayMessage{}} on success
-    - {:error, :not_found} if no pending tool call with this call_id exists
-    - {:error, changeset} on validation failure
-
-  ## Example
-      iex> mark_tool_executing("call_123")
-      {:ok, %DisplayMessage{status: "executing", ...}}
+  Joins to Conversation to enforce tenant isolation — wrong-scope callers
+  receive `{:error, :not_found}`.
   """
-  @spec mark_tool_executing(String.t()) ::
+  @spec mark_tool_executing(Scope.t(), String.t()) ::
           {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def mark_tool_executing(call_id) do
-    query =
-      from m in DisplayMessage,
-        where: fragment("?->>'call_id' = ?", m.content, ^call_id),
-        where: m.content_type == "tool_call",
-        where: m.status == "pending"
-
-    case Repo.one(query) do
+  def mark_tool_executing(%Scope{} = scope, call_id) do
+    call_id
+    |> tool_call_query()
+    |> where([m], m.status == "pending")
+    |> scope_conversation_query(scope)
+    |> Repo.one()
+    |> case do
       nil ->
         {:error, :not_found}
 
@@ -310,34 +283,17 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Updates a tool call message to "completed" status and adds result metadata.
-
-  This is called when a tool successfully completes execution. Accepts tool calls in
-  either "pending" or "executing" status.
-
-  ## Parameters
-    - call_id: The tool call ID
-    - result_metadata: Map containing result information (e.g., %{"result" => "success"})
-
-  ## Returns
-    - {:ok, %DisplayMessage{}} on success
-    - {:error, :not_found} if no pending/executing tool call with this call_id exists
-    - {:error, changeset} on validation failure
-
-  ## Example
-      iex> complete_tool_call("call_123", %{"result" => "File written successfully"})
-      {:ok, %DisplayMessage{status: "completed", metadata: %{"result" => ...}}}
+  Updates a tool call message to "completed" status with result metadata, scoped.
   """
-  @spec complete_tool_call(String.t(), map()) ::
+  @spec complete_tool_call(Scope.t(), String.t(), map()) ::
           {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def complete_tool_call(call_id, result_metadata \\ %{}) do
-    query =
-      from m in DisplayMessage,
-        where: fragment("?->>'call_id' = ?", m.content, ^call_id),
-        where: m.content_type == "tool_call",
-        where: m.status in ["pending", "executing", "interrupted"]
-
-    case Repo.one(query) do
+  def complete_tool_call(%Scope{} = scope, call_id, result_metadata \\ %{}) do
+    call_id
+    |> tool_call_query()
+    |> where([m], m.status in ["pending", "executing", "interrupted"])
+    |> scope_conversation_query(scope)
+    |> Repo.one()
+    |> case do
       nil ->
         {:error, :not_found}
 
@@ -354,34 +310,17 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Updates a tool call message to "failed" status and adds error information.
-
-  This is called when a tool execution fails. Accepts tool calls in either "pending"
-  or "executing" status.
-
-  ## Parameters
-    - call_id: The tool call ID
-    - error_info: Map containing error details (e.g., %{"error" => "File not found"})
-
-  ## Returns
-    - {:ok, %DisplayMessage{}} on success
-    - {:error, :not_found} if no pending/executing tool call with this call_id exists
-    - {:error, changeset} on validation failure
-
-  ## Example
-      iex> fail_tool_call("call_123", %{"error" => "Permission denied"})
-      {:ok, %DisplayMessage{status: "failed", metadata: %{"error" => ...}}}
+  Updates a tool call message to "failed" status with error information, scoped.
   """
-  @spec fail_tool_call(String.t(), map()) ::
+  @spec fail_tool_call(Scope.t(), String.t(), map()) ::
           {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def fail_tool_call(call_id, error_info \\ %{}) do
-    query =
-      from m in DisplayMessage,
-        where: fragment("?->>'call_id' = ?", m.content, ^call_id),
-        where: m.content_type == "tool_call",
-        where: m.status in ["pending", "executing", "interrupted"]
-
-    case Repo.one(query) do
+  def fail_tool_call(%Scope{} = scope, call_id, error_info \\ %{}) do
+    call_id
+    |> tool_call_query()
+    |> where([m], m.status in ["pending", "executing", "interrupted"])
+    |> scope_conversation_query(scope)
+    |> Repo.one()
+    |> case do
       nil ->
         {:error, :not_found}
 
@@ -398,30 +337,17 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Updates a tool call message to "interrupted" status and adds interrupt information.
-
-  This is called when a tool execution is interrupted (e.g., sub-agent HITL).
-  Accepts tool calls in "pending" or "executing" status.
-
-  ## Parameters
-    - call_id: The tool call ID
-    - interrupt_info: Map containing interrupt details (e.g., %{"display_text" => "Sub-agent awaiting approval"})
-
-  ## Returns
-    - {:ok, %DisplayMessage{}} on success
-    - {:error, :not_found} if no pending/executing tool call with this call_id exists
-    - {:error, changeset} on validation failure
+  Updates a tool call message to "interrupted" status, scoped.
   """
-  @spec interrupt_tool_call(String.t(), map()) ::
+  @spec interrupt_tool_call(Scope.t(), String.t(), map()) ::
           {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def interrupt_tool_call(call_id, interrupt_info \\ %{}) do
-    query =
-      from m in DisplayMessage,
-        where: fragment("?->>'call_id' = ?", m.content, ^call_id),
-        where: m.content_type == "tool_call",
-        where: m.status in ["pending", "executing"]
-
-    case Repo.one(query) do
+  def interrupt_tool_call(%Scope{} = scope, call_id, interrupt_info \\ %{}) do
+    call_id
+    |> tool_call_query()
+    |> where([m], m.status in ["pending", "executing"])
+    |> scope_conversation_query(scope)
+    |> Repo.one()
+    |> case do
       nil ->
         {:error, :not_found}
 
@@ -438,27 +364,17 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Updates a tool call message to "cancelled" status.
-
-  Called when a tool execution (typically a sub-agent task) was abandoned because
-  the parent agent was cancelled. Accepts tool calls in "pending", "executing",
-  or "interrupted" status.
-
-  ## Returns
-    - {:ok, %DisplayMessage{}} on success
-    - {:error, :not_found} if no eligible tool call with this call_id exists
-    - {:error, changeset} on validation failure
+  Updates a tool call message to "cancelled" status, scoped.
   """
-  @spec cancel_tool_call(String.t()) ::
+  @spec cancel_tool_call(Scope.t(), String.t()) ::
           {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def cancel_tool_call(call_id) do
-    query =
-      from m in DisplayMessage,
-        where: fragment("?->>'call_id' = ?", m.content, ^call_id),
-        where: m.content_type == "tool_call",
-        where: m.status in ["pending", "executing", "interrupted"]
-
-    case Repo.one(query) do
+  def cancel_tool_call(%Scope{} = scope, call_id) do
+    call_id
+    |> tool_call_query()
+    |> where([m], m.status in ["pending", "executing", "interrupted"])
+    |> scope_conversation_query(scope)
+    |> Repo.one()
+    |> case do
       nil ->
         {:error, :not_found}
 
@@ -470,33 +386,23 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Records an HITL decision (approved/rejected) on a tool call display message.
+  Records an HITL decision (approved/rejected) on a tool call display message, scoped.
 
-  Adds `"hitl_decision"` to the tool call's metadata so the UI can display
-  a discreet indicator of what the user decided. The metadata persists through
-  subsequent status transitions (executing → completed/failed) since those
-  operations merge metadata.
-
-  ## Parameters
-    - call_id: The tool call ID
-    - decision: "approved" or "rejected"
-
-  ## Returns
-    - {:ok, %DisplayMessage{}} on success
-    - {:error, :not_found} if no tool call with this call_id exists
-    - {:error, changeset} on validation failure
+  Adds `"hitl_decision"` to the tool call's metadata so the UI can display a
+  discreet indicator of what the user decided. The metadata persists through
+  subsequent status transitions since those operations merge metadata. Also stamps
+  the matching tool_result message when one exists.
   """
-  @spec record_hitl_decision(String.t(), String.t()) ::
+  @spec record_hitl_decision(Scope.t(), String.t(), String.t()) ::
           {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def record_hitl_decision(call_id, decision) when decision in ["approved", "rejected"] do
-    # Update tool_call display message metadata
-    tool_call_query =
-      from m in DisplayMessage,
-        where: fragment("?->>'call_id' = ?", m.content, ^call_id),
-        where: m.content_type == "tool_call"
-
+  def record_hitl_decision(%Scope{} = scope, call_id, decision)
+      when decision in ["approved", "rejected"] do
     result =
-      case Repo.one(tool_call_query) do
+      call_id
+      |> tool_call_query()
+      |> scope_conversation_query(scope)
+      |> Repo.one()
+      |> case do
         nil ->
           {:error, :not_found}
 
@@ -508,13 +414,11 @@ defmodule <%= @context_module %> do
           |> Repo.update()
       end
 
-    # Also stamp the matching tool_result display message content
-    tool_result_query =
-      from m in DisplayMessage,
-        where: fragment("?->>'tool_call_id' = ?", m.content, ^call_id),
-        where: m.content_type == "tool_result"
-
-    case Repo.one(tool_result_query) do
+    call_id
+    |> tool_result_query()
+    |> scope_conversation_query(scope)
+    |> Repo.one()
+    |> case do
       nil ->
         :ok
 
@@ -530,31 +434,17 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Resolves an interrupted tool result display message after a sub-agent resumes.
-
-  Finds a tool_result display message matching the given tool_call_id where
-  is_interrupt is true in the content JSON, and updates it to clear the interrupt
-  flag and replace the content with the actual result.
-
-  ## Parameters
-    - tool_call_id: The tool call ID to find the matching tool result
-    - result_content: The actual result content string to replace the interrupt placeholder
-
-  ## Returns
-    - {:ok, %DisplayMessage{}} on success
-    - {:error, :not_found} if no matching interrupted tool result exists
-    - {:error, changeset} on validation failure
+  Resolves an interrupted tool result display message after a sub-agent resumes, scoped.
   """
-  @spec resolve_interrupted_tool_result(String.t(), String.t()) ::
+  @spec resolve_interrupted_tool_result(Scope.t(), String.t(), String.t()) ::
           {:ok, DisplayMessage.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def resolve_interrupted_tool_result(tool_call_id, result_content) do
-    query =
-      from m in DisplayMessage,
-        where: fragment("?->>'tool_call_id' = ?", m.content, ^tool_call_id),
-        where: m.content_type == "tool_result",
-        where: fragment("(?->>'is_interrupt')::boolean = true", m.content)
-
-    case Repo.one(query) do
+  def resolve_interrupted_tool_result(%Scope{} = scope, tool_call_id, result_content) do
+    tool_call_id
+    |> tool_result_query()
+    |> where([m], fragment("(?->>'is_interrupt')::boolean = true", m.content))
+    |> scope_conversation_query(scope)
+    |> Repo.one()
+    |> case do
       nil ->
         {:error, :not_found}
 
@@ -571,17 +461,9 @@ defmodule <%= @context_module %> do
   end
 
   @doc """
-  Searches message content across all types.
-
-  Requires scope for security. Searches within all conversations
-  accessible to the given scope.
-
-  ## Examples
-
-      search_messages(scope, "quarterly report")
+  Searches message content across all types, within the scope's conversations.
   """
   def search_messages(%Scope{} = scope, search_term) do
-    # Extract owner field from scope for security
     owner_id = get_owner_id(scope)
 
     from(m in DisplayMessage,
@@ -597,40 +479,70 @@ defmodule <%= @context_module %> do
   # Private Helpers
   #
 
-  # TODO: Customize this based on YOUR scope struct fields
+  # Scope the primary Conversation table.
   #
-  # Example implementations:
+  # CUSTOMIZE based on YOUR scope struct fields:
   #
   # Single-user scope:
-  # defp scope_query(query, %Scope{user_id: user_id}) do
-  #   from q in query, where: q.<%= @owner_field %> == ^user_id
-  # end
+  #   defp scope_query(query, %Scope{user_id: user_id}) do
+  #     from q in query, where: q.<%= @owner_field %> == ^user_id
+  #   end
   #
   # Multi-tenant (organization):
-  # defp scope_query(query, %Scope{organization_id: org_id}) do
-  #   from q in query, where: q.organization_id == ^org_id
-  # end
-  #
-  # Team-based:
-  # defp scope_query(query, %Scope{team_id: team_id}) do
-  #   from q in query, where: q.team_id == ^team_id
-  # end
-  #
+  #   defp scope_query(query, %Scope{organization_id: org_id}) do
+  #     from q in query, where: q.organization_id == ^org_id
+  #   end
   defp scope_query(query, %Scope{} = scope) do
-    # CUSTOMIZE THIS: Use your scope's actual fields
     owner_id = get_owner_id(scope)
     from q in query, where: q.<%= @owner_field %> == ^owner_id
+  end
+
+  # Scope a query that has already joined to Conversation. Applies the tenant
+  # filter to the joined `c` binding instead of the primary binding.
+  defp scope_conversation_query(query, %Scope{} = scope) do
+    owner_id = get_owner_id(scope)
+    from [_m, c] in query, where: c.<%= @owner_field %> == ^owner_id
+  end
+
+  # Base query for tool_call display messages by call_id. Callers refine with
+  # their own status predicate (or none) and pipe through scope_conversation_query/2
+  # to enforce tenant isolation.
+  defp tool_call_query(call_id) do
+    from m in DisplayMessage,
+      join: c in Conversation,
+      on: m.conversation_id == c.id,
+      where: fragment("?->>'call_id' = ?", m.content, ^call_id),
+      where: m.content_type == "tool_call"
+  end
+
+  # Base query for tool_result display messages by tool_call_id. Callers refine
+  # with additional predicates (e.g. is_interrupt) and pipe through
+  # scope_conversation_query/2 to enforce tenant isolation.
+  defp tool_result_query(tool_call_id) do
+    from m in DisplayMessage,
+      join: c in Conversation,
+      on: m.conversation_id == c.id,
+      where: fragment("?->>'tool_call_id' = ?", m.content, ^tool_call_id),
+      where: m.content_type == "tool_result"
+  end
+
+  # Authorization check: does this conversation belong to the given scope?
+  # Emits `SELECT 1 ... LIMIT 1` instead of hydrating the row, since the
+  # caller only needs a yes/no answer before proceeding with a write.
+  defp authorize_conversation(%Scope{} = scope, conversation_id) do
+    Conversation
+    |> scope_query(scope)
+    |> where([c], c.id == ^conversation_id)
+    |> Repo.exists?()
+    |> case do
+      true -> :ok
+      false -> {:error, :not_found}
+    end
   end
 
   # Extracts the owner ID from the scope struct.
   #
   # This default assumes your Scope has a `<%= @owner_type %>` field containing
-  # a struct with an `id` field. Customize if your Scope has a different structure:
-  #
-  # Examples:
-  # defp get_owner_id(%Scope{<%= @owner_type %>: <%= @owner_type %>}), do: <%= @owner_type %>.id  # struct with id
-  # defp get_owner_id(%Scope{<%= @owner_field %>: id}), do: id                    # direct ID field
-  # defp get_owner_id(%Scope{current_<%= @owner_field %>: id}), do: id            # current_ prefix
-  #
+  # a struct with an `id` field. Customize if your Scope has a different structure.
   defp get_owner_id(%Scope{<%= @owner_type %>: <%= @owner_type %>}), do: <%= @owner_type %>.id
 end

--- a/test/sagents/agent_server_message_preprocessor_test.exs
+++ b/test/sagents/agent_server_message_preprocessor_test.exs
@@ -9,7 +9,7 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
     @behaviour Sagents.MessagePreprocessor
 
     @impl true
-    def preprocess(message, _context) do
+    def preprocess(_scope, message, _context) do
       {:ok, message, message}
     end
   end
@@ -18,7 +18,7 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
     @behaviour Sagents.MessagePreprocessor
 
     @impl true
-    def preprocess(_message, _context) do
+    def preprocess(_scope, _message, _context) do
       display_msg = Message.new_user!("[display] original")
       llm_msg = Message.new_user!("[llm] original")
       {:ok, display_msg, llm_msg}
@@ -29,7 +29,7 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
     @behaviour Sagents.MessagePreprocessor
 
     @impl true
-    def preprocess(_message, _context) do
+    def preprocess(_scope, _message, _context) do
       {:error, :message_rejected}
     end
   end
@@ -38,9 +38,9 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
     @behaviour Sagents.MessagePreprocessor
 
     @impl true
-    def preprocess(message, context) do
-      # Send context to the registered test process
-      send(context.tool_context[:test_pid], {:preprocessor_context, context})
+    def preprocess(scope, message, context) do
+      # Send scope + context to the registered test process
+      send(context.tool_context[:test_pid], {:preprocessor_context, scope, context})
       {:ok, message, message}
     end
   end
@@ -49,7 +49,7 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
     @behaviour Sagents.MessagePreprocessor
 
     @impl true
-    def preprocess(_message, _context) do
+    def preprocess(_scope, _message, _context) do
       raise "preprocessor crashed"
     end
   end
@@ -58,7 +58,7 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
     @behaviour Sagents.DisplayMessagePersistence
 
     @impl true
-    def save_message(_conversation_id, message) do
+    def save_message(_scope, message, _context) do
       # Use the process dictionary to find the test pid
       # (set by the test before starting the server)
       if pid = Process.get(:test_pid) do
@@ -69,20 +69,22 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
     end
 
     @impl true
-    def update_tool_status(_status, _info), do: {:ok, nil}
+    def update_tool_status(_scope, _status, _info, _context), do: {:ok, nil}
   end
 
   defp create_agent(agent_id, opts \\ []) do
     {:ok, model} = ChatOpenAI.new(%{model: "gpt-4", api_key: "test-key"})
 
     tool_context = Keyword.get(opts, :tool_context, %{})
+    scope = Keyword.get(opts, :scope)
 
     {:ok, agent} =
       Agent.new(%{
         agent_id: agent_id,
         model: model,
         base_system_prompt: "You are helpful",
-        tool_context: tool_context
+        tool_context: tool_context,
+        scope: scope
       })
 
     agent
@@ -192,9 +194,10 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
   end
 
   describe "preprocessor context" do
-    test "receives agent_id, conversation_id, tool_context, and state" do
-      tool_context = %{current_scope: {:user, 42}, custom_key: "value", test_pid: self()}
-      agent = create_agent("ctx-1", tool_context: tool_context)
+    test "receives scope as first arg plus agent_id, conversation_id, tool_context, and state" do
+      tool_context = %{custom_key: "value", test_pid: self()}
+      scope = {:user, 42}
+      agent = create_agent("ctx-1", tool_context: tool_context, scope: scope)
 
       {:ok, _pid} =
         AgentServer.start_link(
@@ -207,11 +210,12 @@ defmodule Sagents.AgentServerMessagePreprocessorTest do
       msg = Message.new_user!("Hello")
       :ok = GenServer.call(AgentServer.get_name("ctx-1"), {:add_message, msg})
 
-      assert_received {:preprocessor_context, context}
+      assert_received {:preprocessor_context, received_scope, context}
+      assert received_scope == {:user, 42}
       assert context.agent_id == "ctx-1"
       assert context.conversation_id == "conv-5"
-      assert context.tool_context.current_scope == {:user, 42}
       assert context.tool_context.custom_key == "value"
+      refute Map.has_key?(context.tool_context, :current_scope)
       assert %State{} = context.state
 
       AgentServer.stop("ctx-1")

--- a/test/sagents/agent_server_test.exs
+++ b/test/sagents/agent_server_test.exs
@@ -974,15 +974,16 @@ defmodule Sagents.AgentServerTest do
 
       assert AgentServer.get_status(agent_id) == :idle
 
-      # Verify persistence was called with :on_completion context
+      # Verify persistence was called with :on_completion lifecycle
       calls = TestAgentPersistence.get_calls_for(agent_id)
 
       completion_call =
-        Enum.find(calls, fn {_id, _data, ctx} -> ctx == :on_completion end)
+        Enum.find(calls, fn {_id, _scope, _data, ctx} -> ctx.lifecycle == :on_completion end)
 
       assert completion_call != nil
-      {persisted_agent_id, persisted_state_data, :on_completion} = completion_call
+      {persisted_agent_id, _scope, persisted_state_data, ctx} = completion_call
       assert persisted_agent_id == agent_id
+      assert ctx.lifecycle == :on_completion
       assert persisted_state_data["version"] == 1
       assert persisted_state_data["state"] != nil
     end
@@ -1041,15 +1042,16 @@ defmodule Sagents.AgentServerTest do
 
       assert AgentServer.get_status(agent_id) == :idle
 
-      # Verify persistence was called with :on_completion context for resume 3-tuple
+      # Verify persistence was called with :on_completion lifecycle for resume 3-tuple
       calls = TestAgentPersistence.get_calls_for(agent_id)
 
       completion_call =
-        Enum.find(calls, fn {_id, _data, ctx} -> ctx == :on_completion end)
+        Enum.find(calls, fn {_id, _scope, _data, ctx} -> ctx.lifecycle == :on_completion end)
 
       assert completion_call != nil
-      {persisted_agent_id, persisted_state_data, :on_completion} = completion_call
+      {persisted_agent_id, _scope, persisted_state_data, ctx} = completion_call
       assert persisted_agent_id == agent_id
+      assert ctx.lifecycle == :on_completion
       assert persisted_state_data["version"] == 1
     end
   end

--- a/test/sagents/sub_agent_tool_context_test.exs
+++ b/test/sagents/sub_agent_tool_context_test.exs
@@ -96,9 +96,11 @@ defmodule Sagents.SubAgentToolContextTest do
 
       assert %State{} = ctx.state
       assert is_list(ctx.parent_middleware)
-      # Only internal keys present (including :tool_context which holds the empty map)
-      assert Map.keys(ctx) |> Enum.sort() == [:parent_middleware, :state, :tool_context]
+      # Only internal keys present (including :tool_context which holds the empty map,
+      # and :scope which defaults to nil when no scope is supplied).
+      assert Map.keys(ctx) |> Enum.sort() == [:parent_middleware, :scope, :state, :tool_context]
       assert ctx.tool_context == %{}
+      assert ctx.scope == nil
     end
   end
 

--- a/test/support/test_agent_persistence.ex
+++ b/test/support/test_agent_persistence.ex
@@ -5,6 +5,9 @@ defmodule Sagents.TestAgentPersistence do
   Before use, call `setup/0` in your test setup to create the ETS table.
   After the test, call `get_calls/0` or `get_calls_for/1` to inspect what was persisted.
 
+  Records each call as `{agent_id, scope, state_data, context}`. The `context` is
+  the full callback-context map including `:lifecycle`.
+
   ## Usage
 
       setup do
@@ -17,7 +20,7 @@ defmodule Sagents.TestAgentPersistence do
         # ... trigger execution ...
 
         calls = Sagents.TestAgentPersistence.get_calls()
-        assert Enum.any?(calls, fn {_id, _data, ctx} -> ctx == :on_completion end)
+        assert Enum.any?(calls, fn {_id, _scope, _data, ctx} -> ctx.lifecycle == :on_completion end)
       end
   """
 
@@ -39,7 +42,8 @@ defmodule Sagents.TestAgentPersistence do
   end
 
   @doc """
-  Returns all recorded persistence calls as a list of `{agent_id, state_data, context}` tuples.
+  Returns all recorded persistence calls as a list of
+  `{agent_id, scope, state_data, context}` tuples.
   """
   def get_calls do
     :ets.tab2list(@table_name)
@@ -61,13 +65,13 @@ defmodule Sagents.TestAgentPersistence do
   end
 
   @impl true
-  def persist_state(agent_id, state_data, context) do
-    :ets.insert(@table_name, {agent_id, state_data, context})
+  def persist_state(scope, state_data, context) do
+    :ets.insert(@table_name, {context.agent_id, scope, state_data, context})
     :ok
   end
 
   @impl true
-  def load_state(_agent_id) do
+  def load_state(_scope, _context) do
     {:error, :not_found}
   end
 end

--- a/test/support/test_display_message_persistence.ex
+++ b/test/support/test_display_message_persistence.ex
@@ -8,13 +8,13 @@ defmodule Sagents.TestDisplayMessagePersistence do
   @behaviour Sagents.DisplayMessagePersistence
 
   @impl true
-  def save_message(_conversation_id, %LangChain.Message{} = message) do
+  def save_message(_scope, %LangChain.Message{} = message, _context) do
     display_data = Sagents.TestingHelpers.message_to_display_data(message)
     {:ok, [display_data]}
   end
 
   @impl true
-  def update_tool_status(_status, _tool_info) do
+  def update_tool_status(_scope, _status, _tool_info, _context) do
     {:error, :not_found}
   end
 end
@@ -27,12 +27,12 @@ defmodule Sagents.TestDisplayMessagePersistenceRaising do
   @behaviour Sagents.DisplayMessagePersistence
 
   @impl true
-  def save_message(_conversation_id, _message) do
+  def save_message(_scope, _message, _context) do
     raise "Simulated persistence error"
   end
 
   @impl true
-  def update_tool_status(_status, _tool_info) do
+  def update_tool_status(_scope, _status, _tool_info, _context) do
     {:error, :not_found}
   end
 end
@@ -51,7 +51,7 @@ defmodule Sagents.TestDisplayMessagePersistenceForwarding do
   end
 
   @impl true
-  def save_message(_conversation_id, %LangChain.Message{} = message) do
+  def save_message(_scope, %LangChain.Message{} = message, _context) do
     display_items = Sagents.Message.DisplayHelpers.extract_display_items(message)
     pid = :persistent_term.get({__MODULE__, :test_pid})
     send(pid, {:saved_message, message, display_items})
@@ -59,7 +59,7 @@ defmodule Sagents.TestDisplayMessagePersistenceForwarding do
   end
 
   @impl true
-  def update_tool_status(_status, _tool_info) do
+  def update_tool_status(_scope, _status, _tool_info, _context) do
     {:error, :not_found}
   end
 end


### PR DESCRIPTION
## Problem

Sagents already adopted the Phoenix Scope pattern as its design intent: the setup generator takes a `--scope` flag, generated `Conversations` modules document "every function takes a `%Scope{}` as its first argument," and LiveView-facing code paths (create/list/get/delete) honor that contract. But agent-initiated code paths — AgentServer state snapshots, display-message writes, tool-call lifecycle updates — were generated without scope, leaving a trapdoor where the framework threaded tenant context inconsistently. Integrators ended up with a Conversations context that was mostly scope-safe but had a large gap for anything sagents initiated on its own.

This PR closes that gap by making scope a first-class argument everywhere it matters.

## Solution

1. **First-class `:scope` field on `Agent`.** A virtual field (not serialized) that sagents propagates to every surface that needs tenant context: persistence callbacks (as positional arg no. 1), tool-call `custom_context` (under the canonical `:scope` key), and downstream sub-agents.

2. **Scope-first callback contracts.** Every behaviour that plausibly performs a tenant-filtered operation takes `scope` as positional arg no. 1 (breaking):
   - `AgentPersistence.persist_state/3`, `load_state/2`
   - `DisplayMessagePersistence.save_message/3`, `update_tool_status/4`, `resolve_tool_result/4`
   - `FileSystemCallbacks.on_write/4`, `on_read/3`, `on_delete/3`, `on_list/2`
   - `MessagePreprocessor.preprocess/3`

   Positional (not map-nested) because scope is the only argument that must appear in the function body for the implementation to be correct. Remaining identifiers (agent_id, conversation_id, lifecycle) move into a trailing context map.

3. **Renames.** `:user_scope` → `:scope` (Coordinator) and `:parent_scope` → `:scope` (SubAgent). Both names were vestigial prefixes from an earlier migration. Sub-agents now auto-inherit from `agent.scope` when no explicit scope is passed.

4. **Generator templates regenerated.** Every emitted module (Coordinator, Factory, AgentPersistence, DisplayMessagePersistence, AgentLiveHelpers, and the Conversations context) threads scope through. The Conversations template is the largest rewrite, with ~14 functions growing a leading scope argument and category-appropriate enforcement (primary-table filter vs. join-based filter for call_id / tool_call_id lookups).

5. **Quality-of-life improvements in the Conversations template.** `authorize_conversation/2` uses `Repo.exists?/1` instead of hydrating full rows just to discard them. `tool_call_query/1` and `tool_result_query/1` base-query helpers eliminate duplicated `from/join/where` boilerplate across six tool-lifecycle functions.

## Changes

**Sagents library (breaking):**

- `lib/sagents/agent.ex` — Added `:scope` virtual field; auto-merges into `custom_context.scope` at chain-build time
- `lib/sagents/agent_server.ex` — Threads scope through five persistence call sites via new `current_scope/1` and `callback_context/1` helpers
- `lib/sagents/agent_supervisor.ex` — Uses `agent.scope` when loading state from DB; clarified comment on scope's child-spec carry-over behaviour
- `lib/sagents/agent_persistence.ex` — Callback signatures now take `scope` as arg 1; added `persist_context` and `load_context` types; moduledoc documents the scope-first contract
- `lib/sagents/display_message_persistence.ex` — Same scope-first treatment for all three callbacks
- `lib/sagents/file_system_callbacks.ex` — Same for `on_write` / `on_read` / `on_delete` / `on_list`
- `lib/sagents/message_preprocessor.ex` — `preprocess/3` takes scope as arg 1
- `lib/sagents/sub_agent.ex` — `:parent_scope` opt renamed to `:scope`, defaults to `agent.scope`
- `lib/sagents/middleware/sub_agent.ex` — Passes `scope:` (not `parent_scope:`) to SubAgent constructors

**Templates (regenerated for the new shape):**

- `priv/templates/coordinator.ex.eex` — `:user_scope` opt renamed to `:scope`; threads scope to Factory and `load_state/2`; doc clarifies that nil scope is allowed but tenant-scoped queries will have no owner to filter by
- `priv/templates/factory.ex.eex` — Accepts `:scope` opt and sets it on the returned Agent
- `priv/templates/agent_persistence.ex.eex` — Scope-first callback bodies; handles `{:error, :not_found}` for deleted or unauthorized conversations gracefully
- `priv/templates/display_message_persistence.ex.eex` — All five callback clauses take scope as arg 1
- `priv/templates/agent_live_helpers.ex.eex` — Threads scope through LiveView helpers
- `priv/templates/sagents.gen.persistence/context.ex.eex` — Largest single rewrite: 14+ Conversations functions grow a leading scope argument, with `scope_query/2` and `scope_conversation_query/2` enforcement helpers, a new `authorize_conversation/2` existence check, and `tool_call_query/1` / `tool_result_query/1` base-query helpers; scope-security moduledoc trimmed to the essentials

**Tests:**

- `test/sagents/agent_server_message_preprocessor_test.exs`, `test/sagents/agent_server_test.exs`, `test/sagents/sub_agent_tool_context_test.exs` — Updated to use new callback arities and opt names
- `test/support/test_agent_persistence.ex`, `test/support/test_display_message_persistence.ex` — Updated mock implementations for the new callback contracts

## Testing

Full suite passes: **1238 tests, 0 failures, 1 skipped.** The demo app (separate PR) exercises the generated code end-to-end through its Phoenix LiveView chat interface; its 325 tests also pass against this branch.