### PR TITLE
Expose agent_id as a top-level tool context key

### DIFF
--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -771,7 +771,11 @@ defmodule Sagents.Agent do
             tool_context: agent.tool_context || %{},
             # First-class scope channel: tool functions read `context.scope`. If
             # tool_context contained `:scope`, it's overridden here.
-            scope: agent.scope
+            scope: agent.scope,
+            # First-class agent identity channel: tool functions read
+            # `context.agent_id` to publish events back through their
+            # AgentServer (e.g. `Sagents.AgentServer.publish_event_from/2`).
+            agent_id: state.agent_id
           }
         )
     }

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -309,7 +309,9 @@ defmodule Sagents.SubAgent do
         # can extract it cleanly (same as Agent.build_chain).
         tool_context: parent_tool_context,
         # First-class scope channel, same canonical key as Agent.build_chain.
-        scope: scope
+        scope: scope,
+        # Direct to the parent agent id.
+        agent_id: parent_agent_id
       })
 
     chain =

--- a/test/sagents/sub_agent_tool_context_test.exs
+++ b/test/sagents/sub_agent_tool_context_test.exs
@@ -57,6 +57,27 @@ defmodule Sagents.SubAgentToolContextTest do
       assert is_list(ctx.parent_middleware)
     end
 
+    test "SubAgent context.agent_id is the parent_agent_id (subscribers live there)" do
+      agent = bare_agent()
+
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "parent-with-subscribers",
+          instructions: "Do work",
+          agent_config: agent
+        )
+
+      ctx = subagent.chain.custom_context
+
+      # context.agent_id routes tool-published events to the entity that
+      # actually has subscribers — the parent. SubAgents run as Tasks and
+      # have no subscribers of their own.
+      assert ctx.agent_id == "parent-with-subscribers"
+      # The sub-agent's own runtime id remains accessible via state.
+      assert is_binary(ctx.state.agent_id)
+      refute ctx.state.agent_id == "parent-with-subscribers"
+    end
+
     test "internal keys take precedence over parent_tool_context on collision" do
       agent = bare_agent()
 
@@ -96,11 +117,20 @@ defmodule Sagents.SubAgentToolContextTest do
 
       assert %State{} = ctx.state
       assert is_list(ctx.parent_middleware)
-      # Only internal keys present (including :tool_context which holds the empty map,
-      # and :scope which defaults to nil when no scope is supplied).
-      assert Map.keys(ctx) |> Enum.sort() == [:parent_middleware, :scope, :state, :tool_context]
+      # Only internal keys present (including :tool_context which holds the
+      # empty map, :scope which defaults to nil when no scope is supplied,
+      # and :agent_id which routes back to the parent AgentServer because
+      # SubAgents have no subscribers of their own).
+      assert Map.keys(ctx) |> Enum.sort() ==
+               [:agent_id, :parent_middleware, :scope, :state, :tool_context]
+
       assert ctx.tool_context == %{}
       assert ctx.scope == nil
+      # context.agent_id is the parent's id (the entity with subscribers),
+      # not the sub-agent's own runtime id. Tools that need the sub-agent's
+      # id can still read it from ctx.state.agent_id.
+      assert ctx.agent_id == "parent-3"
+      refute ctx.agent_id == ctx.state.agent_id
     end
   end
 

--- a/test/sagents/tool_context_integration_test.exs
+++ b/test/sagents/tool_context_integration_test.exs
@@ -193,5 +193,113 @@ defmodule Sagents.ToolContextIntegrationTest do
       # But non-colliding caller context survives
       assert ctx.user_id == 99
     end
