### PR TITLE
Move ProcessContext snapshot to state.runtime (virtual, non-serialized)

### DIFF
--- a/lib/sagents/middleware/process_context.ex
+++ b/lib/sagents/middleware/process_context.ex
@@ -68,8 +68,18 @@ defmodule Sagents.Middleware.ProcessContext do
   Use `update/1` to refresh it. The middleware already has the spec from
   `init/1`, so the caller only supplies the `agent_id`. Capture functions run
   in the *caller of* `update/1`, then the new snapshot replaces the stored
-  snapshot in the agent's `state.metadata` and is used for every subsequent
+  snapshot in the agent's `state.runtime` and is used for every subsequent
   boundary crossing.
+
+  ## Snapshot lives in `state.runtime`
+
+  The captured snapshot intentionally contains non-serializable values
+  (closures, OTel context tokens, PIDs, tuples). It is therefore stored under
+  `state.runtime[ProcessContext]`, a virtual field that `StateSerializer`
+  never persists. After process restart the snapshot is gone and
+  `on_server_start/2` re-captures from the new caller process — which is the
+  correct semantic, since a stale OTel/Sentry/tenant token would be wrong to
+  re-apply anyway.
 
       # In a LiveView, before relaying a new user message to the agent:
       Sagents.Middleware.ProcessContext.update(agent_id)
@@ -111,11 +121,12 @@ defmodule Sagents.Middleware.ProcessContext do
   @impl true
   def on_server_start(state, config) do
     # One-time bootstrap: copy the init-time capture from config into
-    # state.metadata. From here on, state.metadata is the only place the
-    # snapshot lives. If state.metadata already has a snapshot (restored
-    # from persisted state, or an update/1 message that landed before
-    # on_server_start), preserve it.
-    state = ensure_snapshot_in_metadata(state, config)
+    # state.runtime. From here on, state.runtime is the only place the
+    # snapshot lives. If state.runtime already has a snapshot (e.g. an
+    # update/1 message that landed before on_server_start), preserve it.
+    # Note: state.runtime is virtual and never restored from persistence,
+    # so a freshly-restored agent always falls through to the config copy.
+    state = ensure_snapshot_in_runtime(state, config)
     apply_snapshot(state)
     {:ok, state}
   end
@@ -134,8 +145,8 @@ defmodule Sagents.Middleware.ProcessContext do
 
   @impl true
   def handle_message({:update_context, %{keys: _, propagators: _} = snapshot}, state, _config) do
-    metadata = Map.put(state.metadata || %{}, ProcessContext, snapshot)
-    {:ok, %{state | metadata: metadata}}
+    runtime = Map.put(state.runtime || %{}, ProcessContext, snapshot)
+    {:ok, %{state | runtime: runtime}}
   end
 
   def handle_message(_message, state, _config), do: {:ok, state}
@@ -205,24 +216,24 @@ defmodule Sagents.Middleware.ProcessContext do
     }
   end
 
-  # state.metadata is the single source of truth for the live snapshot.
+  # state.runtime is the single source of truth for the live snapshot.
   # Bootstrap (`config.snapshot`) is copied in once by `on_server_start/2`;
   # all other reads — including the LangChain callback that fires inside the
-  # per-tool Task — go through state.metadata only.
-  defp ensure_snapshot_in_metadata(state, config) do
-    case state.metadata do
+  # per-tool Task — go through state.runtime only.
+  defp ensure_snapshot_in_runtime(state, config) do
+    case state.runtime do
       %{ProcessContext => _} ->
         state
 
-      metadata ->
-        %{state | metadata: Map.put(metadata || %{}, ProcessContext, config.snapshot)}
+      runtime ->
+        %{state | runtime: Map.put(runtime || %{}, ProcessContext, config.snapshot)}
     end
   end
 
   defp apply_snapshot(nil), do: :ok
 
   defp apply_snapshot(state) do
