### PR TITLE
Update docs and templates for first-class scope channel

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -21,7 +21,7 @@ This separation means:
 ### What Gets Persisted
 
 ```elixir
-# State structure
+# State structure (stored as JSONB in agent_states.state_data)
 %State{
   agent_id: "conversation-123",     # Links to conversation
   messages: [...],                  # Full conversation history
@@ -43,29 +43,40 @@ This separation means:
   middleware: [...],                # Middleware stack
   tools: [...],                     # Additional tools
   base_system_prompt: "...",        # System prompt
-  callbacks: %{...}                 # Event callbacks
+  scope: %Scope{...}                # Tenant scope (session/runtime state; NOT persisted)
 }
 ```
+
+> **Note on scope:** `agent.scope` is session/runtime state belonging to the
+> caller who started the agent right now, not to the persisted conversation.
+> It is deliberately excluded from serialization. On restore, scope comes from
+> the fresh Coordinator invocation, not from anything loaded out of the
+> database. Never stash scope into `State.metadata` — that would leak across
+> sessions.
 
 ## Code Generator
 
 ### Basic Usage
 
 ```bash
-mix sagents.gen.persistence MyApp.Conversations
+mix sagents.setup MyApp.Conversations --scope MyApp.Accounts.Scope
 ```
 
 This generates:
-- `lib/my_app/conversations.ex` - Context module
-- `lib/my_app/conversations/conversation.ex` - Conversation schema
-- `lib/my_app/conversations/agent_state.ex` - State schema
-- `lib/my_app/conversations/display_message.ex` - UI message schema
-- `priv/repo/migrations/..._create_conversations.exs` - Migration
+- `lib/my_app/conversations.ex` — Context module (scope-filtered CRUD, display messages, tool-call lifecycle)
+- `lib/my_app/conversations/conversation.ex` — Conversation schema
+- `lib/my_app/conversations/agent_state.ex` — State schema
+- `lib/my_app/conversations/display_message.ex` — UI message schema
+- `lib/my_app/agents/factory.ex` — Agent factory (model + middleware)
+- `lib/my_app/agents/coordinator.ex` — Session management and agent lifecycle
+- `lib/my_app/agents/agent_persistence.ex` — `Sagents.AgentPersistence` implementation
+- `lib/my_app/agents/display_message_persistence.ex` — `Sagents.DisplayMessagePersistence` implementation
+- `priv/repo/migrations/..._create_sagents_tables.exs` — Migration
 
 ### With Options
 
 ```bash
-mix sagents.gen.persistence MyApp.Conversations \
+mix sagents.setup MyApp.Conversations \
   --scope MyApp.Accounts.Scope \
   --owner-type user \
   --owner-field user_id \
@@ -74,11 +85,14 @@ mix sagents.gen.persistence MyApp.Conversations \
 ```
 
 Options:
-- `--scope` - Application scope module (required)
-- `--owner-type` - Owner type (user, account, team, org, none)
-- `--owner-field` - Foreign key field name
-- `--owner-module` - Owner schema module
-- `--table-prefix` - Database table prefix
+- `--scope` — Application scope module (required)
+- `--owner-type` — Owner type (`user`, `account`, `team`, `org`, `none`)
+- `--owner-field` — Foreign key field name (default: `user_id`)
+- `--owner-module` — Owner schema module (inferred from `--owner-type` if omitted)
+- `--table-prefix` — Database table prefix (default: `sagents_`)
+- `--factory` / `--coordinator` / `--pubsub` / `--presence` — Module name overrides
+
+See `mix help sagents.setup` for the full option list.
 
 ## Generated Schemas
 
@@ -89,18 +103,21 @@ defmodule MyApp.Conversations.Conversation do
   use Ecto.Schema
 
   schema "sagents_conversations" do
-    field :title, :string
-    field :scope, :map  # {:user, 123} stored as %{"type" => "user", "id" => 123}
-
-    belongs_to :user, MyApp.Accounts.User
+    belongs_to :user, MyApp.Accounts.User, foreign_key: :user_id, type: :id
 
     has_one :agent_state, MyApp.Conversations.AgentState
     has_many :display_messages, MyApp.Conversations.DisplayMessage
 
-    timestamps()
+    field :title, :string
+    field :version, :integer, default: 1
+    field :metadata, :map, default: %{}
+
+    timestamps(type: :utc_datetime_usec)
   end
 end
 ```
+
+Tenant isolation is enforced through the owner foreign key (`user_id` by default) and the context's `scope_query/2` helper, not through a generic `:scope` column.
 
 ### AgentState
 
@@ -109,11 +126,12 @@ defmodule MyApp.Conversations.AgentState do
   use Ecto.Schema
 
   schema "sagents_agent_states" do
-    field :data, :map  # Serialized State struct
-
     belongs_to :conversation, MyApp.Conversations.Conversation
 
-    timestamps()
+    field :state_data, :map   # Serialized State struct (JSONB)
+    field :version, :integer
+
+    timestamps(type: :utc_datetime_usec)
   end
 end
 ```
@@ -125,39 +143,56 @@ defmodule MyApp.Conversations.DisplayMessage do
   use Ecto.Schema
 
   schema "sagents_display_messages" do
-    field :role, Ecto.Enum, values: [:user, :assistant, :tool, :system]
-    field :content, :string
-    field :metadata, :map  # Tool calls, token usage, etc.
-    field :sequence, :integer  # Ordering
-
     belongs_to :conversation, MyApp.Conversations.Conversation
 
-    timestamps()
+    field :message_type, :string      # "user", "assistant", "tool", "system"
+    field :content, :map              # Flexible JSONB storage
+    field :content_type, :string      # "text", "thinking", "image", "tool_call", etc.
+    field :sequence, :integer, default: 0
+    field :status, :string, default: "completed"
+    field :metadata, :map, default: %{}
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
   end
 end
 ```
 
+DisplayMessages are multi-content-type: one logical assistant turn can produce several rows (thinking + text + tool_call), ordered by `(inserted_at, sequence)`. See the schema's moduledoc for the valid `content_type` values and their expected `content` shapes.
+
 ## Context Module
 
-The generated context provides CRUD operations:
+The generated context provides scope-filtered CRUD. Every public function takes a `%Scope{}` as its first argument. Wrong-scope callers receive `{:error, :not_found}`.
 
 ```elixir
 defmodule MyApp.Conversations do
   # Conversation CRUD
   def create_conversation(scope, attrs)
   def get_conversation(scope, id)
+  def get_conversation!(scope, id)
   def update_conversation(conversation, attrs)
+  def delete_conversation(conversation)
   def delete_conversation(scope, id)
   def list_conversations(scope, opts \\ [])
+  def search_messages(scope, term)
 
   # Agent state
-  def save_agent_state(conversation_id, state)
-  def load_agent_state(conversation_id)
+  def save_agent_state(scope, conversation_id, state)
+  def load_agent_state(scope, conversation_id)
+  def load_todos(scope, conversation_id)
 
   # Display messages