+
+    test "tool function receives agent_id as a top-level context key", %{model: model} do
+      test_pid = self()
+
+      check_context_tool =
+        Function.new!(%{
+          name: "check_context",
+          description: "Receives and reports context",
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, context ->
+            send(test_pid, {:received_context, context})
+            {:ok, "ok"}
+          end
+        })
+
+      stub(ChatOpenAI, :call, fn _model, messages, _tools ->
+        case length(messages) do
+          2 ->
+            {:ok,
+             [
+               Message.new_assistant!(%{
+                 tool_calls: [
+                   ToolCall.new!(%{
+                     call_id: "call_ctx_4",
+                     name: "check_context",
+                     arguments: %{}
+                   })
+                 ]
+               })
+             ]}
+
+          _ ->
+            {:ok, [Message.new_assistant!("Done.")]}
+        end
+      end)
+
+      {:ok, agent} =
+        Agent.new(%{
+          model: model,
+          tools: [check_context_tool],
+          replace_default_middleware: true,
+          middleware: []
+        })
+
+      state = State.new!(%{messages: [Message.new_user!("Go")]})
+
+      {:ok, _final_state} = Agent.execute(agent, state)
+
+      assert_received {:received_context, ctx}
+      # Whatever runtime id Agent.execute uses, it surfaces as a top-level
+      # context key matching state.agent_id.
+      assert is_binary(ctx.agent_id)
+      assert ctx.agent_id == ctx.state.agent_id
+    end
+
+    test "internal agent_id wins over caller-supplied tool_context :agent_id", %{model: model} do
+      test_pid = self()
+
+      check_context_tool =
+        Function.new!(%{
+          name: "check_context",
+          description: "Receives and reports context",
+          parameters_schema: %{type: "object", properties: %{}},
+          function: fn _args, context ->
+            send(test_pid, {:received_context, context})
+            {:ok, "ok"}
+          end
+        })
+
+      stub(ChatOpenAI, :call, fn _model, messages, _tools ->
+        case length(messages) do
+          2 ->
+            {:ok,
+             [
+               Message.new_assistant!(%{
+                 tool_calls: [
+                   ToolCall.new!(%{
+                     call_id: "call_ctx_5",
+                     name: "check_context",
+                     arguments: %{}
+                   })
+                 ]
+               })
+             ]}
+
+          _ ->
+            {:ok, [Message.new_assistant!("Done.")]}
+        end
+      end)
+
+      {:ok, agent} =
+        Agent.new(%{
+          model: model,
+          tool_context: %{agent_id: "caller-tried-to-set-this"},
+          tools: [check_context_tool],
+          replace_default_middleware: true,
+          middleware: []
+        })
+
+      state = State.new!(%{messages: [Message.new_user!("Go")]})
+
+      {:ok, _final_state} = Agent.execute(agent, state)
+
+      assert_received {:received_context, ctx}
+      # Canonical runtime identity wins, mirroring the :scope precedence rule.
+      refute ctx.agent_id == "caller-tried-to-set-this"
+      assert ctx.agent_id == ctx.state.agent_id
+    end
   end
 end


### PR DESCRIPTION
## Problem

Tools executing inside an agent often need to publish events back through the agent's `AgentServer` (for example, broadcasting progress on the `agent_server:#{agent_id}` PubSub topic). Until now, a tool function had no clean way to discover the running agent's id from its execution context — `agent_id` was reachable only by digging into `context.state.agent_id`, which leaked an internal detail and made simple "publish from a tool" patterns awkward.

For `SubAgent`-spawned tools, the situation was worse: the sub-agent has no subscribers of its own, so the *parent* agent id is what tools actually need to reach a real audience.

## Solution

Promote `agent_id` to a first-class channel on the tool execution context, alongside the existing `:scope` and `:tool_context` keys.

- `Sagents.Agent.build_chain/1` now sets `custom_context.agent_id` from `state.agent_id`, so any tool executed by the agent sees the canonical runtime id at `context.agent_id`.
- `Sagents.SubAgent` sets `custom_context.agent_id` to the **parent** agent id — tools spawned inside a sub-agent route their events back to the entity that actually has subscribers. The sub-agent's own runtime id is still available via `context.state.agent_id`.
- The internal `agent_id` overrides any caller-supplied `tool_context[:agent_id]`, mirroring the existing precedence rule for `:scope`.

This unlocks straightforward patterns like calling `Sagents.AgentServer.publish_event_from(context.agent_id, event)` directly from inside a tool function.

## Changes

- [lib/sagents/agent.ex](lib/sagents/agent.ex) — Inject `agent_id: state.agent_id` into the chain's `custom_context` in `build_chain/1`.
- [lib/sagents/sub_agent.ex](lib/sagents/sub_agent.ex) — Inject `agent_id: parent_agent_id` into the sub-agent chain's `custom_context` so sub-agent tools publish to the parent.
- [test/sagents/sub_agent_tool_context_test.exs](test/sagents/sub_agent_tool_context_test.exs) — Cover the parent-id routing rule and the updated key set on the context map.
- [test/sagents/tool_context_integration_test.exs](test/sagents/tool_context_integration_test.exs) — End-to-end tests proving (a) tool functions see `context.agent_id` as a top-level key matching `state.agent_id`, and (b) the canonical value wins over a caller-supplied `tool_context[:agent_id]`.

## Testing

- New unit-level tests in `sub_agent_tool_context_test.exs` verify the SubAgent context shape.
- New integration tests in `tool_context_integration_test.exs` execute a real `Agent.execute/2` flow with a stubbed model and assert what the tool function actually receives at runtime, including the precedence rule.
- No live API calls; tests use Mimic stubs for `ChatOpenAI`.