-    case state.metadata do
+    case state.runtime do
       %{ProcessContext => snapshot} -> do_apply(snapshot)
       _ -> :ok
     end

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -654,12 +654,14 @@ defmodule Sagents.Middleware.SubAgent do
         until_tool_map = Map.get(config, :until_tool_map, %{})
         until_tool = Map.get(until_tool_map, task_name)
 
-        # Extract parent's tool_context, metadata, and scope so SubAgent tools see the
-        # same context as parent tools. Agent.build_chain stores the original
-        # tool_context map as an explicit :tool_context key in custom_context, and
-        # scope under the canonical :scope key. Metadata is nested in state and copied
-        # into the SubAgent's fresh State.
-        {parent_tool_context, parent_metadata, parent_scope} = extract_parent_context(context)
+        # Extract parent's tool_context, metadata, runtime, and scope so
+        # SubAgent tools see the same context as parent tools. Agent.build_chain
+        # stores the original tool_context map as an explicit :tool_context key
+        # in custom_context, and scope under the canonical :scope key. Metadata
+        # and runtime are nested in state and copied into the SubAgent's fresh
+        # State.
+        {parent_tool_context, parent_metadata, parent_runtime, parent_scope} =
+          extract_parent_context(context)
 
         # Create SubAgent struct from pre-configured agent
         # Check if it's a Compiled struct (with initial_messages) or just an Agent
@@ -675,6 +677,7 @@ defmodule Sagents.Middleware.SubAgent do
                 until_tool: until_tool,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
+                parent_runtime: parent_runtime,
                 scope: parent_scope
               )
 
@@ -687,6 +690,7 @@ defmodule Sagents.Middleware.SubAgent do
                 until_tool: until_tool,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
+                parent_runtime: parent_runtime,
                 scope: parent_scope
               )
           end
@@ -767,8 +771,10 @@ defmodule Sagents.Middleware.SubAgent do
             interrupt_on: nil
           )
 
-        # Extract parent's tool_context, metadata, and scope for SubAgent inheritance
-        {parent_tool_context, parent_metadata, parent_scope} = extract_parent_context(context)
+        # Extract parent's tool_context, metadata, runtime, and scope for SubAgent
+        # inheritance.
+        {parent_tool_context, parent_metadata, parent_runtime, parent_scope} =
+          extract_parent_context(context)
 
         # Create SubAgent struct with parent context
         subagent =
@@ -778,6 +784,7 @@ defmodule Sagents.Middleware.SubAgent do
             agent_config: agent_config,
             parent_tool_context: parent_tool_context,
             parent_metadata: parent_metadata,
+            parent_runtime: parent_runtime,
             scope: parent_scope
           )
 
@@ -810,19 +817,21 @@ defmodule Sagents.Middleware.SubAgent do
     end
   end
 
-  # Extract parent's tool_context, state.metadata, and scope from the runtime context.
+  # Extract parent's tool_context, state.metadata, state.runtime, and scope
+  # from the runtime context.
   #
   # Agent.build_chain stores the original tool_context map as an explicit
   # :tool_context key in custom_context, and the parent's scope under the
   # canonical :scope key. We read both directly.
-  # Metadata lives nested inside context.state.metadata.
+  # Metadata and runtime live nested inside context.state.
   #
-  # Returns {tool_context_map, metadata_map, scope}.
+  # Returns {tool_context_map, metadata_map, runtime_map, scope}.
   defp extract_parent_context(context) do
     parent_tool_context = Map.get(context, :tool_context, %{})
     parent_metadata = get_in(context, [:state, Access.key(:metadata)]) || %{}
+    parent_runtime = get_in(context, [:state, Access.key(:runtime)]) || %{}
     parent_scope = Map.get(context, :scope)
-    {parent_tool_context, parent_metadata, parent_scope}
+    {parent_tool_context, parent_metadata, parent_runtime, parent_scope}
   end
 
   defp default_general_purpose_prompt() do

