### PR TITLE
Recover from stale interrupted state on agent restart

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -1821,6 +1821,29 @@ defmodule Sagents.AgentServer do
   end
 
   @impl true
+  def handle_info({:EXIT, pid, reason}, server_state) do
+    # Task.async/1 both links and monitors, so a crashing execution task
+    # delivers both {:EXIT, pid, reason} (via link, because we trap exits)
+    # and {:DOWN, ref, :process, pid, reason} (via monitor). The DOWN path
+    # already routes to handle_task_down/2 and transitions the agent to
+    # :error. If for some reason that path didn't run yet (race), make sure
+    # the EXIT also drives the same transition so the agent never gets
+    # stuck in :running with a dead task.
+    case server_state.task do
+      %Task{pid: ^pid} ->
+        if server_state.status in [:error, :cancelled] do
+          {:noreply, server_state}
+        else
+          handle_task_down(reason, server_state)
+        end
+
+      _ ->
+        # Some other linked process exited; nothing for us to do here.
+        {:noreply, server_state}
+    end
+  end
+
+  @impl true
   def handle_info({:llm_deltas, _deltas}, server_state) do
     # Deltas are broadcast via on_llm_new_delta callback in build_pubsub_callbacks
     # No need to process them here - the client (chat_live.ex) will handle merging

--- a/lib/sagents/middleware/ask_user_question.ex
+++ b/lib/sagents/middleware/ask_user_question.ex
@@ -58,6 +58,7 @@ defmodule Sagents.Middleware.AskUserQuestion do
 
   @behaviour Sagents.Middleware
 
+  alias Sagents.AgentServer
   alias Sagents.State
   alias LangChain.Function
   alias LangChain.Message.ToolResult
@@ -102,13 +103,13 @@ defmodule Sagents.Middleware.AskUserQuestion do
 
   # Resolve: resume_data is a response map. Process the user's answer.
   def handle_resume(
-        _agent,
+        agent,
         %State{interrupt_data: %{type: :ask_user_question}} = state,
         response,
         _config,
         _opts
       ) do
-    resolve_single_question(state, state.interrupt_data, response)
+    resolve_single_question(agent, state, state.interrupt_data, response)
   end
 
   # Multiple interrupts where ALL are ask_user questions.
@@ -128,7 +129,7 @@ defmodule Sagents.Middleware.AskUserQuestion do
   end
 
   def handle_resume(
-        _agent,
+        agent,
         %State{interrupt_data: %{type: :multiple_interrupts, interrupts: interrupts}} = state,
         responses,
         _config,
@@ -136,7 +137,7 @@ defmodule Sagents.Middleware.AskUserQuestion do
       )
       when is_list(responses) do
     if Enum.all?(interrupts, &(&1.type == :ask_user_question)) do
-      resolve_multiple_questions(state, interrupts, responses)
+      resolve_multiple_questions(agent, state, interrupts, responses)
     else
       {:cont, state}
     end
@@ -144,7 +145,7 @@ defmodule Sagents.Middleware.AskUserQuestion do
 
   def handle_resume(_agent, state, _resume_data, _config, _opts), do: {:cont, state}
 
-  defp resolve_single_question(state, question_data, response) do
+  defp resolve_single_question(agent, state, question_data, response) do
     case process_response(response, question_data) do
       {:ok, tool_result_content} ->
         new_tool_result =
@@ -155,6 +156,8 @@ defmodule Sagents.Middleware.AskUserQuestion do
             is_interrupt: false
           })
 
+        save_user_facing_message(agent, question_data, response)
+
         {:ok, State.replace_tool_result(state, question_data.tool_call_id, new_tool_result)}
 
       {:error, reason} ->
@@ -162,7 +165,7 @@ defmodule Sagents.Middleware.AskUserQuestion do
     end
   end
 
-  defp resolve_multiple_questions(state, interrupts, responses) do
+  defp resolve_multiple_questions(agent, state, interrupts, responses) do
     # Build a map of tool_call_id -> response for lookup
     responses_by_id = Map.new(responses, fn r -> {r.tool_call_id, r} end)
 
