### PR TITLE
Add synthetic display message hook for middleware

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -567,6 +567,27 @@ defmodule Sagents.AgentServer do
   end
 
   @doc """
+  Persist a synthetic display message and broadcast it to subscribers.
+
+  Designed for middleware that needs to record user-facing transcript entries
+  that do not correspond to an LLM message (for example, a user's answer to an
+  `ask_user` question, or a "user cancelled" notification).
+
+  The attrs map should contain at minimum `:message_type`, `:content_type`, and
+  `:content`. AgentServer routes the request to the configured
+  `Sagents.DisplayMessagePersistence` implementation and broadcasts the saved
+  record via `{:display_message_saved, msg}`.
+
+  No-op if the AgentServer was not configured with both
+  `display_message_persistence` and `conversation_id`, or if the configured
+  persistence module does not implement `save_synthetic_message/3`.
+  """
+  @spec save_synthetic_message_from(String.t(), map()) :: :ok
+  def save_synthetic_message_from(agent_id, attrs) when is_map(attrs) do
+    GenServer.cast(get_name(agent_id), {:save_synthetic_message, attrs})
+  end
+
+  @doc """
   Request the AgentServer to publish a specific debug PubSub message or event.
 
   Designed to make it easier for middleware to publish debug messages to the
@@ -1715,6 +1736,12 @@ defmodule Sagents.AgentServer do
     {:noreply, server_state}
   end
 
+  @impl true
+  def handle_cast({:save_synthetic_message, attrs}, server_state) do
+    maybe_save_synthetic_and_broadcast(server_state, attrs)
+    {:noreply, server_state}
+  end
+
   # Rolling-state turn update: append the completed message to the live state so
   # `get_state/1`, debuggers, and persistence all observe turn-level progress
   # before Agent.execute/3 returns. Out-of-order casts (from a cancelled or
@@ -2754,6 +2781,44 @@ defmodule Sagents.AgentServer do
     else
       # No persistence configured — just broadcast the message event
       broadcast_event(server_state, {:llm_message, message})
+    end
+  end
+
+  # Persist a middleware-originated synthetic display message via the configured
+  # DisplayMessagePersistence module and broadcast the saved record. Skipped
+  # silently if persistence is unconfigured or the optional callback isn't
+  # implemented.
+  defp maybe_save_synthetic_and_broadcast(server_state, attrs) do
+    cond do
+      is_nil(server_state.display_message_persistence) or is_nil(server_state.conversation_id) ->
+        :ok
+
+      not function_exported?(
+        server_state.display_message_persistence,
+        :save_synthetic_message,
+        3
+      ) ->
+        Logger.warning(
+          "Synthetic display message requested but #{inspect(server_state.display_message_persistence)} does not implement save_synthetic_message/3"
+        )
+
+      true ->
+        module = server_state.display_message_persistence
+        scope = current_scope(server_state)
+        context = callback_context(server_state)
+
+        try do
+          case module.save_synthetic_message(scope, attrs, context) do
+            {:ok, display_msg} ->
+              broadcast_event(server_state, {:display_message_saved, display_msg})
+
+            {:error, reason} ->
+              Logger.error("Synthetic display message persistence failed: #{inspect(reason)}")
+          end
+        rescue
+          exception ->
+            Logger.error("Synthetic display message persistence raised: #{inspect(exception)}")
+        end
     end
   end
 

--- a/lib/sagents/display_message_persistence.ex
+++ b/lib/sagents/display_message_persistence.ex
@@ -151,5 +151,49 @@ defmodule Sagents.DisplayMessagePersistence do
               context :: callback_context()
             ) :: {:ok, term()} | {:error, :not_found | term()}
 
-  @optional_callbacks [resolve_tool_result: 4]
+  @typedoc """
+  Attributes for a synthetic display message produced by middleware (not by an
+  LLM). The shape mirrors the fields a typical implementation will write to
+  its display-message store.
+  """
+  @type synthetic_message_attrs :: %{
+          required(:message_type) => String.t(),
+          required(:content_type) => String.t(),
+          required(:content) => map(),
+          optional(:metadata) => map()
+        }
+
+  @doc """
+  Persist a synthetic display message originated by middleware.
+
+  Used for transcript entries that should appear in the conversation but do
+  not correspond to a `LangChain.Message` — for example, the user's answer
+  to an `ask_user` question, or a "user cancelled" notification.
+
+  AgentServer invokes this callback in response to
+  `Sagents.AgentServer.save_synthetic_message_from/2` and broadcasts the
+  saved record as `{:display_message_saved, msg}` so LiveViews stream it in
+  via the same path used for LLM-generated display messages.
+
+  Optional callback — middleware that uses this feature is responsible for
+  ensuring the configured persistence module implements it.
+
+  ## Parameters
+
+  - `scope` — Integrator-defined scope struct (or `nil`). Use to filter DB writes.
+  - `attrs` — Map with `:message_type`, `:content_type`, `:content` (and optionally `:metadata`).
+  - `context` — Map with `:agent_id` and `:conversation_id`.
+
+  ## Returns
+
+  - `{:ok, display_message}` — Persisted record, broadcast as `{:display_message_saved, msg}`.
+  - `{:error, reason}` — Persistence failed (logged, does not affect agent).
+  """
+  @callback save_synthetic_message(
+              scope :: term() | nil,
+              attrs :: synthetic_message_attrs(),
+              context :: callback_context()
+            ) :: {:ok, term()} | {:error, term()}
+
+  @optional_callbacks [resolve_tool_result: 4, save_synthetic_message: 3]
 end

--- a/priv/templates/display_message_persistence.ex.eex
+++ b/priv/templates/display_message_persistence.ex.eex
@@ -88,4 +88,12 @@ defmodule <%= module %> do
   def resolve_tool_result(scope, tool_call_id, result_content, _context) do
     <%= conversations_module %>.resolve_interrupted_tool_result(scope, tool_call_id, result_content)
   end
+
+  @impl true
+  def save_synthetic_message(_scope, _attrs, %{conversation_id: nil}),
+    do: {:error, :no_conversation}
+
+  def save_synthetic_message(scope, attrs, %{conversation_id: conversation_id}) do
+    <%= conversations_module %>.append_display_message(scope, conversation_id, attrs)
+  end
 end

--- a/test/sagents/agent_server_synthetic_message_test.exs
+++ b/test/sagents/agent_server_synthetic_message_test.exs
@@ -1,0 +1,163 @@
+defmodule Sagents.AgentServerSyntheticMessageTest do
+  @moduledoc """
+  Tests for `AgentServer.save_synthetic_message_from/2`: the public hook
+  middleware uses to record user-facing transcript entries that don't come
+  from an LLM (e.g., a user's answer to an `ask_user` question).
+  """
+
+  use Sagents.BaseCase, async: false
+
+  alias Sagents.AgentServer
+  alias Sagents.TestDisplayMessagePersistenceForwarding, as: Forwarder
+  alias Sagents.TestingHelpers
+
+  setup do
+    Forwarder.register_test_process(self())
+    Forwarder.clear_synthetic_response()
+
+    on_exit(fn -> Forwarder.clear_synthetic_response() end)
+
+    :ok
+  end
+
+  describe "save_synthetic_message_from/2" do
+    test "persists via the configured callback and broadcasts :display_message_saved" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+      conversation_id = "conv-synth-1"
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: conversation_id,
+          display_message_persistence: Forwarder
+        )
+
+      attrs = %{
+        message_type: "user",
+        content_type: "text",
+        content: %{"text" => "PostgreSQL"}
+      }
+
+      :ok = AgentServer.save_synthetic_message_from(agent_id, attrs)
+
+      assert_receive {:saved_synthetic_message, _scope, ^attrs, context}, 200
+      assert context.agent_id == agent_id
+      assert context.conversation_id == conversation_id
+
+      assert_receive {:agent, {:display_message_saved, %{attrs: ^attrs}}}, 200
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "no-op when conversation_id is missing" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          display_message_persistence: Forwarder
+          # no conversation_id
+        )
+
+      :ok =
+        AgentServer.save_synthetic_message_from(agent_id, %{
+          message_type: "user",
+          content_type: "text",
+          content: %{"text" => "ignored"}
+        })
+
+      # Sync via get_state to flush mailbox.
+      _ = AgentServer.get_state(agent_id)
+
+      refute_received {:saved_synthetic_message, _, _, _}
+      refute_received {:agent, {:display_message_saved, _}}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "no-op when no persistence module is configured" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-x"
+          # no display_message_persistence
+        )
+
+      :ok =
+        AgentServer.save_synthetic_message_from(agent_id, %{
+          message_type: "user",
+          content_type: "text",
+          content: %{"text" => "ignored"}
+        })
+
+      _ = AgentServer.get_state(agent_id)
+
+      refute_received {:saved_synthetic_message, _, _, _}
+      refute_received {:agent, {:display_message_saved, _}}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "logs and continues when persistence callback returns {:error, _}" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-err",
+          display_message_persistence: Forwarder
+        )
+
+      Forwarder.set_synthetic_response({:error, :db_down})
+
+      :ok =
+        AgentServer.save_synthetic_message_from(agent_id, %{
+          message_type: "user",
+          content_type: "text",
+          content: %{"text" => "x"}
+        })
+
+      assert_receive {:saved_synthetic_message, _scope, _attrs, _context}, 200
+      refute_received {:agent, {:display_message_saved, _}}
+
+      # Server still alive after the failure
+      assert is_map(AgentServer.get_state(agent_id))
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "logs and continues when persistence callback raises" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-raise",
+          display_message_persistence: Forwarder
+        )
+
+      Forwarder.set_synthetic_response(:raise)
+
+      :ok =
+        AgentServer.save_synthetic_message_from(agent_id, %{
+          message_type: "user",
+          content_type: "text",
+          content: %{"text" => "x"}
+        })
+
+      assert_receive {:saved_synthetic_message, _scope, _attrs, _context}, 200
+      refute_received {:agent, {:display_message_saved, _}}
+
+      assert is_map(AgentServer.get_state(agent_id))
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+  end
+end

--- a/test/support/test_display_message_persistence.ex
+++ b/test/support/test_display_message_persistence.ex
@@ -62,4 +62,24 @@ defmodule Sagents.TestDisplayMessagePersistenceForwarding do
   def update_tool_status(_scope, _status, _tool_info, _context) do
     {:error, :not_found}
   end
+
+  @impl true
+  def save_synthetic_message(scope, attrs, context) do
+    pid = :persistent_term.get({__MODULE__, :test_pid})
+    send(pid, {:saved_synthetic_message, scope, attrs, context})
+
+    case :persistent_term.get({__MODULE__, :synthetic_response}, :ok) do
+      :ok -> {:ok, %{id: "synthetic-#{System.unique_integer([:positive])}", attrs: attrs}}
+      {:error, _} = err -> err
+      :raise -> raise "Simulated synthetic persistence error"
+    end
+  end
+
+  def set_synthetic_response(response) do
+    :persistent_term.put({__MODULE__, :synthetic_response}, response)
+  end
+
+  def clear_synthetic_response do
+    :persistent_term.erase({__MODULE__, :synthetic_response})
+  end
 end


### PR DESCRIPTION
## Problem

Middleware sometimes needs to record user-facing transcript entries that don't correspond to a `LangChain.Message` from the LLM. Two concrete cases:

- An `ask_user` middleware needs the user's *answer* to appear in the conversation as a user message, even though it never went through the model as a user message (it's a tool response).
- A cancellation flow needs a system-style notification like "User cancelled" to be visible in the transcript on reload.

There was no supported path for middleware to persist these entries through the same display-message pipeline that LLM-generated messages use, and therefore no way to get them broadcast to LiveViews via the existing `:display_message_saved` event.

## Solution

Add a public AgentServer API that middleware can call to persist a synthetic display message, plus an optional callback on the `DisplayMessagePersistence` behaviour that integrators implement to actually write it.

- `Sagents.AgentServer.save_synthetic_message_from/2` casts to the AgentServer, which routes the request to the configured persistence module and broadcasts the saved record as `{:display_message_saved, msg}` — the same event LiveViews already subscribe to for LLM messages.
- The new `save_synthetic_message/3` callback is declared **optional** on the behaviour, so existing implementations don't break. AgentServer checks `function_exported?/3` before calling and logs a warning if missing.
- Persistence failures (`{:error, _}` or raised exceptions) are logged but never propagate — synthetic messages are a transcript convenience and must not destabilise the agent.
- Generator template (`priv/templates/display_message_persistence.ex.eex`) gets a default implementation that delegates to the integrator's `Conversations` context, so newly generated projects pick this up automatically.

## Changes

- `lib/sagents/agent_server.ex` — Added `save_synthetic_message_from/2` public API, `:save_synthetic_message` cast handler, and the `maybe_save_synthetic_and_broadcast/2` helper that gates on persistence + conversation_id, checks the optional callback, and rescues errors.
- `lib/sagents/display_message_persistence.ex` — Added `synthetic_message_attrs` typedoc and `save_synthetic_message/3` optional callback with full `@doc` covering parameters, return shape, and the broadcast contract.
- `priv/templates/display_message_persistence.ex.eex` — Default generated implementation delegating to `Conversations.append_display_message/3`, with a `{:error, :no_conversation}` guard for missing `conversation_id`.
- `test/sagents/agent_server_synthetic_message_test.exs` — New test module covering the happy path, both no-op cases (missing `conversation_id`, missing persistence module), `{:error, _}` returns, and rescued exceptions.
- `test/support/test_display_message_persistence.ex` — Extended `TestDisplayMessagePersistenceForwarding` with `save_synthetic_message/3` plus `set_synthetic_response/1` and `clear_synthetic_response/0` helpers driven via `:persistent_term`, so a single test module can simulate ok/error/raise outcomes.

## Testing

`mix test test/sagents/agent_server_synthetic_message_test.exs` covers all five scenarios listed above. No live API calls — the forwarder persistence module substitutes for a real implementation and asserts the AgentServer's behaviour around it.