--- a/lib/sagents/state.ex
+++ b/lib/sagents/state.ex
@@ -59,6 +59,11 @@ defmodule Sagents.State do
     field :messages, {:array, :any}, default: [], virtual: true
     field :todos, {:array, :map}, default: []
     field :metadata, :map, default: %{}
+    # Runtime-only middleware state. Virtual: never persisted, never JSON-encoded.
+    # Use this for values that are inherently process-local or non-serializable —
+    # captured closures, OTel/Sentry context tokens, PIDs, refs, tuples — that
+    # only make sense within the lifetime of a single OS process.
+    field :runtime, :map, default: %{}, virtual: true
     # Interrupt data for HumanInTheLoop middleware
     field :interrupt_data, :map, default: nil, virtual: true
   end
@@ -82,7 +87,7 @@ defmodule Sagents.State do
   """
   def new(attrs \\ %{}) do
     %State{}
-    |> cast(attrs, [:agent_id, :messages, :todos, :metadata, :interrupt_data])
+    |> cast(attrs, [:agent_id, :messages, :todos, :metadata, :runtime, :interrupt_data])
     |> apply_action(:insert)
   end
 
@@ -156,6 +161,7 @@ defmodule Sagents.State do
       messages: merge_messages(left.messages, right.messages),
       todos: merge_todos(left.todos, right.todos),
       metadata: deep_merge_maps(left.metadata, right.metadata),
+      runtime: merge_runtime(left.runtime, right.runtime),
       interrupt_data: right.interrupt_data || left.interrupt_data
     }
   end
@@ -196,6 +202,16 @@ defmodule Sagents.State do
   defp deep_merge_maps(left, _right) when is_map(left), do: left
   defp deep_merge_maps(_left, right) when is_map(right), do: right
   defp deep_merge_maps(_left, _right), do: %{}
+
+  # Runtime entries are shallow merged. A namespacing strategy used by
+  # ProcessContext is to store the data under the module as the key.
+  defp merge_runtime(left, right) when is_map(left) and is_map(right) do
+    Map.merge(left, right)
+  end
+
+  defp merge_runtime(left, _right) when is_map(left), do: left
+  defp merge_runtime(_left, right) when is_map(right), do: right
+  defp merge_runtime(_left, _right), do: %{}
 
   @doc """
   Add a message to the state.
@@ -369,7 +385,8 @@ defmodule Sagents.State do
       agent_id: state.agent_id,
       messages: [],
       todos: [],
-      metadata: %{}
+      metadata: %{},
+      runtime: %{}
     }
   end
 

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -176,6 +176,10 @@ defmodule Sagents.SubAgent do
   - `:parent_metadata` - Parent's state metadata map to inherit (optional).
     Dynamic, middleware-managed data (e.g., `conversation_title`) that tools
     access via `context.state.metadata`. Defaults to `%{}`.
+  - `:parent_runtime` - Parent's `state.runtime` map to inherit (optional).
+    Process-local middleware state such as captured `ProcessContext` snapshots.
+    Inherited so sub-agents continue to see the parent's propagated tenant /
+    OTel / Sentry context. Defaults to `%{}`.
   - `:scope` - Scope struct to inherit from the parent (optional). Propagated to
     the SubAgent's `custom_context.scope` so sub-agent tools and persistence callbacks
     see the same tenant context as the parent. Defaults to `agent_config.scope`.
@@ -218,6 +222,10 @@ defmodule Sagents.SubAgent do
   - `:parent_metadata` - Parent's state metadata map to inherit (optional).
     Dynamic, middleware-managed data (e.g., `conversation_title`) that tools
     access via `context.state.metadata`. Defaults to `%{}`.
+  - `:parent_runtime` - Parent's `state.runtime` map to inherit (optional).
+    Process-local middleware state such as captured `ProcessContext` snapshots.
+    Inherited so sub-agents continue to see the parent's propagated tenant /
+    OTel / Sentry context. Defaults to `%{}`.
   - `:scope` - Scope struct to inherit from the parent (optional). Propagated to
     the SubAgent's `custom_context.scope` so sub-agent tools and persistence callbacks
     see the same tenant context as the parent. Defaults to `compiled_agent.scope`.