@@ -183,6 +186,8 @@ defmodule Sagents.Middleware.AskUserQuestion do
                 is_interrupt: false
               })
 
+            save_user_facing_message(agent, question_data, response)
+
             {:cont,
              {:ok,
               State.replace_tool_result(acc_state, question_data.tool_call_id, new_tool_result)}}
@@ -193,6 +198,29 @@ defmodule Sagents.Middleware.AskUserQuestion do
       end
     end)
   end
+
+  # Fire a synthetic display message so the user's answer (or cancellation)
+  # appears in the conversation transcript. Skipped when called outside a live
+  # AgentServer context (nil agent in unit tests, missing agent_id, or a cast
+  # to a registered name that isn't currently alive).
+  defp save_user_facing_message(nil, _question_data, _response), do: :ok
+
+  defp save_user_facing_message(%{agent_id: agent_id}, question_data, response)
+       when is_binary(agent_id) do
+    case user_facing_attrs(response, question_data) do
+      {:ok, attrs} ->
+        try do
+          AgentServer.save_synthetic_message_from(agent_id, attrs)
+        catch
+          :exit, _ -> :ok
+        end
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp save_user_facing_message(_agent, _question_data, _response), do: :ok
 
   # -- Tool definition --
 
@@ -514,6 +542,113 @@ defmodule Sagents.Middleware.AskUserQuestion do
       _ ->
         {:error, "freeform 'other_text' must be a string"}
     end
+  end
+
+  # -- User-facing display formatting --
+  #
+  # Produces synthetic display message attrs from a user response. Uses option
+  # *labels* (what the user saw), unlike `process_response/2` which builds the
+  # LLM-facing text from option *values*.
+
+  @doc false
+  @spec user_facing_attrs(map(), map()) :: {:ok, map()} | {:error, term()}
+  def user_facing_attrs(%{type: :cancel}, %{allow_cancel: true}) do
+    {:ok, notification_attrs("User cancelled")}
+  end
+
+  def user_facing_attrs(%{type: :cancel}, _question_data) do
+    {:error, :cancellation_not_allowed}
+  end
+
+  def user_facing_attrs(%{type: :answer} = response, %{response_type: :freeform}) do
+    case Map.get(response, :other_text) do
+      text when is_binary(text) and byte_size(text) > 0 -> {:ok, user_text_attrs(text)}
+      _ -> {:error, :empty_freeform}
+    end
+  end
+
+  def user_facing_attrs(%{type: :answer} = response, %{response_type: :single_select} = q) do
+    case Map.get(response, :selected, []) do
+      [value] when is_binary(value) ->
+        cond do
+          special_other?(value, q.options) and not Map.get(q, :allow_other, false) ->
+            {:error, :other_not_allowed}
+
+          special_other?(value, q.options) ->
+            other_text = Map.get(response, :other_text, "")
+            {:ok, user_text_attrs("Other:  \n#{other_text}")}
+
+          true ->
+            {:ok, user_text_attrs(lookup_label(q.options, value))}
+        end
+
+      _ ->
+        {:error, :invalid_single_select}
+    end
+  end
+
+  def user_facing_attrs(%{type: :answer} = response, %{response_type: :multi_select} = q) do
+    case Map.get(response, :selected, []) do
+      selected when is_list(selected) and selected != [] ->
+        has_other? = Enum.any?(selected, &special_other?(&1, q.options))
+
+        cond do
+          has_other? and not Map.get(q, :allow_other, false) ->
+            {:error, :other_not_allowed}
+
+          true ->
+            regular = Enum.reject(selected, &special_other?(&1, q.options))
+            labels_csv = regular |> Enum.map(&lookup_label(q.options, &1)) |> Enum.join(", ")
+
+            text =
+              if has_other? do
+                other_text = Map.get(response, :other_text, "")
+
+                case labels_csv do
+                  "" -> "Other:  \n#{other_text}"
+                  csv -> "#{csv}  \nOther:  \n#{other_text}"
+                end
+              else
+                labels_csv
+              end
+
+            {:ok, user_text_attrs(text)}
+        end
+
+      _ ->
+        {:error, :invalid_multi_select}
+    end
+  end
+
+  def user_facing_attrs(_response, _question_data), do: {:error, :invalid_response}
+
+  defp lookup_label(options, value) do
+    case Enum.find(options, &(&1.value == value)) do
+      %{label: label} when is_binary(label) -> label
+      _ -> value
+    end
+  end
+
+  # The special "Other" sentinel only applies when "other" is NOT a regular
+  # option value -- otherwise the LLM provided "other" as a real choice.
+  defp special_other?(value, options) do
+    value == "other" and not Enum.any?(options, &(&1.value == "other"))
+  end
+
+  defp user_text_attrs(text) do
+    %{
+      message_type: "user",
+      content_type: "text",
+      content: %{"text" => text}
+    }
+  end
+
+  defp notification_attrs(text) do
+    %{
+      message_type: "system",
+      content_type: "notification",
+      content: %{"text" => text}
+    }
   end
 
   # -- System prompt --

