### PR TITLE
Expose middleware-injected messages to debug subscribers mid-turn

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -1739,6 +1739,20 @@ defmodule Sagents.AgentServer do
     end
   end
 
+  # Sync `server_state.state` to the post-middleware state and broadcast it.
+  # Makes middleware-injected messages visible mid-turn via `get_state/1`.
+  # Dropped if the run was superseded or cancelled.
+  @impl true
+  def handle_cast({:after_middleware_broadcast, exec_seq, prepared_state}, server_state) do
+    if exec_seq == server_state.execution_seq and server_state.status == :running do
+      new_server_state = %{server_state | state: prepared_state}
+      broadcast_debug_event(new_server_state, {:after_middleware_state, prepared_state})
+      {:noreply, new_server_state}
+    else
+      {:noreply, server_state}
+    end
+  end
+
   @impl true
   def handle_cast(:touch, server_state) do
     # Reset the inactivity timer to keep the agent alive
@@ -2024,11 +2038,11 @@ defmodule Sagents.AgentServer do
     server_name = get_name(agent_id)
 
     %{
-      # Sagents-specific callback (NOT a LangChain key).
-      # Fired by Agent.fire_callback/3 after before_model hooks, before LLM call.
-      # Broadcasts the prepared state (with middleware modifications) on the debug channel.
+      # Sagents-only callback. Fires after before_model hooks, before the LLM call.
+      # Casts to the GenServer so the broadcast uses the live publisher state
+      # (subscribers that joined mid-turn) instead of the closure's snapshot.
       on_after_middleware: fn prepared_state ->
-        broadcast_debug_event(server_state, {:after_middleware_state, prepared_state})
+        safe_cast(server_name, {:after_middleware_broadcast, exec_seq, prepared_state})
       end,
 
       # Callback for streaming deltas (tokens as they arrive)

--- a/test/sagents/agent_server_debug_pubsub_test.exs
+++ b/test/sagents/agent_server_debug_pubsub_test.exs
@@ -78,6 +78,97 @@ defmodule Sagents.AgentServerDebugPubSubTest do
     end
   end
 
+  describe "after_middleware_broadcast" do
+    # The on_after_middleware callback closure runs in the execution Task and
+    # would normally broadcast against a frozen snapshot of subscribers. Routing
+    # through the GenServer (this cast) ensures subscribers that joined AFTER
+    # execute started — e.g. a debugger that opened mid-turn — still receive
+    # the post-middleware state. Reconciling server_state.state with
+    # prepared_state also makes mid-turn `get_state/1` reflect middleware
+    # injections (e.g. a foundation-document preamble).
+
+    test "broadcasts :after_middleware_state to debug subscribers and reconciles state" do
+      agent = create_test_agent()
+      agent_id = agent.agent_id
+
+      {:ok, _pid} = AgentServer.start_link(agent: agent)
+
+      # Force the server into :running with a known execution_seq so the
+      # cast's gate matches.
+      :sys.replace_state(AgentServer.get_pid(agent_id), fn server_state ->
+        %{server_state | status: :running, execution_seq: 1}
+      end)
+
+      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent_id)
+
+      injected_user = Message.new_user!("synthetic kickoff")
+      injected_assistant = Message.new_assistant!("synthetic reference dump")
+      real_user = Message.new_user!("real first message")
+
+      prepared_state =
+        State.new!(%{messages: [injected_user, injected_assistant, real_user]})
+
+      GenServer.cast(
+        AgentServer.get_pid(agent_id),
+        {:after_middleware_broadcast, 1, prepared_state}
+      )
+
+      assert_receive {:agent, {:debug, {:after_middleware_state, broadcast_state}}}, 200
+      assert length(broadcast_state.messages) == 3
+
+      # Reconciliation: get_state now returns prepared_state's messages,
+      # not the empty pre-middleware list. This is what makes mid-turn
+      # snapshots correct for newly-arrived debugger views.
+      reconciled = AgentServer.get_state(agent_id)
+      assert length(reconciled.messages) == 3
+    end
+
+    test "drops cast when execution_seq is stale" do
+      agent = create_test_agent()
+      agent_id = agent.agent_id
+
+      {:ok, _pid} = AgentServer.start_link(agent: agent)
+
+      :sys.replace_state(AgentServer.get_pid(agent_id), fn server_state ->
+        %{server_state | status: :running, execution_seq: 5}
+      end)
+
+      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent_id)
+
+      stale_state = State.new!(%{messages: [Message.new_user!("from old run")]})
+
+      GenServer.cast(
+        AgentServer.get_pid(agent_id),
+        {:after_middleware_broadcast, 1, stale_state}
+      )
+
+      refute_receive {:agent, {:debug, {:after_middleware_state, _}}}, 100
+
+      # State unchanged.
+      assert AgentServer.get_state(agent_id).messages == []
+    end
+
+    test "drops cast when status is not :running" do
+      agent = create_test_agent()
+      agent_id = agent.agent_id
+
+      {:ok, _pid} = AgentServer.start_link(agent: agent)
+
+      # Server starts in :idle.
+      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent_id)
+
+      prepared_state = State.new!(%{messages: [Message.new_user!("ignored")]})
+
+      GenServer.cast(
+        AgentServer.get_pid(agent_id),
+        {:after_middleware_broadcast, 0, prepared_state}
+      )
+
+      refute_receive {:agent, {:debug, {:after_middleware_state, _}}}, 100
+      assert AgentServer.get_state(agent_id).messages == []
+    end
+  end
+
   describe "debug events with state restoration" do
     test "debug subscriptions work after restoring from persisted state" do
       agent = create_test_agent()


### PR DESCRIPTION
## Problem

When middleware injected synthetic messages into the conversation (e.g. a foundation-document preamble, or any non-user/non-assistant message added in a `before_model` hook), debug subscribers didn't see them until they left and rejoined — at which point a full state snapshot would catch them up.

The cause: `on_after_middleware` was a closure built when execution started, broadcasting against a frozen `server_state` snapshot. Subscribers that joined *after* the snapshot — including a debugger that opened mid-turn — were invisible to the broadcast. Equally, `server_state.state` was never reconciled with the post-middleware state, so a mid-turn `get_state/1` returned the pre-middleware messages.

## Solution

Route the `on_after_middleware` callback through the GenServer instead of broadcasting from the execution Task's closure.

The closure now does a `safe_cast` of `{:after_middleware_broadcast, exec_seq, prepared_state}` to the server. The new `handle_cast` clause:

1. Gates on `exec_seq == server_state.execution_seq` and `status == :running` so stale or cancelled runs don't leak state.
2. Updates `server_state.state` to `prepared_state`, making middleware-injected messages visible to mid-turn `get_state/1` calls.
3. Calls `broadcast_debug_event/2` with the *live* server state, so subscribers that joined since execution started receive the event.

## Changes

- `lib/sagents/agent_server.ex` — Added `handle_cast({:after_middleware_broadcast, ...})` clause that reconciles state and broadcasts using the live server state. Replaced the inline closure broadcast with a `safe_cast` to the server.
- `test/sagents/agent_server_debug_pubsub_test.exs` — Three new tests under an `after_middleware_broadcast` describe block: (1) the happy path verifies both the debug broadcast and `get_state/1` reconciliation, (2) stale `execution_seq` drops the cast, (3) non-running status drops the cast.

## Testing

Unit tests use `:sys.replace_state` to drive the server into the precise `status` / `execution_seq` combinations needed to exercise each branch of the new `handle_cast`, then assert on both the broadcast event and the reconciled `get_state/1` view. No live API calls.