@@ -270,6 +278,7 @@ defmodule Sagents.SubAgent do
     parent_agent_id = Keyword.fetch!(opts, :parent_agent_id)
     parent_tool_context = Keyword.get(opts, :parent_tool_context, %{})
     parent_metadata = Keyword.get(opts, :parent_metadata, %{})
+    parent_runtime = Keyword.get(opts, :parent_runtime, %{})
     # Scope propagates from parent to SubAgent so sub-agent tools and callbacks
     # see the same tenant context. Fall back to the compiled/config agent's own
     # `:scope` field if the caller didn't pass one (e.g., direct new_from_compiled).
@@ -279,8 +288,15 @@ defmodule Sagents.SubAgent do
 
     sub_agent_id = "#{parent_agent_id}-sub-#{:erlang.unique_integer([:positive])}"
 
-    # SubAgent gets its own state but inherits parent's metadata snapshot.
-    subagent_state = State.new!(%{agent_id: sub_agent_id, metadata: parent_metadata})
+    # SubAgent gets its own state but inherits the parent's metadata snapshot
+    # and runtime context. The runtime carries process-local middleware state
+    # like ProcessContext snapshots.
+    subagent_state =
+      State.new!(%{
+        agent_id: sub_agent_id,
+        metadata: parent_metadata,
+        runtime: parent_runtime
+      })
 
     # Merge parent_tool_context into custom_context (same pattern as
     # Agent.build_chain). Internal keys always take precedence on collision.

--- a/test/sagents/middleware/process_context_test.exs
+++ b/test/sagents/middleware/process_context_test.exs
@@ -403,4 +403,138 @@ defmodule Sagents.Middleware.ProcessContextTest do
       AgentServer.stop(agent_id)
     end
   end