--- a/lib/sagents/persistence/state_serializer.ex
+++ b/lib/sagents/persistence/state_serializer.ex
@@ -157,7 +157,10 @@ defmodule Sagents.Persistence.StateSerializer do
       end
 
     case State.new(%{agent_id: agent_id, messages: messages, todos: todos, metadata: metadata}) do
-      {:ok, state} -> {:ok, state}
+      # Always sanitize stale interrupts. `interrupt_data` on a ToolResult is
+      # a virtual field, so any persisted `is_interrupt: true` result loses
+      # its data on round-trip and would crash the chain on the next run.
+      {:ok, state} -> {:ok, State.clean_stale_interrupts(state)}
       {:error, changeset} -> {:error, {:invalid_state, changeset}}
     end
   end

--- a/lib/sagents/state.ex
+++ b/lib/sagents/state.ex
@@ -129,10 +129,8 @@ defmodule Sagents.State do
     - `{:error, reason}` - Deserialization failed
   """
   def from_serialized(agent_id, data) when is_binary(agent_id) and is_map(data) do
-    case Sagents.Persistence.StateSerializer.deserialize_state(agent_id, data) do
-      {:ok, state} -> {:ok, clean_stale_interrupts(state)}
-      error -> error
-    end
+    # StateSerializer.deserialize_state/2 already applies clean_stale_interrupts/1.
+    Sagents.Persistence.StateSerializer.deserialize_state(agent_id, data)
   end
 
   @doc """

--- a/priv/templates/agent_subscriber_session.ex.eex
+++ b/priv/templates/agent_subscriber_session.ex.eex
@@ -100,7 +100,13 @@ defmodule <%= module %> do
 
   @doc """
   Status changed to :interrupted (waiting for human input).
+
+  Returns an empty changes map when `interrupt_data` is `nil` (e.g. an agent
+  whose status is `:interrupted` but whose interrupt payload hasn't been
+  populated yet). Callers can apply the result unconditionally.
   """
