### PR TITLE
Add optional debug_summary/1 callback to middleware behaviour

### DIFF
--- a/lib/sagents/middleware.ex
+++ b/lib/sagents/middleware.ex
@@ -342,6 +342,21 @@ defmodule Sagents.Middleware do
               | {:interrupt, State.t(), interrupt_data :: map()}
               | {:error, term()}
 
+  @doc """
+  Optional. Returns a debugger-friendly representation of this middleware's
+  runtime config, suitable for rendering in the live debugger's Middleware
+  tab.
+
+  Use this when your config holds large structures (compiled agents, caches,
+  big maps) that would dominate the inspect output and slow down the debugger
+  UI. Keep the result small — this is for human reading.
+
+  Return either a map (rendered as a key/value config table) or a string
+  (rendered verbatim in a code block). If not implemented, the debugger falls
+  back to inspecting the raw config map with bounded limits.
+  """
+  @callback debug_summary(middleware_config()) :: map() | String.t()
+
   @optional_callbacks [
     init: 1,
     system_prompt: 1,
@@ -352,7 +367,8 @@ defmodule Sagents.Middleware do
     state_schema: 0,
     on_server_start: 2,
     callbacks: 1,
-    handle_resume: 5
+    handle_resume: 5,
+    debug_summary: 1
   ]
 
   @doc """

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -289,6 +289,23 @@ defmodule Sagents.Middleware.SubAgent do
     end
   end
 
+  @impl true
+  def debug_summary(config) do
+    subagents =
+      Enum.map(config.agent_map, fn
+        {name, :dynamic} -> "#{name} (general-purpose, dynamic tool inheritance)"
+        {name, _agent_struct} -> name
+      end)
+
+    %{
+      subagents: subagents,
+      descriptions: config.descriptions,
+      block_middleware: config.block_middleware,
+      until_tool_map: config.until_tool_map,
+      has_use_instructions: not Enum.empty?(Map.get(config, :use_instructions_map, %{}))
+    }
+  end
+
   defp has_use_instructions?(config) when is_map(config) do
     config
     |> Map.get(:use_instructions_map, %{})

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -113,6 +113,78 @@ defmodule Sagents.Middleware.SubAgentTest do
     end
   end
 
+  describe "debug_summary/1" do
+    test "returns slim summary that omits the heavy agent_map" do
+      config1 = build_subagent_config("agent1", "First agent")
+      config2 = build_subagent_config("agent2", "Second agent")
+
+      opts = [
+        agent_id: "parent",
+        model: test_model(),
+        middleware: [],
+        subagents: [config1, config2]
+      ]
+
+      {:ok, middleware_config} = SubAgentMiddleware.init(opts)
+      summary = SubAgentMiddleware.debug_summary(middleware_config)
+
+      # Heavy field is dropped
+      refute Map.has_key?(summary, :agent_map)
+
+      # Slim fields are present
+      assert is_list(summary.subagents)
+      assert "agent1" in summary.subagents
+      assert "agent2" in summary.subagents
+
+      # general-purpose is annotated rather than rendered as a raw agent
+      assert Enum.any?(summary.subagents, &String.contains?(&1, "general-purpose"))
+      assert Enum.any?(summary.subagents, &String.contains?(&1, "dynamic tool inheritance"))
+
+      # Small descriptive fields pass through
+      assert summary.descriptions["agent1"] == "First agent"
+      assert summary.descriptions["agent2"] == "Second agent"
+      assert is_list(summary.block_middleware)
+      assert is_map(summary.until_tool_map)
+      assert summary.has_use_instructions == false
+    end
+
+    test "produces dramatically smaller output than raw inspect" do
+      # Build a config with 5 subagents — each agent_map entry is a full Agent
+      # struct with model + middleware. Without debug_summary the inspect output
+      # is huge; with it, the output is bounded by the slim shape.
+      configs =
+        for i <- 1..5 do
+          build_subagent_config("agent_#{i}", "Agent number #{i}")
+        end
+
+      opts = [
+        agent_id: "parent",
+        model: test_model(),
+        middleware: [],
+        subagents: configs
+      ]
+
+      {:ok, middleware_config} = SubAgentMiddleware.init(opts)
+
+      raw = inspect(middleware_config, limit: :infinity, printable_limit: :infinity)
+      summary_str = inspect(SubAgentMiddleware.debug_summary(middleware_config))
+
+      # The summary should be at least an order of magnitude smaller. In practice
+      # it's typically 50-100x smaller, but we use a conservative bound to avoid
+      # flakiness if the Agent struct shrinks.
+      assert byte_size(summary_str) * 10 < byte_size(raw),
+             "debug_summary should shrink output by >10x. raw=#{byte_size(raw)} summary=#{byte_size(summary_str)}"
+    end
+
+    test "callback is exported on the module" do
+      # Mirror the live debugger's check: ensure_loaded? + function_exported?.
+      # `function_exported?` alone returns false on unloaded modules, which is
+      # why the production guard combines both calls.
+      assert Code.ensure_loaded?(SubAgentMiddleware)
+      assert function_exported?(SubAgentMiddleware, :debug_summary, 1)
+    end
+  end
+
   describe "system_prompt/1" do
     test "returns guidance for using SubAgents" do
       prompt = SubAgentMiddleware.system_prompt(nil)


### PR DESCRIPTION
## Problem

When the [`sagents_live_debugger`](https://github.com/sagents-ai/sagents_live_debugger) opens an agent's **Middleware** tab, it inspects every middleware's runtime config map with `Kernel.inspect/2` and renders the result. For most middleware this is fine — the config is small. For [`Sagents.Middleware.SubAgent`](lib/sagents/middleware/sub_agent.ex) it isn't: the config holds an `agent_map` containing fully-built `%Sagents.Agent{}` structs (each with their own model, middleware stack, and tool functions). Inspecting that recursively serializes potentially a lot of data into the LiveView's HTML, and the tab can hang the page for seconds.

The same trap is open to any custom middleware that stashes a large structure (compiled agents, caches, big maps) in its config — the debugger has no way to know what's worth showing and what to skip. The middleware author is the only one who has that knowledge.

## Solution

Add an **optional** `debug_summary/1` callback to the [`Sagents.Middleware`](lib/sagents/middleware.ex) behaviour. Middleware modules can implement it to return a small, debugger-friendly representation of their runtime config — either a `map` (rendered as a key/value table) or a `String.t()` (rendered verbatim in a code block).

Implement the callback for `Sagents.Middleware.SubAgent`. The implementation drops the heavy `agent_map` and surfaces only what's useful for debugging: the list of configured sub-agent names (with `general-purpose` annotated as `\"… (general-purpose, dynamic tool inheritance)\"`), the descriptions map, the block-middleware list, the until-tool map, and a `has_use_instructions` boolean.

Because the callback is optional, this change is purely additive — existing middleware (in this repo or downstream) keeps compiling and behaving identically. The companion change in `sagents_live_debugger` calls the callback when exported and falls back to bounded `inspect/2` otherwise, so middleware that hasn't opted in is still safe.

## Changes

- [lib/sagents/middleware.ex](lib/sagents/middleware.ex) — Declared `@callback debug_summary(middleware_config()) :: map() | String.t()`, documented the contract (when to use it, what to return, what happens if not implemented), and added `debug_summary: 1` to `@optional_callbacks`.
- [lib/sagents/middleware/sub_agent.ex](lib/sagents/middleware/sub_agent.ex) — Implemented `debug_summary/1`. Iterates `agent_map` to produce a list of name strings (with the `:dynamic` marker turned into a human-readable annotation) and returns the slim five-key summary map.
- [test/sagents/middleware/sub_agent_test.exs](test/sagents/middleware/sub_agent_test.exs) — New `describe \"debug_summary/1\"` block with three tests: structural assertions on the returned shape, a size-bound check that the summary is at least 10× smaller than `inspect/2` of the full config, and an `ensure_loaded? + function_exported?` check that mirrors the production guard the debugger uses to discover the callback.

## Testing

- New unit tests in [test/sagents/middleware/sub_agent_test.exs](test/sagents/middleware/sub_agent_test.exs) cover the callback's return shape, its size reduction vs raw inspect, and the export-detection contract.
- `mix precommit` clean: 1262 tests, 0 failures, 1 skipped.
- The companion debugger-side change (bounded `inspect_for_display/1`, callback dispatch in `middleware_item/1`) lives in `sagents_live_debugger` and will be a separate PR there.