+
+  describe "persistence: snapshot lives in state.runtime, not state.metadata" do
+    # Regression: the captured snapshot contains tuples and closures that
+    # JSON cannot encode. It must live in state.runtime (virtual) so it never
+    # reaches the serialized payload that ends up in JSONB.
+    test "AgentServer.export_state/1 produces a JSON-encodable payload" do
+      Process.put(:test_marker, "orgA")
+
+      agent_id = "test-#{:erlang.unique_integer([:positive])}"
+
+      capture_fn = fn -> :captured_value end
+      apply_fn = fn _value -> :ok end
+
+      agent =
+        build_agent(
+          agent_id,
+          [
+            {ProcessContext, keys: [:test_marker], propagators: [{capture_fn, apply_fn}]}
+          ],
+          []
+        )
+
+      start_agent_supervised(agent)
+
+      # Synchronize so on_server_start has fully run and the snapshot is in
+      # the AgentServer's state.runtime.
+      _ = AgentServer.get_state(agent_id)
+
+      exported = AgentServer.export_state(agent_id)
+
+      # The serialized payload has no runtime key (it is virtual) and no
+      # ProcessContext entry leaked into metadata.
+      refute Map.has_key?(exported["state"], "runtime")
+      refute Map.has_key?(exported["state"]["metadata"] || %{}, to_string(ProcessContext))
+
+      # And the whole payload encodes cleanly to JSON for JSONB storage.
+      assert {:ok, _json} = Jason.encode(exported)
+
+      AgentServer.stop(agent_id)
+    end
+
+    test "the live snapshot still drives propagation (not regressed by the move)" do
+      # Sanity: after the metadata→runtime move, the snapshot must still
+      # flow through every boundary. We re-prove boundary 3 (per-tool async
+      # Task) here as a regression guard.
+      Process.put(:test_marker, "orgA")
+
+      agent_id = "test-#{:erlang.unique_integer([:positive])}"
+      tool = marker_reader_tool("async_reader", true)
+
+      agent =
+        build_agent(
+          agent_id,
+          [{ProcessContext, keys: [:test_marker]}],
+          [tool]
+        )
+
+      expect_tool_call_then_done("async_reader")
+      start_agent_supervised(agent)
+
+      AgentServer.add_message(agent_id, Message.new_user!("Read"))
+
+      assert_receive {:tool_saw, "async_reader", "orgA", _}, 500
+      assert_receive {:agent, {:status_changed, :idle, _}}, 500
+
+      AgentServer.stop(agent_id)
+    end
+  end
+
+  describe "sub-agent inheritance" do
+    # Sub-agents cross another process boundary (parent chain → SubAgentServer).
+    # The parent's state.runtime must be copied into the sub-agent's fresh State
+    # so its own on_server_start sees the captured snapshot and can re-apply it
+    # at every boundary the sub-agent crosses.
+    alias Sagents.SubAgent, as: SubAgentStruct
+
+    test "SubAgent.new_from_config/1 copies parent_runtime into the sub-agent's State" do
+      Process.put(:test_marker, "orgA")
+
+      {:ok, %{snapshot: snapshot}} =
+        ProcessContext.init(
+          keys: [:test_marker],
+          propagators: [{fn -> :v end, fn _ -> :ok end}]
+        )
+
+      parent_runtime = %{ProcessContext => snapshot}
+
+      {:ok, agent_config} =
+        Agent.new(
+          %{
+            agent_id: "sub",
+            model: ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"}),
+            base_system_prompt: "Sub agent",
+            middleware: [{ProcessContext, keys: [:test_marker]}]
+          },
+          replace_default_middleware: true
+        )
+
+      subagent =
+        SubAgentStruct.new_from_config(
+          parent_agent_id: "parent",
+          instructions: "do work",
+          agent_config: agent_config,
+          parent_runtime: parent_runtime
+        )
+
+      sub_state = subagent.chain.custom_context.state
+      assert sub_state.runtime == parent_runtime
+      # And metadata is independent — empty by default, not contaminated.
+      assert sub_state.metadata == %{}
+    end
+
+    test "parent_runtime defaults to %{} when not provided (non-ProcessContext callers)" do
+      {:ok, agent_config} =
+        Agent.new(
+          %{
+            agent_id: "sub",
+            model: ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"}),
+            base_system_prompt: "Sub agent",
+            middleware: []
+          },
+          replace_default_middleware: true
+        )
+
+      subagent =
+        SubAgentStruct.new_from_config(
+          parent_agent_id: "parent",
+          instructions: "do work",
+          agent_config: agent_config
+        )
+
+      assert subagent.chain.custom_context.state.runtime == %{}
+    end
+  end
 end

--- a/test/sagents/persistence/state_serializer_test.exs
+++ b/test/sagents/persistence/state_serializer_test.exs
@@ -792,4 +792,43 @@ defmodule Sagents.Persistence.StateSerializerTest do
       assert calc_call.arguments == %{"expression" => "1+1"}
     end
   end
+
+  describe "state.runtime is excluded from serialization" do
+    # Regression: ProcessContext (and any other middleware that stashes
+    # process-local data) writes to state.runtime, a virtual field. The
+    # serializer must not see it, so non-serializable values like 2-tuples
+    # and captured closures cannot leak into JSONB.
+    test "ProcessContext snapshot in state.runtime never reaches the serialized payload" do
+      alias Sagents.Middleware.ProcessContext
+
+      Process.put(:test_marker, "orgA")
+
+      capture_fn = fn -> :captured_value end
+      apply_fn = fn _value -> :ok end
+
+      {:ok, %{snapshot: snapshot}} =
+        ProcessContext.init(
+          keys: [:test_marker],
+          propagators: [{capture_fn, apply_fn}]
+        )
+
+      state =
+        State.new!(%{
+          messages: [Message.new_user!("hi")],
+          metadata: %{"keep_me" => "in_metadata"},
+          runtime: %{ProcessContext => snapshot}
+        })
+
+      serialized = StateSerializer.serialize_state(state)
+
+      # metadata round-trips normally
+      assert serialized["metadata"] == %{"keep_me" => "in_metadata"}
+
+      # runtime is virtual — it's not in the serialized output at all
+      refute Map.has_key?(serialized, "runtime")
+
+      # And the JSONB-bound payload encodes cleanly
+      assert {:ok, _json} = Jason.encode(serialized)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`ProcessContext` middleware captures a snapshot of caller-process state (tenant markers, OTel context tokens, Sentry scope, etc.) so it can be re-applied across every process boundary the agent crosses. That snapshot is intentionally non-serializable: it contains 2-tuples of captured closures, PIDs, and refs.