-  def append_display_message(conversation_id, role, content, metadata \\ %{})
-  def load_display_messages(conversation_id)
-  def clear_display_messages(conversation_id)
+  def append_display_message(scope, conversation_id, attrs)
+  def append_text_message(scope, conversation_id, message_type, text)
+  def load_display_messages(scope, conversation_id, opts \\ [])
+
+  # Tool-call lifecycle
+  def mark_tool_executing(scope, call_id)
+  def complete_tool_call(scope, call_id, metadata)
+  def fail_tool_call(scope, call_id, error_info)
+  def interrupt_tool_call(scope, call_id, info)
+  def cancel_tool_call(scope, call_id)
+  def record_hitl_decision(scope, call_id, decision)
+  def resolve_interrupted_tool_result(scope, tool_call_id, content)
 end
 ```
 
@@ -166,158 +201,125 @@ end
 ### Creating a Conversation
 
 ```elixir
-# Get scope from current user
-scope = {:user, current_user.id}
+# scope is whatever your Scope module builds, typically from the caller's session
+scope = socket.assigns.current_scope
 
-# Create conversation
-{:ok, conversation} = MyApp.Conversations.create_conversation(scope, %{
-  title: "New Chat"
-})
-
-# Conversation is now ready for an agent
+{:ok, conversation} = MyApp.Conversations.create_conversation(scope, %{title: "New Chat"})
 ```
 
 ### Starting an Agent with Persistence
 
-```elixir
-defmodule MyApp.Agents.Coordinator do
-  def start_conversation_session(conversation_id) do
-    agent_id = "conversation-#{conversation_id}"
-
-    case AgentServer.whereis(agent_id) do
-      nil -> start_new_agent(agent_id, conversation_id)
-      pid -> {:ok, %{agent_id: agent_id, pid: pid}}
-    end
-  end
-
-  defp start_new_agent(agent_id, conversation_id) do
-    # Load or create state
-    initial_state = case Conversations.load_agent_state(conversation_id) do
-      {:ok, state} -> state
-      {:error, :not_found} -> State.new!()
-    end
-
-    # Create agent from code
-    {:ok, agent} = AgentFactory.create_agent(agent_id: agent_id)
-
-    # Start with auto-save
-    {:ok, pid} = AgentServer.start_link(
-      agent: agent,
-      initial_state: initial_state,
-      pubsub: {Phoenix.PubSub, MyApp.PubSub},
-      auto_save: [
-        callback: fn _id, state ->
-          Conversations.save_agent_state(conversation_id, state)
-        end,
-        interval: 30_000,
-        on_idle: true
-      ],
-      conversation_id: conversation_id,
-      save_new_message_fn: fn conv_id, message ->
-        Conversations.save_message(conv_id, message)
-      end
-    )
-
-    {:ok, %{agent_id: agent_id, pid: pid}}
-  end
-end
-```
-
-### Auto-Save Configuration
+The generated `Coordinator` module handles this end-to-end. You do not implement persistence wiring yourself — the Coordinator starts an `AgentSupervisor` with `:agent_persistence` and `:display_message_persistence` set to your generated behaviour implementations, and sagents threads scope through them.
 
 ```elixir
-AgentServer.start_link(
-  agent: agent,
-  auto_save: [
-    # Function called to save state
-    callback: fn agent_id, state ->
-      conversation_id = extract_conversation_id(agent_id)
-      Conversations.save_agent_state(conversation_id, state)
-    end,
+# In a LiveView handle_event
+filesystem_scope = {:user, socket.assigns.current_scope.user.id}
 
-    # Save interval (only if changed)
-    interval: 30_000,  # 30 seconds
+{:ok, session} =
+  MyApp.Agents.Coordinator.start_conversation_session(
+    conversation_id,
+    scope: socket.assigns.current_scope,
+    filesystem_scope: filesystem_scope
+  )
 
-    # Save when execution completes
-    on_idle: true,
-
-    # Save before shutdown
-    on_shutdown: true  # default: true
-  ]
-)
+# session = %{agent_id: "conversation-123", pid: pid, conversation_id: ...}
 ```
+
+Internally the Coordinator:
+1. Calls `AgentPersistence.load_state(scope, %{agent_id: ..., conversation_id: ...})` to restore saved state (or starts fresh on `{:error, :not_found}`).
+2. Creates the Agent via the Factory with `scope:` set on `agent.scope`.
+3. Starts the `AgentSupervisor` with `:agent_persistence` and `:display_message_persistence` configured.
+
+From that point, AgentServer invokes the callbacks automatically at the right lifecycle points — no callback-function wiring required at the call site.
+
+### How Persistence Callbacks Fire
+
+`AgentServer` holds the `:agent_persistence` and `:display_message_persistence` module references in its state. At each lifecycle point it calls the behaviour:
+
+| Trigger | Callback |
+|---------|----------|
+| Agent state should be snapshotted (idle, shutdown, post-interrupt) | `AgentPersistence.persist_state(scope, state_data, context)` |
+| New message produced (user, assistant, tool) | `DisplayMessagePersistence.save_message(scope, message, context)` |
+| Tool execution starts / completes / fails / interrupts / cancels | `DisplayMessagePersistence.update_tool_status(scope, status, tool_info, context)` |
+| Sub-agent resumes and produces the final tool result | `DisplayMessagePersistence.resolve_tool_result(scope, tool_call_id, content, context)` |
+
+In every callback, `scope` is the first positional argument — sourced from `server_state.agent.scope`. The `context` map carries `:agent_id`, `:conversation_id`, and (for `persist_state`) `:lifecycle`.
+
+See the moduledocs of `Sagents.AgentPersistence` and `Sagents.DisplayMessagePersistence` for the full behaviour contract.
 
 ### Manual Save
 
 ```elixir
-# Get current state
-state = AgentServer.export_state(agent_id)
+# Grab current serialized state (map; safe to store as JSONB)
+state_data = AgentServer.export_state(agent_id)
 
-# Save to database
-Conversations.save_agent_state(conversation_id, state)
+# Persist through your context, with the correct scope
+MyApp.Conversations.save_agent_state(scope, conversation_id, state_data)
 ```
 
-### Loading Conversations
+### Loading Conversations for UI
 
 ```elixir
 # List user's conversations
-conversations = Conversations.list_conversations(scope, [
-  order_by: [desc: :updated_at],
-  limit: 20
-])
+conversations =
+  MyApp.Conversations.list_conversations(scope, limit: 20, offset: 0)
 
-# Get specific conversation with messages
-conversation = Conversations.get_conversation(scope, id)
-display_messages = Conversations.load_display_messages(id)
+# Load a single conversation + messages
+conversation = MyApp.Conversations.get_conversation!(scope, id)
+display_messages = MyApp.Conversations.load_display_messages(scope, id)
+
+# Load just the todos (no need to start the agent)
+todos = MyApp.Conversations.load_todos(scope, id)
 ```
+
+If you try to load a conversation the scope doesn't own, `get_conversation/2` returns `{:error, :not_found}`, `get_conversation!/2` raises `Ecto.NoResultsError`, and `load_display_messages/3` returns `[]`.
 
 ## Display Messages
 
-Display messages are a UI-friendly representation of the conversation:
+Display messages are a UI-friendly representation of the conversation.
 
 ### Why Separate from State?
 
-1. **Performance**: Don't deserialize full state just to show message list
-2. **Flexibility**: Format content differently for UI vs LLM
-3. **History**: Keep display messages even if the Agent's internal state is summarized
+1. **Performance**: Don't deserialize full state just to show the message list.
+2. **Flexibility**: Multi-content-type rendering (thinking + text + image + tool_call as separate rows) that doesn't map cleanly to the LLM message shape.
+3. **History**: Keep display messages even if the agent's internal state is summarized.
 
 ### Saving Display Messages
 
+Saving is handled by the generated `DisplayMessagePersistence` module; AgentServer calls `save_message/3` on every new LangChain message. You don't wire this up — `mix sagents.setup` did.
+
+If you need to append a message manually (e.g., a system notification from a LiveView event):
+
 ```elixir