+  def handle_status_interrupted(nil), do: %{}
+
   def handle_status_interrupted(interrupt_data) do
     Map.merge(
       %{loading: false, agent_status: :interrupted, interrupt_data: interrupt_data},

--- a/test/sagents/agent_server_test.exs
+++ b/test/sagents/agent_server_test.exs
@@ -480,6 +480,35 @@ defmodule Sagents.AgentServerTest do
       assert info.error == "Something went wrong"
     end
 
+    test "transitions to :error when execution task crashes", %{agent: agent, agent_id: agent_id} do
+      # Simulates the BadMapError-style crash inside the execution task
+      # (e.g. langchain's check_tool_interrupts raising on stale state). The
+      # AgentServer must transition cleanly to :error so the user sees a real
+      # failure they can retry — not get stuck in :running with a dead task,
+      # and not silently absorb the EXIT signal.
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      Agent
+      |> expect(:execute, fn ^agent, _state, _opts ->
+        raise BadMapError, term: nil
+      end)
+
+      {:ok, _pid} =
+        AgentServer.start_link(
+          agent: agent,
+          initial_state: initial_state,
+          name: AgentServer.get_name(agent_id),
+          pubsub: nil
+        )
+
+      assert :ok = AgentServer.execute(agent_id)
+
+      # Give the crash a moment to propagate through DOWN/EXIT.
+      Process.sleep(100)
+
+      assert AgentServer.get_status(agent_id) == :error
+    end
+
     test "handles 3-tuple {:ok, state, extra} from until_tool completion", %{
       agent: agent,
       agent_id: agent_id

--- a/test/sagents/middleware/ask_user_question_test.exs
+++ b/test/sagents/middleware/ask_user_question_test.exs
@@ -784,4 +784,167 @@ defmodule Sagents.Middleware.AskUserQuestionTest do
       assert content_text(result_2.content) =~ "cancelled"
     end
   end
+
+  describe "user_facing_attrs/2" do
+    defp question(overrides) do
+      Map.merge(
+        %{
+          type: :ask_user_question,
+          response_type: :single_select,
+          options: [
+            %{label: "PostgreSQL", value: "postgresql"},
+            %{label: "MongoDB", value: "mongodb"}
+          ],
+          allow_other: false,
+          allow_cancel: true,
+          context: nil,
+          tool_call_id: "call_1"
+        },
+        overrides
+      )
+    end
+
+    test "single_select renders the chosen option's label" do
+      response = %{type: :answer, selected: ["postgresql"]}
+
+      assert {:ok, attrs} = AskUserQuestion.user_facing_attrs(response, question(%{}))
+
+      assert attrs == %{
+               message_type: "user",
+               content_type: "text",
+               content: %{"text" => "PostgreSQL"}
+             }
+    end
+
+    test "single_select with special 'other' renders 'Other' + typed text" do
+      q = question(%{allow_other: true})
+      response = %{type: :answer, selected: ["other"], other_text: "DuckDB please"}
+
+      assert {:ok, attrs} = AskUserQuestion.user_facing_attrs(response, q)
+      assert attrs.content == %{"text" => "Other:  \nDuckDB please"}
+      assert attrs.message_type == "user"
+    end
+
+    test "single_select 'other' is rejected when allow_other is false" do
+      response = %{type: :answer, selected: ["other"], other_text: "x"}
+
+      assert {:error, :other_not_allowed} =
+               AskUserQuestion.user_facing_attrs(response, question(%{allow_other: false}))
+    end
+
+    test "single_select treats 'other' as a regular value when it's a real option" do
+      q =
+        question(%{
+          options: [
+            %{label: "Yes", value: "yes"},
+            %{label: "Other Brand", value: "other"}
+          ]
+        })
+
+      response = %{type: :answer, selected: ["other"]}
+
+      assert {:ok, attrs} = AskUserQuestion.user_facing_attrs(response, q)
+      assert attrs.content == %{"text" => "Other Brand"}
+    end
+
+    test "multi_select joins labels with ', '" do
+      q =
+        question(%{
+          response_type: :multi_select,
+          options: [
+            %{label: "Auth", value: "auth"},
+            %{label: "Billing", value: "billing"},
+            %{label: "Notifications", value: "notif"}
+          ]
+        })
+
+      response = %{type: :answer, selected: ["auth", "notif"]}
+
+      assert {:ok, attrs} = AskUserQuestion.user_facing_attrs(response, q)
+      assert attrs.content == %{"text" => "Auth, Notifications"}
+    end
+
+    test "multi_select with 'other' appends a new line + typed text" do
+      q =
+        question(%{
+          response_type: :multi_select,
+          allow_other: true,
+          options: [
+            %{label: "Auth", value: "auth"},
+            %{label: "Billing", value: "billing"}
+          ]
+        })
+
+      response = %{
+        type: :answer,
+        selected: ["auth", "other"],
+        other_text: "audit logging"
+      }
+
+      assert {:ok, attrs} = AskUserQuestion.user_facing_attrs(response, q)
+      assert attrs.content == %{"text" => "Auth  \nOther:  \naudit logging"}
+    end
+
+    test "multi_select 'other' alone (no regular selections) renders without leading CSV" do
+      q =
+        question(%{
+          response_type: :multi_select,
+          allow_other: true,
+          options: [%{label: "A", value: "a"}, %{label: "B", value: "b"}]
+        })
+
+      response = %{type: :answer, selected: ["other"], other_text: "neither"}
+
+      assert {:ok, attrs} = AskUserQuestion.user_facing_attrs(response, q)
+      assert attrs.content == %{"text" => "Other:  \nneither"}
+    end
+
+    test "multi_select rejects 'other' when allow_other is false" do
+      q =
+        question(%{
+          response_type: :multi_select,
+          allow_other: false,
+          options: [%{label: "A", value: "a"}]
+        })
+
+      response = %{type: :answer, selected: ["a", "other"], other_text: "x"}
+
+      assert {:error, :other_not_allowed} = AskUserQuestion.user_facing_attrs(response, q)
+    end
+
+    test "freeform renders the user's typed text" do
+      q = question(%{response_type: :freeform, options: []})
+      response = %{type: :answer, other_text: "Use jsonb columns."}
+
+      assert {:ok, attrs} = AskUserQuestion.user_facing_attrs(response, q)
+      assert attrs.content == %{"text" => "Use jsonb columns."}
+      assert attrs.message_type == "user"
+    end
+
+    test "freeform with empty text errors" do
+      q = question(%{response_type: :freeform, options: []})
+
+      assert {:error, :empty_freeform} =
+               AskUserQuestion.user_facing_attrs(%{type: :answer, other_text: ""}, q)
+    end
+
+    test "cancel produces a notification message" do
+      assert {:ok, attrs} =
+               AskUserQuestion.user_facing_attrs(%{type: :cancel}, question(%{}))
+
+      assert attrs == %{
+               message_type: "system",
+               content_type: "notification",
+               content: %{"text" => "User cancelled"}
+             }
+    end
+
+    test "cancel is rejected when allow_cancel is false" do
+      assert {:error, :cancellation_not_allowed} =
+               AskUserQuestion.user_facing_attrs(
+                 %{type: :cancel},
+                 question(%{allow_cancel: false})
+               )
+    end
+  end
 end

--- a/test/sagents/persistence/state_serializer_test.exs
+++ b/test/sagents/persistence/state_serializer_test.exs
@@ -246,6 +246,52 @@ defmodule Sagents.Persistence.StateSerializerTest do
       assert tool_call.arguments["expression"] == "2 + 2"
     end
 
+    test "sanitizes stale interrupted tool results on deserialize" do
+      # interrupt_data is a virtual field, so a persisted is_interrupt: true
+      # tool result loses its data on round-trip. clean_stale_interrupts/1
+      # must be applied automatically so the next chain run does not crash on
+      # nil interrupt_data inside extract_interrupt_data/1.
+      serialized = %{
+        "version" => 1,
+        "state" => %{
+          "messages" => [
+            %{
+              "role" => "tool",
+              "content" => nil,
+              "status" => "complete",
+              "tool_results" => [
+                %{
+                  "type" => "function",
+                  "tool_call_id" => "call-1",
+                  "name" => "ask_user",
+                  "content" => "Waiting for user response...",
+                  "is_interrupt" => true
+                }
+              ]
+            }
+          ],
+          "todos" => [],
+          "metadata" => %{}
+        },
+        "agent_config" => %{
+          "model" => %{
+            "module" => "Elixir.LangChain.ChatModels.ChatOpenAI",
+            "model" => "gpt-4"
+          },
+          "middleware" => []
+        },
+        "serialized_at" => "2025-11-29T10:30:00Z"
+      }
+
+      {:ok, state} = StateSerializer.deserialize_server_state("agent-123", serialized)
+
+      assert [tool_message] = state.messages
+      assert [result] = tool_message.tool_results
+      refute result.is_interrupt
+      assert result.is_error
+      assert result.content =~ "interrupted"
+    end
+
     test "handles missing version field" do
       serialized = %{
         "state" => %{


### PR DESCRIPTION
## Problem

When an agent is interrupted by an `ask_user_question` and then shuts down before the user responds, the persisted state is unsafe to restore. `ToolResult.interrupt_data` is a virtual field, so a serialized result with `is_interrupt: true` comes back with `interrupt_data: nil`. On the next chain run, langchain's `check_tool_interrupts` raises a `BadMapError`, the execution task crashes inside `AgentServer`, and the agent gets stuck in `:running` with a dead task. The user sees a broken conversation they cannot retry.

A second, related gap: when the user finally answers an `ask_user_question`, only the LLM-facing tool result is recorded. The user's actual choice (or cancellation) never lands in the display transcript, so reloading the conversation shows the question without the answer.

## Solution

Three coordinated fixes:

1. **Sanitize stale interrupts at the serializer boundary.** [`StateSerializer.deserialize_state/2`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/persistence/state_serializer.ex#L160) now applies `State.clean_stale_interrupts/1` unconditionally on the way out, converting `is_interrupt: true` results into `is_error: true` results with a clear message. The duplicate call in [`State.from_serialized/2`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/state.ex#L131) is removed so there is one source of truth.

2. **Catch execution-task crashes in `AgentServer`.** A new [`handle_info({:EXIT, pid, reason}, ...)`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/agent_server.ex#L1823) clause routes a crashed `Task.async` process through the same `handle_task_down/2` path the monitor uses, so the agent transitions cleanly to `:error` instead of getting stuck. Idempotent against the existing `:DOWN` handler.

3. **Persist user answers as display messages.** [`AskUserQuestion.handle_resume/5`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/middleware/ask_user_question.ex#L105) now calls `AgentServer.save_synthetic_message_from/2` with attrs built by the new [`user_facing_attrs/2`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/middleware/ask_user_question.ex#L553), which renders option *labels* (single/multi select), typed freeform text, the special `Other` sentinel, and cancellation notifications. Safe-by-default: `nil` agent or missing `agent_id` is a no-op so unit tests keep working.

Bonus: the generated [`agent_subscriber_session.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/priv/templates/agent_subscriber_session.ex.eex#L108) template now has a `handle_status_interrupted(nil)` clause so subscribers can apply the result unconditionally without crashing on agents that report `:interrupted` before their interrupt payload is populated.

## Changes

- [`lib/sagents/agent_server.ex`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/agent_server.ex) Added `handle_info({:EXIT, ...})` clause to drive crashed execution tasks to `:error`.
- [`lib/sagents/persistence/state_serializer.ex`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/persistence/state_serializer.ex) Apply `clean_stale_interrupts/1` on every deserialize so virtual `interrupt_data` cannot resurface as `nil` on the next run.
- [`lib/sagents/state.ex`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/state.ex) Removed the now-redundant `clean_stale_interrupts/1` call in `from_serialized/2`.
- [`lib/sagents/middleware/ask_user_question.ex`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/lib/sagents/middleware/ask_user_question.ex) New `user_facing_attrs/2` formatter and `save_user_facing_message/3` hook in `handle_resume`. Threads `agent` through `resolve_single_question` and `resolve_multiple_questions`.
- [`priv/templates/agent_subscriber_session.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/priv/templates/agent_subscriber_session.ex.eex) Added `handle_status_interrupted(nil)` clause and a moduledoc note.
- [`test/sagents/agent_server_test.exs`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/test/sagents/agent_server_test.exs) New test: execution-task crash transitions the server to `:error`.
- [`test/sagents/persistence/state_serializer_test.exs`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/test/sagents/persistence/state_serializer_test.exs) New test: round-tripping a stale `is_interrupt: true` result is sanitized into an error result with `interrupt_data: nil` cleared.
- [`test/sagents/middleware/ask_user_question_test.exs`](https://github.com/sagents-ai/sagents/blob/me-recover-from-stale-interrupted-tool/test/sagents/middleware/ask_user_question_test.exs) Twelve new tests covering `user_facing_attrs/2`: single/multi select label rendering, the `other` sentinel vs a real `other` option, freeform, cancellation, and the `allow_other` / `allow_cancel` rejection paths.

## Testing

- New unit tests for each of the three fixes (crash recovery, serializer sanitization, user-facing formatter) plus the existing suite covers the happy paths through `handle_resume`.
- Run `mix test` from `sagents/` to exercise. No live API calls required.