Until now the snapshot was stashed in `state.metadata[ProcessContext]`. `state.metadata` is persisted via `StateSerializer` into a JSONB column, so any agent using `ProcessContext` was one `Jason.encode/1` call away from a serialization crash, and conceptually a stale OTel/tenant token from a long-dead process could be restored from disk and re-applied — which would be wrong even if it encoded.

## Solution

Introduce a new virtual field on `Sagents.State` — `runtime` — explicitly reserved for process-local middleware data that must never be serialized. `ProcessContext` now stores its snapshot under `state.runtime[ProcessContext]` instead of `state.metadata[ProcessContext]`.

Because `runtime` is `virtual: true`, `StateSerializer` never sees it, so the JSONB payload stays clean. After a process restart the snapshot is gone and `on_server_start/2` re-captures from the new caller process — the correct semantic, since stale captured tokens shouldn't be re-applied anyway.

Sub-agents cross another process boundary, so `Middleware.SubAgent` and `Sagents.SubAgent` were updated to read the parent's `state.runtime` and seed it into the sub-agent's fresh `State`, so the inherited `ProcessContext` middleware can re-apply propagators inside the sub-agent process.

## Changes

- `lib/sagents/state.ex` — Added `runtime` virtual field, included it in `cast/3`, `merge/2`, and the empty-state helper. Added `merge_runtime/2` (shallow merge, namespaced by middleware module).
- `lib/sagents/middleware/process_context.ex` — Snapshot now read/written via `state.runtime`. Renamed `ensure_snapshot_in_metadata/2` → `ensure_snapshot_in_runtime/2`. Updated `@moduledoc` with a new \"Snapshot lives in \`state.runtime\`\" section explaining the persistence semantics.
- `lib/sagents/middleware/sub_agent.ex` — `extract_parent_context/1` now also pulls `state.runtime`; both call sites pass it through as `:parent_runtime`.
- `lib/sagents/sub_agent.ex` — `new_from_compiled/1` and `new_from_config/1` accept `:parent_runtime`, defaulting to `%{}`, and seed it into the sub-agent's `State.new!/1`. `@doc`s updated.
- `test/sagents/middleware/process_context_test.exs` — Two new describe blocks: \"persistence: snapshot lives in state.runtime, not state.metadata\" (proves `AgentServer.export_state/1` is JSON-encodable and that `ProcessContext` doesn't leak into metadata; regression guard re-asserting boundary-3 propagation through per-tool async tasks) and \"sub-agent inheritance\" (verifies `SubAgent.new_from_config/1` copies `parent_runtime` into sub-state and defaults to `%{}`).
- `test/sagents/persistence/state_serializer_test.exs` — Added \"state.runtime is excluded from serialization\" describe with a regression test proving that a `ProcessContext` snapshot in `state.runtime` is absent from `StateSerializer.serialize_state/1` output and the payload encodes cleanly.

## Testing

- New unit tests in \`process_context_test.exs\` and \`state_serializer_test.exs\` covering: JSON-encodability of exported state, non-leakage into metadata, end-to-end propagation through async tool boundaries, and sub-agent inheritance (both happy path and default).
- Existing \`ProcessContext\` propagation tests (boundaries 1–3) continue to pass unchanged after the rename — confirming the move doesn't regress any of the live snapshot semantics.