-# Configure callback when starting agent
-AgentServer.start_link(
-  agent: agent,
-  conversation_id: conversation_id,
-  save_new_message_fn: fn conv_id, message ->
-    # This is called for each message (user, assistant, tool)
-    # Returns {:ok, [saved_display_messages]} or {:error, reason}
-    Conversations.save_message(conv_id, message)
-  end
+# Via the convenience helper for text
+MyApp.Conversations.append_text_message(
+  scope,
+  conversation_id,
+  :assistant,
+  "Task complete."
 )
 
-# Or save manually based on events
-def handle_info({:agent, {:llm_message, message}}, socket) do
-  Conversations.append_display_message(
-    socket.assigns.conversation_id,
-    :assistant,
-    message.content,
-    %{token_usage: extract_usage(message)}
-  )
-  {:noreply, socket}
-end
+# Or with a full attrs map for other content types
+MyApp.Conversations.append_display_message(scope, conversation_id, %{
+  message_type: "assistant",
+  content_type: "text",
+  content: %{"text" => "Hi there!"},
+  metadata: %{"token_usage" => %{input: 12, output: 34}}
+})
 ```
 
 ### Loading for UI
 
 ```elixir
-def mount(%{"id" => id}, _session, socket) do
-  conversation = Conversations.get_conversation(scope, id)
-  messages = Conversations.load_display_messages(id)
+def handle_params(%{"conversation_id" => id}, _uri, socket) do
+  scope = socket.assigns.current_scope
+  conversation = MyApp.Conversations.get_conversation!(scope, id)
+  messages = MyApp.Conversations.load_display_messages(scope, id)
 
-  {:ok, assign(socket,
-    conversation: conversation,
-    messages: messages
-  )}
+  {:noreply,
+   socket
+   |> assign(:conversation, conversation)
+   |> stream(:messages, messages, reset: true)}
 end
 ```
 
@@ -326,27 +328,14 @@ end
 ### State Serialization
 
 ```elixir
-# State.to_serialized/1
+# State.to_serialized/1 produces a plain map (safe for JSONB)
 %{
   "messages" => [
-    %{
-      "role" => "user",
-      "content" => "Hello",
-      "metadata" => %{}
-    },
-    %{
-      "role" => "assistant",
-      "content" => "Hi there!",
-      "tool_calls" => [],
-      "metadata" => %{}
-    }
+    %{"role" => "user", "content" => "Hello", "metadata" => %{}},
+    %{"role" => "assistant", "content" => "Hi there!", "tool_calls" => [], "metadata" => %{}}
   ],
   "todos" => [
-    %{
-      "id" => "todo-1",
-      "content" => "Task description",
-      "status" => "completed"
-    }
+    %{"id" => "todo-1", "content" => "Task description", "status" => "completed"}
   ],
   "metadata" => %{
     "conversation_title" => "Greeting",
@@ -358,15 +347,14 @@ end
 ### State Deserialization
 
 ```elixir
-# State.from_serialized/2
 {:ok, state} = State.from_serialized(agent_id, serialized_data)
 ```
 
-The `agent_id` is required because it's not stored in the serialized data (it's the conversation's identity).
+The `agent_id` is required because it's not stored in the serialized data — it's the conversation's identity, supplied by the restoring caller.
 
 ### Custom Serialization
 
-Middleware can define custom serialization:
+Middleware can define custom serialization via `state_schema/0`:
 
 ```elixir
 defmodule MyMiddleware do
@@ -400,10 +388,11 @@ defmodule MyNewMiddleware do
   @impl true
   def before_model(state, _config) do
     # Initialize state if this middleware hasn't been used before
-    state = case State.get_metadata(state, :my_feature) do
-      nil -> State.put_metadata(state, :my_feature, default_value())
-      _ -> state
-    end
+    state =
+      case State.get_metadata(state, :my_feature) do
+        nil -> State.put_metadata(state, :my_feature, default_value())
+        _ -> state
+      end
 
     {:ok, state}
   end
@@ -413,10 +402,10 @@ end
 ```
 
 This approach is preferred because:
-- Migration logic lives with the middleware, not in persistence layer
-- No database migrations needed when adding middleware
-- Each middleware is responsible for its own defaults
-- Existing conversations seamlessly gain new capabilities
+- Migration logic lives with the middleware, not the persistence layer.
+- No database migrations needed when adding middleware.
+- Each middleware is responsible for its own defaults.
+- Existing conversations seamlessly gain new capabilities.
 
 ### Changing Middleware Configuration
 
@@ -446,107 +435,89 @@ The unused metadata has no effect on agent behavior and will naturally disappear
 
 ## Scope Pattern
 
-Scopes isolate data between users/organizations:
+Sagents uses the Phoenix `Scope` pattern. The integrator defines a scope struct; sagents treats it as opaque and passes it through as the first positional argument to every context function.
 
 ```elixir
 defmodule MyApp.Accounts.Scope do
-  defstruct [:type, :id]
+  alias MyApp.Accounts.User
 
-  def for_user(user) do
-    %__MODULE__{type: :user, id: user.id}
-  end
+  defstruct [:user, :org]
 
-  def for_org(org) do
-    %__MODULE__{type: :organization, id: org.id}
-  end
+  def for_user(%User{} = user), do: %__MODULE__{user: user}
+  def for_user_in_org(user, org), do: %__MODULE__{user: user, org: org}
 end
 ```
 
-Usage in context:
+The generated context contains a `scope_query/2` helper that turns a scope into an Ecto `where` clause. The default assumes your Scope has a field matching `--owner-type` (e.g., `:user`) with a struct containing an `:id`:
 
 ```elixir
-def list_conversations(%Scope{type: :user, id: user_id}, opts) do
-  Conversation
-  |> where([c], c.user_id == ^user_id)
-  |> order_by([c], desc: c.updated_at)
-  |> Repo.all()
+# Default generated implementation
+defp scope_query(query, %Scope{} = scope) do
+  owner_id = get_owner_id(scope)
+  from q in query, where: q.user_id == ^owner_id
 end
 
-def list_conversations(%Scope{type: :organization, id: org_id}, opts) do
-  Conversation
-  |> join(:inner, [c], u in User, on: c.user_id == u.id)
-  |> where([c, u], u.organization_id == ^org_id)
-  |> Repo.all()
+defp get_owner_id(%Scope{user: user}), do: user.id
+```
+
+Customize `scope_query/2` (and `scope_conversation_query/2` for queries already joined to Conversation) if your Scope has a different shape — for example, multi-tenant by organization:
+
+```elixir
+defp scope_query(query, %Scope{org: %{id: org_id}}) do
+  from q in query,
+    join: u in assoc(q, :user),
+    where: u.organization_id == ^org_id
 end
 ```
 
 ## Best Practices
 
-### 1. Always Use Scopes
+### 1. Always Pass Scope
 
 ```elixir
 # Good
 Conversations.get_conversation(scope, id)
+Conversations.load_display_messages(scope, id)
 
-# Bad - no authorization
+# Compiles but blows up at runtime — every generated function pattern-matches %Scope{}
 Conversations.get_conversation(id)
 ```
 
-### 2. Save on Completion
+### 2. Let the Generated Persistence Modules Do the Work
+
+`mix sagents.setup` wires `AgentPersistence` and `DisplayMessagePersistence` into the Coordinator for you. Agents started through the Coordinator get automatic state snapshots (on idle, on shutdown, post-interrupt) and message/tool-call persistence. You should rarely need to call `save_agent_state/3` directly.
+
+### 3. Handle Missing State Gracefully on Restore
+
+The generated `AgentPersistence.load_state/2` already returns `{:error, :not_found}` for both "no row exists" and "row exists but belongs to a different scope." Callers should treat both the same way:
 
 ```elixir
-# Configure auto-save with on_idle
-auto_save: [
-  callback: &save/2,
-  on_idle: true  # Save when agent becomes idle
-]
-```
-
-### 3. Handle Missing State Gracefully
-
-```elixir
-case Conversations.load_agent_state(id) do
-  {:ok, state} ->
-    # Restore conversation
+case Conversations.load_agent_state(scope, id) do
+  {:ok, state_data} ->
+    {:ok, state} = State.from_serialized(agent_id, state_data["state"])
     state
 
   {:error, :not_found} ->
-    # Fresh state - this is normal for new conversations
-    State.new!()
-
-  {:error, :deserialization_failed} ->
-    # Data corruption - log and start fresh
-    Logger.error("Failed to deserialize state for #{id}")
-    State.new!()
+    # Fresh state — normal for new conversations or wrong-scope access
+    State.new!(%{})
 end
 ```
 
-### 4. Keep Display Messages in Sync
-
-```elixir
-# In LiveView
-def handle_info({:agent, {:llm_message, message}}, socket) do
-  # Save to database
-  {:ok, display_msg} = Conversations.append_display_message(
-    socket.assigns.conversation_id,
-    :assistant,
-    message.content
-  )
-
-  # Update UI
-  {:noreply, update(socket, :messages, &(&1 ++ [display_msg]))}
-end
-```
-
-### 5. Clean Up Old Conversations
+### 4. Clean Up Old Conversations
 
 ```elixir
 # Periodic cleanup job
 def cleanup_old_conversations do
   cutoff = DateTime.add(DateTime.utc_now(), -30, :day)
 
-  Conversation
+  MyApp.Conversations.Conversation
   |> where([c], c.updated_at < ^cutoff)
   |> Repo.delete_all()
 end
 ```
+
+`AgentState` and `DisplayMessage` rows cascade-delete via the foreign-key constraint on `conversation_id` (the migration sets `on_delete: :delete_all`).
+
+### 5. Never Persist Scope
+
+`agent.scope` is excluded from serialization on purpose. If you find yourself reaching for `State.put_metadata(state, :scope, scope)` to "remember" it across restores, stop — that would leak scope across sessions. Scope must come from the fresh caller on every agent start, via `Coordinator.start_conversation_session(id, scope: current_scope, ...)`.

--- a/docs/tool_context_and_state.md
+++ b/docs/tool_context_and_state.md
@@ -60,6 +60,45 @@ end
 
 **Collision rule:** if `tool_context` contains a `:scope` key, sagents overrides it with `agent.scope` when building `custom_context`. Sagents owns that key. Don't put scope in `tool_context`.
 
+#### Keep scope lean
+
+The scope struct crosses process boundaries every time it reaches the Agent — LiveView process → Coordinator call → AgentServer GenServer → (for sub-agents) SubAgent processes → (for every tool invocation) the LLMChain's tool-call executor. In Erlang/Elixir, message passing between processes **copies** the term. A "scope" that embeds fully-loaded Ecto structs with preloaded associations (e.g., a `%User{}` with loaded `:organization`, `:memberships`, `:preferences`, `:api_keys`) gets copied in its entirety on every hop.
+
+For agents this cost adds up: a long-running conversation can cross those boundaries hundreds of times, and the BEAM has to copy the whole graph each time even if the tool only reads `scope.user.id`.
+
+If your application's Phoenix `Scope` is heavy, consider defining a **minimal agent-scoped struct** to pass to the agent instead of the full app scope:
+
+```elixir
+defmodule MyApp.Accounts.AgentScope do
+  @moduledoc """
+  Slim projection of `MyApp.Accounts.Scope` for passing to sagents.
+
+  Contains only the fields tool functions and persistence queries actually
+  read — not the full preloaded user graph.
+  """
+  defstruct [:user_id, :user_email, :org_id, :role]
+
+  def from_scope(%MyApp.Accounts.Scope{} = scope) do
+    %__MODULE__{
+      user_id: scope.user.id,
+      user_email: scope.user.email,
+      org_id: scope.org && scope.org.id,
+      role: scope.role
+    }
+  end
+end
+
+# At the LiveView / Coordinator call site:
+Coordinator.start_conversation_session(conversation_id,
+  scope: MyApp.Accounts.AgentScope.from_scope(socket.assigns.current_scope),
+  filesystem_scope: filesystem_scope
+)
+```
+
+Then your generated context's `scope_query/2` and `get_owner_id/1` helpers target fields on the slim struct (`scope.user_id`) instead of the full one (`scope.user.id`).
+
+This is *not* required — the default generated code assumes the full Phoenix Scope and works fine for most applications. It's worth doing when (a) your Scope preloads deep associations, (b) you run long conversations with many tool invocations, or (c) profiling shows scope-copy cost on hot paths. If in doubt, start with the full Scope and slim it down if it becomes a measured problem.
+
 ### `tool_context` -- Static, Caller-Supplied Grab-Bag
 
 `tool_context` is the integrator's own map of non-scope, caller-supplied data. It's for data that the agent's tools need but that doesn't have its own dedicated channel: feature flags, request-correlation IDs, a tenant-display-name to render in responses, etc.

--- a/docs/tool_context_and_state.md
+++ b/docs/tool_context_and_state.md
@@ -1,6 +1,6 @@
 # Tool Context and State: Passing Data to Tools
 
-This document explains how runtime data flows to tool functions in Sagents, the distinction between the two context channels, and how they behave across main agents and SubAgents.
+This document explains how runtime data flows to tool functions in Sagents, the three context channels a tool sees, and how they behave across main agents and SubAgents.
 
 ## Overview
 
@@ -13,42 +13,80 @@ fn args, context ->
 end
 ```
 
-The `context` map is built by the agent system and contains data from two distinct sources: **tool_context** and **state**. Understanding the difference is essential for writing tools that work correctly in both main agents and SubAgents.
+The `context` map is built by the agent system from three distinct sources: **scope**, **tool_context**, and **state**. Each has a different lifetime and a different purpose. Understanding them is essential for writing tools that work correctly in both main agents and SubAgents.
 
-## The Two Context Channels
+## The Three Context Channels
 
-### `tool_context` -- Static, External Environment
+### `scope` -- Tenant / Auth Identity (first-class)
 
-`tool_context` is caller-supplied data set once when the agent is created. It represents the environment the agent runs in -- which user, which project, which tenant. Think of it like environment variables for a process.
+`scope` is the integrator-defined struct (e.g. `%MyApp.Accounts.Scope{}`) that identifies *who* the agent is running on behalf of. It's the canonical channel for tenancy and authorization data and it has its own dedicated field on the Agent struct.
+
+```elixir
+# Set at agent creation time via the dedicated :scope key
+{:ok, agent} = Agent.new(%{
+  model: model,
+  scope: %MyApp.Accounts.Scope{user: current_user, org_id: 42}
+})
+```
+
+In practice, the Coordinator forwards scope from the LiveView socket to the Factory, which sets it on the Agent:
+
+```elixir
+# In Coordinator.start_conversation_session/2
+{:ok, agent} = Factory.create_agent(
+  agent_id: agent_id,
+  scope: scope,                     # <- dedicated channel, not tool_context
+  filesystem_scope: filesystem_scope,
+  tool_context: tool_context
+)
+```
+
+**Characteristics:**
+
+- First-class: `agent.scope` is a named field, not a magic key in a grab-bag.
+- Opaque to sagents: the library doesn't inspect its contents. The integrator defines what lives inside.
+- Not serialized: scope is session/runtime state, belonging to the *caller starting the agent right now*, not to the persisted conversation. On restore, scope comes from the fresh Coordinator invocation, not from anything loaded out of the database.
+- **Never stash scope in `State.metadata` or other persisted surfaces** — that would leak across sessions.
+- Sagents auto-merges `agent.scope` into the tool `custom_context` under the canonical top-level key `:scope`. Tool code reads `context.scope`.
+- The same scope is also passed as the *first positional argument* to persistence-behaviour callbacks (`persist_state/3`, `save_message/3`, etc.). Scope appears in the same shape at every layer.
+
+**Access pattern in tools:**
+
+```elixir
+fn _args, context ->
+  context.scope  #=> %MyApp.Accounts.Scope{user: %User{...}, org_id: 42}
+end
+```
+
+**Collision rule:** if `tool_context` contains a `:scope` key, sagents overrides it with `agent.scope` when building `custom_context`. Sagents owns that key. Don't put scope in `tool_context`.
+
+### `tool_context` -- Static, Caller-Supplied Grab-Bag
+
+`tool_context` is the integrator's own map of non-scope, caller-supplied data. It's for data that the agent's tools need but that doesn't have its own dedicated channel: feature flags, request-correlation IDs, a tenant-display-name to render in responses, etc.
 
 ```elixir
 # Set at agent creation time
 {:ok, agent} = Agent.new(%{
   model: model,
-  tool_context: %{user_id: 42, tenant: "acme", current_scope: scope}
+  scope: scope,                                    # tenant identity -- its own channel
+  tool_context: %{feature_flags: flags, tenant_name: "Acme"}
 })
 ```
 
-In practice, the Coordinator sets `tool_context` when starting a conversation session:
-
-```elixir
-# In Coordinator.start_conversation_session/2
-tool_context = Map.put(tool_context, :current_scope, user_scope)
-factory_opts = Keyword.put(opts, :tool_context, tool_context)
-```
-
 **Characteristics:**
-- Set once at agent creation, never changes during execution
-- Read-only from the tool's perspective
-- Merged flat into the `context` map -- accessed as top-level keys
-- Not persisted or serialized (it's a virtual field on the Agent struct)
+
+- Set once at agent creation, never changes during execution.
+- Read-only from the tool's perspective.
+- Merged flat into the `context` map — accessed as top-level keys.
+- Not persisted or serialized (virtual field on the Agent struct).
+- **Not for scope** — scope has its own channel. `tool_context` was the old transport; it is not any more.
 
 **Access pattern in tools:**
+
 ```elixir
 fn _args, context ->
-  context.user_id        #=> 42
-  context.tenant         #=> "acme"
-  context.current_scope  #=> %Scope{user: %User{...}}
+  context.feature_flags  #=> %{new_search: true}
+  context.tenant_name    #=> "Acme"
 end
 ```
 
@@ -57,6 +95,7 @@ end
 `state.metadata` is a mutable key-value store within the agent's `State` struct. Middleware and tools can read and write it during execution. It evolves over the lifetime of a conversation and is persisted across sessions.
 
 **Set by middleware during execution:**
+
 ```elixir
 # ConversationTitle middleware sets a title after generating one
 def after_model(state, _config) do
@@ -71,6 +110,7 @@ end
 ```
 
 **Set by tools returning updated state:**
+
 ```elixir
 function: fn _args, context ->
   updated_state = State.put_metadata(context.state, "last_search_query", query)
@@ -79,12 +119,14 @@ end
 ```
 
 **Characteristics:**
-- Mutable -- middleware and tools can read and write it
-- Evolves during agent execution
-- Persisted and restored across sessions via `StateSerializer`
-- Nested inside the `State` struct within `context`
+
+- Mutable — middleware and tools can read and write it.
+- Evolves during agent execution.
+- Persisted and restored across sessions via `StateSerializer`.
+- Nested inside the `State` struct within `context`.
 
 **Access pattern in tools:**
+
 ```elixir
 fn _args, context ->
   context.state.metadata["conversation_title"]  #=> "My Chat"
@@ -94,10 +136,10 @@ end
 
 ## The Full `context` Map
 
-When `Agent.build_chain` constructs the LLMChain, it builds `custom_context` by merging `tool_context` flat into the map alongside internal keys:
+When `Agent.build_chain` constructs the LLMChain, it merges the three channels (plus a few internal keys) into a single `custom_context`:
 
 ```elixir
-# From agent.ex ~line 730
+# From agent.ex
 custom_context =
   Map.merge(
     agent.tool_context || %{},
@@ -105,21 +147,27 @@ custom_context =
       state: state,
       parent_middleware: agent.middleware,
       parent_tools: agent.tools,
-      # The original map is preserved for clean SubAgent extraction
-      tool_context: agent.tool_context || %{}
+      # The original tool_context is preserved for clean SubAgent extraction
+      tool_context: agent.tool_context || %{},
+      # First-class scope channel -- sagents owns this key, so it always wins
+      # on collision with anything an integrator put in tool_context.
+      scope: agent.scope
     }
   )
 ```
 
-Internal keys (`:state`, `:parent_middleware`, `:parent_tools`, `:tool_context`) always take precedence on collision -- if your `tool_context` includes a key named `:state`, the internal `State` struct wins.
+Internal keys (`:state`, `:parent_middleware`, `:parent_tools`, `:tool_context`, `:scope`) always take precedence on collision — if your `tool_context` includes a key named `:scope` or `:state`, the internal value wins.
 
 A tool function sees:
 
 ```elixir
 fn args, context ->
-  # From tool_context (flat, top-level)
-  context.user_id            #=> 42
-  context.current_scope      #=> %Scope{...}
+  # From scope (flat, top-level, canonical)
+  context.scope              #=> %Scope{...}
+
+  # From tool_context (flat, top-level -- whatever the caller put in)
+  context.feature_flags      #=> %{new_search: true}
+  context.tenant_name        #=> "Acme"
 
   # From state (nested)
   context.state              #=> %State{agent_id: "...", metadata: %{...}, ...}
@@ -128,20 +176,18 @@ fn args, context ->
   # Internal (always present)
   context.parent_middleware  #=> [%MiddlewareEntry{}, ...]
   context.parent_tools       #=> [%Function{}, ...]
-  context.tool_context       #=> %{user_id: 42, ...} (original map, used by SubAgent middleware)
+  context.tool_context       #=> %{feature_flags: ..., tenant_name: "Acme"}
+                             #   (original map, used by SubAgent middleware)
 end
 ```
 
-> **Note:** The `:tool_context` key in `custom_context` holds the original tool_context map.
-> This is an internal detail used by the SubAgent middleware to cleanly extract and forward
-> tool_context to child agents. Tool functions should access their data via the flat keys
-> (e.g., `context.user_id`), not via `context.tool_context`.
+> **Note:** The `:tool_context` key in `custom_context` holds the original tool_context map (without scope). This is an internal detail used by SubAgent middleware to cleanly extract and forward tool_context to child agents. Tool functions should access their data via the flat keys (e.g., `context.feature_flags`), not via `context.tool_context`.
 
 ## Writing Tools That Work in Both Agents and SubAgents
 
-### Reading static environment data
+### Reading the tenant scope
 
-Use `tool_context` for data that comes from outside the agent system and doesn't change during execution:
+Scope is always at `context.scope`, regardless of whether the tool runs in a main agent or a SubAgent:
 
 ```elixir
 def build do
@@ -154,10 +200,24 @@ def build do
       required: ["id"]
     },
     function: fn %{"id" => id}, context ->
-      # tool_context key -- same in main agent and SubAgent
-      Projects.get_project(context.current_scope, id)
+      # Same access in main agent and SubAgent
+      Projects.get_project(context.scope, id)
     end
   })
+end
+```
+
+### Reading caller-supplied tool_context
+
+Use `tool_context` for data that comes from outside the agent system and doesn't change during execution:
+
+```elixir
+function: fn _args, context ->
+  if context.feature_flags[:new_search] do
+    new_search_impl()
+  else
+    legacy_search_impl()
+  end
 end
 ```
 
@@ -178,7 +238,7 @@ Tools can return an updated `State` as a third element in the result tuple:
 
 ```elixir
 function: fn %{"query" => query}, context ->
-  results = SearchService.search(query)
+  results = SearchService.search(context.scope, query)
   updated_state = State.put_metadata(context.state, "last_search", query)
   {:ok, format_results(results), updated_state}
 end
@@ -188,31 +248,37 @@ end
 
 | Use case | Channel | Example |
 |----------|---------|---------|
-| User identity / auth scope | `tool_context` | `context.current_scope` |
-| Tenant or project ID | `tool_context` | `context.tenant` |
+| User identity / auth / tenant | `scope` (dedicated) | `context.scope` |
+| Feature flags, request IDs, tenant display name | `tool_context` | `context.feature_flags` |
 | Conversation title | `state.metadata` | `context.state.metadata["conversation_title"]` |
 | Middleware tracking data | `state.metadata` | `context.state.metadata["debug_log.msg_count"]` |
 | Data a tool writes for later tools | `state.metadata` | `State.put_metadata(state, "key", val)` |
 
-**Rule of thumb:** If it's set by the caller and never changes, use `tool_context`. If it's set or updated during execution, use `state.metadata`.
+**Rules of thumb:**
+
+- Tenant identity → `:scope`. Always. It has its own channel because the whole system treats it specially (persistence callbacks see it as a positional arg, not a map key).
+- Caller-supplied but non-tenant → `:tool_context`. Set at creation, static across the agent's lifetime.
+- Set or updated during execution → `state.metadata`. Middleware publishes, tools read or write.
 
 ## SubAgent Context Propagation
 
-Both context channels should propagate from parent agent to SubAgent so that tools see the same data regardless of where they execute.
+All three channels should propagate from parent agent to SubAgent so that tools see the same data regardless of where they execute.
 
 ### How it works
 
-When the SubAgent middleware spawns a SubAgent, it extracts both channels from the parent's runtime context:
+When the SubAgent middleware spawns a SubAgent, it extracts each channel from the parent's runtime context:
 
-1. **`tool_context`** is stored as an explicit `:tool_context` key inside `custom_context` by `Agent.build_chain`. The SubAgent middleware reads this key directly (`context.tool_context`) and passes it to the SubAgent constructor, which merges it flat into the SubAgent's own `custom_context` and stores it again as `:tool_context` for further nesting.
-2. **`state.metadata`** is copied from the parent's `State` into the SubAgent's fresh `State`.
+1. **`scope`** is carried on the parent `agent.scope` field. The SubAgent middleware reads it (via the parent's `custom_context.scope`, which `Agent.build_chain` set) and assigns it to the SubAgent's own `agent.scope`. Sagents then re-merges it into the SubAgent's `custom_context` under the same canonical `:scope` key. Persistence callbacks on the SubAgent (if configured) see it as arg #1, same as the parent.
+2. **`tool_context`** is stored as an explicit `:tool_context` key inside the parent's `custom_context` by `Agent.build_chain`. The SubAgent middleware reads this key directly and passes it to the SubAgent constructor, which merges it flat into the SubAgent's own `custom_context` and stores it again as `:tool_context` for further nesting.
+3. **`state.metadata`** is copied from the parent's `State` into the SubAgent's fresh `State`.
 
-The SubAgent gets its own isolated `State` (fresh `agent_id`, empty messages, empty todos) but inherits the parent's metadata snapshot and tool_context. This preserves the structural distinction:
+The SubAgent gets its own isolated `State` (fresh `agent_id`, empty messages, empty todos) but inherits the parent's scope, tool_context, and metadata snapshot. This preserves the structural distinction:
 
 ```elixir
 # In a SubAgent tool -- same access patterns as main agent
 fn _args, context ->
-  context.user_id                              #=> 42 (from parent's tool_context)
+  context.scope                                #=> %Scope{...} (from parent's scope)
+  context.feature_flags                        #=> %{...} (from parent's tool_context)
   context.state.metadata["conversation_title"] #=> "My Chat" (from parent's metadata)
   context.state.agent_id                       #=> "parent-1-sub-12345" (SubAgent's own)
 end
@@ -220,8 +286,26 @@ end
 
 ### What does NOT propagate
 
-- **Messages**: SubAgents start with a fresh message history (system prompt + instructions only)
-- **Todos**: SubAgents have their own empty todo list
-- **Agent ID**: Each SubAgent gets a unique ID derived from the parent's
+- **Messages**: SubAgents start with a fresh message history (system prompt + instructions only).
+- **Todos**: SubAgents have their own empty todo list.
+- **Agent ID**: Each SubAgent gets a unique ID derived from the parent's.
 
-This ensures SubAgents are isolated execution units that share the parent's environment context but maintain their own conversational state.
+This ensures SubAgents are isolated execution units that share the parent's environment context (scope, tool_context, metadata) but maintain their own conversational state.
+
+## Migration Notes (from the pre-scope-channel API)
+
+Earlier versions of sagents used `tool_context[:current_scope]` as the convention for threading tenant scope into tool functions. That convention was upgraded to a first-class channel with its own Agent field and its own positional argument on persistence callbacks.
+
+If you wrote tools against the old pattern, here are the mechanical replacements:
+
+| Before | After |
+|--------|-------|
+| `tool_context: %{current_scope: scope, ...}` at agent creation | `scope: scope, tool_context: %{...}` (two separate keys) |
+| `Map.put(tool_context, :current_scope, user_scope)` in Coordinator | Pass `:scope` directly to Factory/Coordinator; drop the manual merge |
+| `context.current_scope` in tool function | `context.scope` |
+| `context.tool_context[:current_scope]` in MessagePreprocessor callback | `context.scope` (scope is now a top-level context key) |
+| `persist_state(agent_id, data, lifecycle)` callback | `persist_state(scope, data, context)` — scope is arg #1; `agent_id` and `lifecycle` are in the context map |
+| `save_message(conv_id, message)` callback | `save_message(scope, message, context)` — scope is arg #1; `conversation_id` is in the context map |
+| `Conversations.load_display_messages(conv_id)` | `Conversations.load_display_messages(scope, conv_id)` |
+
+The upgrade is a hard break — there are no deprecation shims. A grep for `current_scope` in your own code (excluding Phoenix's `socket.assigns.current_scope`, which is unrelated) should surface every call site that needs updating.

--- a/lib/mix/tasks/sagents/gen/live_helpers.ex
+++ b/lib/mix/tasks/sagents/gen/live_helpers.ex
@@ -31,9 +31,16 @@ defmodule Mix.Tasks.Sagents.Gen.LiveHelpers do
         {:ok, socket |> AgentLiveHelpers.init_agent_state() |> assign(...)}
       end
 
-      # In handle_params/3
+      # In handle_params/3 -- pass scope (required) and user_id (for presence)
       def handle_params(%{"conversation_id" => id}, _uri, socket) do
-        case AgentLiveHelpers.load_conversation(socket, id, scope: ...) do
+        current_scope = socket.assigns.current_scope
+
+        case AgentLiveHelpers.load_conversation(
+               socket,
+               id,
+               scope: current_scope,
+               user_id: current_scope.user.id
+             ) do
           {:ok, socket} -> {:noreply, socket}
           {:error, socket} -> {:noreply, push_navigate(socket, to: ~p"/chat")}
         end
@@ -252,7 +259,9 @@ defmodule Mix.Tasks.Sagents.Gen.LiveHelpers do
            * Customize message formatting or error handling as needed
            * The module is hardcoded with your context (#{config.context_module})
 
-        2. Integrate state management helpers:
+        2. Integrate state management helpers. `load_conversation/3` requires
+           a `:scope` — pass the Phoenix scope from the socket so that
+           every DB query and persistence callback is tenant-filtered.
 
            defmodule MyAppWeb.ChatLive do
              alias #{config.helper_module}
@@ -267,7 +276,14 @@ defmodule Mix.Tasks.Sagents.Gen.LiveHelpers do
              end
 
              def handle_params(%{"conversation_id" => id}, _uri, socket) do
-               case AgentLiveHelpers.load_conversation(socket, id, scope: ...) do
+               current_scope = socket.assigns.current_scope
+
+               case AgentLiveHelpers.load_conversation(
+                      socket,
+                      id,
+                      scope: current_scope,
+                      user_id: current_scope.user.id
+                    ) do
                  {:ok, socket} -> {:noreply, socket}
                  {:error, socket} -> {:noreply, push_navigate(socket, to: ~p"/chat")}
                end

--- a/lib/mix/tasks/sagents/setup.ex
+++ b/lib/mix/tasks/sagents/setup.ex
@@ -342,6 +342,18 @@ defmodule Mix.Tasks.Sagents.Setup do
            * Configure HITL in default_interrupt_on/0
            * Change model provider in get_model_config/0 if needed
 
+        5. Thread scope through from the caller. When starting a session:
+
+               #{config.coordinator_module}.start_conversation_session(
+                 conversation_id,
+                 scope: socket.assigns.current_scope,
+                 filesystem_scope: {:#{config.owner_type}, socket.assigns.current_scope.#{config.owner_type}.id}
+               )
+
+           Sagents propagates `:scope` to #{config.context_module} calls (as
+           the first positional argument) and into tool-call `context.scope`.
+           See the Coordinator moduledoc for the full integration pattern.
+
       Your Sagents infrastructure is configured for:
         - Owner type: :#{config.owner_type}
         - Owner field: #{config.owner_field}

--- a/priv/templates/coordinator.ex.eex
+++ b/priv/templates/coordinator.ex.eex
@@ -8,10 +8,12 @@ defmodule <%= module %> do
 
   ## Usage
 
-      # Start or resume a conversation agent with explicit filesystem scope
-      filesystem_scope = {:<%= owner_type %>, current_<%= owner_type %>.id}
+      # Start or resume a conversation agent. Pass the tenant scope and
+      # filesystem scope from the caller's session (e.g. a LiveView socket).
+      filesystem_scope = {:<%= owner_type %>, current_scope.<%= owner_type %>.id}
       {:ok, session} = <%= module %>.start_conversation_session(
         conversation_id,
+        scope: current_scope,
         filesystem_scope: filesystem_scope
       )
 
@@ -37,8 +39,6 @@ defmodule <%= module %> do
   **1. In mount/3 - Subscribe to agent events:**
 
       def mount(%{"conversation_id" => conversation_id}, _session, socket) do
-        <%= owner_type %>_id = socket.assigns.current_<%= owner_type %>.id
-
         if connected?(socket) do
           # Subscribe to agent events for real-time updates
           <%= module %>.ensure_subscribed_to_conversation(conversation_id)
@@ -51,11 +51,19 @@ defmodule <%= module %> do
 
       def handle_event("send_message", %{"message" => message_text}, socket) do
         conversation_id = socket.assigns.conversation_id
-        <%= owner_type %>_id = socket.assigns.current_<%= owner_type %>.id
-        filesystem_scope = {:<%= owner_type %>, <%= owner_type %>_id}
+        current_scope = socket.assigns.current_scope
+        filesystem_scope = {:<%= owner_type %>, current_scope.<%= owner_type %>.id}
 
-        # Start agent session with explicit filesystem scope
-        case <%= module %>.start_conversation_session(conversation_id, filesystem_scope: filesystem_scope) do
+        # Start agent session. Pass `:scope` so sagents can thread it through
+        # persistence callbacks (arg #1) and tool `context.scope`. Pass
+        # `:filesystem_scope` so FileSystem middleware operates on the right
+        # bucket. The two are independent — same owner, different purposes.
+        session_opts = [
+          scope: current_scope,
+          filesystem_scope: filesystem_scope
+        ]
+
+        case <%= module %>.start_conversation_session(conversation_id, session_opts) do
           {:ok, session} ->
             # Create and add message to agent
             message = Message.new_user!(message_text)
@@ -140,16 +148,18 @@ defmodule <%= module %> do
 
   ## Examples
 
-      # Standard usage - pass the filesystem scope explicitly
-      filesystem_scope = {:<%= owner_type %>, current_<%= owner_type %>.id}
+      # Standard usage - pass tenant scope and filesystem scope from the caller.
+      filesystem_scope = {:<%= owner_type %>, current_scope.<%= owner_type %>.id}
       {:ok, session} = <%= module %>.start_conversation_session(
         conversation_id,
+        scope: current_scope,
         filesystem_scope: filesystem_scope
       )
 
       # Custom inactivity timeout (30 minutes)
       {:ok, session} = <%= module %>.start_conversation_session(
         conversation_id,
+        scope: current_scope,
         filesystem_scope: {:<%= owner_type %>, <%= owner_field %>},
         inactivity_timeout: :timer.minutes(30)
       )
@@ -157,15 +167,19 @@ defmodule <%= module %> do
       # With custom factory options (e.g., for timezone-aware middleware)
       {:ok, session} = <%= module %>.start_conversation_session(
         conversation_id,
+        scope: current_scope,
         filesystem_scope: filesystem_scope,
         factory_opts: [timezone: "America/New_York"]
       )
 
-      # With caller context for tool functions
+      # With extra caller context for tool functions (scope is separate — don't
+      # stuff it into :tool_context). `:tool_context` is a grab-bag for
+      # non-scope data your own tools need.
       {:ok, session} = <%= module %>.start_conversation_session(
         conversation_id,
+        scope: current_scope,
         filesystem_scope: filesystem_scope,
-        tool_context: %{user_id: user_id, tenant: "acme"}
+        tool_context: %{feature_flags: flags, request_id: req_id}
       )
 
   """

--- a/priv/templates/coordinator.ex.eex
+++ b/priv/templates/coordinator.ex.eex
@@ -134,6 +134,10 @@ defmodule <%= module %> do
     queries downstream will have no owner to filter by. Set on the agent's `:scope`
     field via the Factory; sagents propagates it as the first positional argument to
     persistence callbacks and as `context.scope` to tool functions.
+    **Sizing note:** the scope struct is copied across process boundaries on every
+    hop (LiveView → AgentServer → tool invocations). If your Phoenix Scope preloads
+    heavy Ecto associations, consider passing a slim version instead. See
+    `sagents/docs/tool_context_and_state.md` ("Keep scope lean") for the pattern.
   - `:inactivity_timeout` - Milliseconds before agent stops (default: 10 minutes)
   - `:tool_context` - Map of caller-supplied data. Its entries become keys on
     the `context` map passed as the tool function's second argument. For example,

--- a/priv/templates/factory.ex.eex
+++ b/priv/templates/factory.ex.eex
@@ -108,7 +108,6 @@ defmodule <%= module %> do
     Pass `nil` to disable HITL entirely.
   - `:tool_context` - Optional. Map of caller-supplied data passed to tool functions
     via `LLMChain.custom_context`. Defaults to `%{}`. Example: `%{user_id: 42}`.
-    Scope is NOT stuffed here — it has its own `:scope` channel.
 
   ## Examples
 

--- a/priv/templates/sagents.gen.persistence/context.ex.eex
+++ b/priv/templates/sagents.gen.persistence/context.ex.eex
@@ -214,6 +214,7 @@ defmodule <%= @context_module %> do
   ## Options
 
     * `:limit` - Maximum number of messages to return (default: all)
+    * `:offset` - Number of messages to skip (default: 0)
   """
   def load_display_messages(%Scope{} = scope, conversation_id, opts \\ []) do
     case authorize_conversation(scope, conversation_id) do
@@ -227,6 +228,12 @@ defmodule <%= @context_module %> do
           case Keyword.get(opts, :limit) do
             nil -> query
             limit -> limit(query, ^limit)
+          end
+
+        query =
+          case Keyword.get(opts, :offset) do
+            nil -> query
+            offset -> offset(query, ^offset)
           end
 
         Repo.all(query)


### PR DESCRIPTION
## Problem

The previous major refactor (https://github.com/sagents-ai/sagents/pull/72) promoted `agent.scope` from a convention (`tool_context[:current_scope]`) to a first-class channel on the Agent struct with its own field. Documentation, generated templates, and setup task instructions still reflected the old pattern in several places, leaving generated code that pointed to `current_user.id` instead of `current_scope.user.id`, examples that stuffed scope into `tool_context`, and guides describing only two context channels instead of three.

A small regression was also introduced in the context template: the `:offset` query argument in `load_display_messages` was accidentally removed.

## Solution

Updates all developer-facing surfaces — docs, mix task output, generated templates — to be consistent with the post-refactor scope model. The library code itself is unchanged; this is a documentation and code-generation correctness pass.

`docs/tool_context_and_state.md` is the canonical reference for the three context channels (`scope`, `tool_context`, `state.metadata`). The doc now explains the "keep scope lean" recommendation (scope is copied across process boundaries on every hop), adds a SubAgent propagation section for scope, and closes with a migration table mapping every old pattern to the new equivalent.

`docs/persistence.md` is updated to match: command names, schema field names, context function signatures (all take `scope` as first arg), and best-practice section now includes "Never Persist Scope."

## Changes

- `docs/persistence.md` — Rewrote to match post-refactor API: `mix sagents.setup`, scope-first function signatures, updated schema examples (`state_data`, `utc_datetime_usec`, multi-content-type `DisplayMessage`), replaced manual auto-save wiring with generated persistence module explanation, added "Never Persist Scope" best practice
- `docs/tool_context_and_state.md` — Promoted from two to three context channels; documented `agent.scope` as first-class; added "Keep scope lean" guidance; added SubAgent scope propagation; added migration table for upgrading from `context.current_scope`
- `priv/templates/coordinator.ex.eex` — Template now passes `scope: current_scope` (not extracted `owner_id`), explains scope vs filesystem_scope distinction in comments, adds sizing note on scope copying
- `lib/mix/tasks/sagents/setup.ex` — Added step 5 to post-setup instructions: how to thread scope from the caller through `start_conversation_session`
- `lib/mix/tasks/sagents/gen/live_helpers.ex` — Generated LiveView examples now show `scope: current_scope, user_id: current_scope.user.id` pattern
- `priv/templates/factory.ex.eex` — Removed a now-redundant comment about scope not belonging in `tool_context`
- `priv/templates/sagents.gen.persistence/context.ex.eex` — Restored the accidentally removed `:offset` query arg in `load_display_messages`

## Testing

Documentation and template changes — no new runtime logic. The `:offset` fix restores a code path that existed before the prior refactor; verified by reading the original and post-change template diff.