### PR TITLE
Consolidate AgentServer subscribe API into subscribe/3 + unsubscribe/3

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -492,64 +492,55 @@ defmodule Sagents.AgentServer do
   end
 
   @doc """
-  Subscribe the calling process to main events from this AgentServer.
+  Subscribe a process to events from this AgentServer.
 
-  Events are delivered as `{:agent, event}` messages via direct `send/2`.
-  The producer monitors the subscriber so departure is
-  cleaned up automatically — but subscribers should also `Process.monitor/1`
-  the returned `server_pid` to detect server death.
+  Events on the `:main` channel are delivered as `{:agent, event}` messages;
+  events on the `:debug` channel are delivered as `{:agent, {:debug, event}}`
+  and provide additional insight into middleware state, sub-agent activity,
+  and similar diagnostic data not surfaced on the main channel.
+
+  Delivery is via direct `send/2`. The producer monitors the subscriber so
+  departure is cleaned up automatically — but subscribers should also
+  `Process.monitor/1` the returned `server_pid` to detect server death.
+
+  ## Arguments
+
+  - `agent_id` — the agent's id.
+  - `channel` — `:main` (default) or `:debug`.
+  - `subscriber_pid` — the pid to receive events. Defaults to `self()` when
+    `nil`.
 
   Returns `{:ok, server_pid, monitor_ref}` on success, or
   `{:error, :process_not_found}` if no AgentServer is running for `agent_id`.
 
   ## Examples
 
+      # Most common: subscribe self() to the main channel.
       {:ok, _pid, _ref} = AgentServer.subscribe("my-agent-1")
+
+      # Subscribe to debug events (used by sagents_live_debugger and similar).
+      {:ok, _pid, _ref} = AgentServer.subscribe("my-agent-1", :debug)
+
+      # Subscribe a foreign pid (e.g. a bridge GenServer that proxies events).
+      {:ok, _pid, _ref} = AgentServer.subscribe("my-agent-1", :main, bridge_pid)
   """
-  @spec subscribe(String.t()) ::
+  @spec subscribe(String.t(), :main | :debug, pid() | nil) ::
           {:ok, pid(), reference()} | {:error, :process_not_found}
-  def subscribe(agent_id) do
-    Publisher.subscribe(get_name(agent_id), :main)
+  def subscribe(agent_id, channel \\ :main, subscriber_pid \\ nil)
+      when is_binary(agent_id) and channel in [:main, :debug] do
+    Publisher.subscribe(get_name(agent_id), channel, subscriber_pid)
   end
 
   @doc """
-  Unsubscribe the calling process from main events.
+  Unsubscribe a process from events on the given channel.
 
-  Always returns `:ok`.
+  Mirrors `subscribe/3`. Defaults `channel` to `:main` and `subscriber_pid`
+  to `self()` (when `nil`). Always returns `:ok`.
   """
-  @spec unsubscribe(String.t()) :: :ok
-  def unsubscribe(agent_id) do
-    Publisher.unsubscribe(get_name(agent_id), :main)
-  end
-
-  @doc """
-  Subscribe the calling process to debug events.
-
-  Debug events are delivered as `{:agent, {:debug, event}}` messages.
-  These provide additional insight into middleware state, sub-agent activity,
-  and similar diagnostic data not surfaced on the main channel.
-
-  Returns `{:ok, server_pid, monitor_ref}` on success, or
-  `{:error, :process_not_found}` if no AgentServer is running.
-
-  ## Examples
-
-      {:ok, _pid, _ref} = AgentServer.subscribe_debug("my-agent-1")
-  """
-  @spec subscribe_debug(String.t()) ::
-          {:ok, pid(), reference()} | {:error, :process_not_found}
-  def subscribe_debug(agent_id) do
-    Publisher.subscribe(get_name(agent_id), :debug)
-  end
-
-  @doc """
-  Unsubscribe the calling process from debug events.
-
-  Always returns `:ok`.
-  """
-  @spec unsubscribe_debug(String.t()) :: :ok
-  def unsubscribe_debug(agent_id) do
-    Publisher.unsubscribe(get_name(agent_id), :debug)
+  @spec unsubscribe(String.t(), :main | :debug, pid() | nil) :: :ok
+  def unsubscribe(agent_id, channel \\ :main, subscriber_pid \\ nil)
+      when is_binary(agent_id) and channel in [:main, :debug] do
+    Publisher.unsubscribe(get_name(agent_id), channel, subscriber_pid)
   end
 
   @doc """

--- a/lib/sagents/publisher.ex
+++ b/lib/sagents/publisher.ex
@@ -50,8 +50,26 @@ defmodule Sagents.Publisher do
   and receive the wrapped events as ordinary process messages. The producer
   monitors each subscriber to clean up on death.
 
-  See `Sagents.Subscriber` for the LiveView/GenServer-side helpers that capture
-  the monitor + Presence + auto-resubscribe loop.
+  ## Typical entry points
+
+  Most consumers should not call `Publisher.subscribe/3` directly — there are
+  higher-level wrappers that take an agent id (or filesystem scope key) and
+  resolve the via-tuple internally:
+
+    * `Sagents.AgentServer.subscribe/3` — `subscribe(agent_id, channel \\ :main,
+      subscriber_pid \\ nil)`. Covers the common case of subscribing `self()`
+      to `:main`, plus `:debug` (used by `sagents_live_debugger`) and
+      foreign-pid subscribers (e.g. a bridge GenServer proxying events to
+      another transport).
+    * `Sagents.FileSystemServer.subscribe/1` — same shape for filesystem
+      change events.
+    * `Sagents.Subscriber` — for hosts (LiveView, GenServer) that need
+      crash-recovery + Phoenix.Presence-driven re-subscription. Wraps the
+      AgentServer/FileSystemServer entry points and threads a subs map
+      through the host's state.
+
+  Reach for `Publisher.subscribe/3` directly only when implementing a new
+  producer module that needs to expose its own `subscribe/N` shorthand.
 
   ## Returned subscription handle
 

--- a/lib/sagents/subscriber.ex
+++ b/lib/sagents/subscriber.ex
@@ -114,7 +114,7 @@ defmodule Sagents.Subscriber do
     key = {:agent, agent_id}
 
     do_subscribe(subs, key, channel, fn ->
-      Publisher.subscribe(AgentServer.get_name(agent_id), channel, subscriber_pid)
+      AgentServer.subscribe(agent_id, channel, subscriber_pid)
     end)
   end
 

--- a/test/sagents/agent_cancel_subagent_test.exs
+++ b/test/sagents/agent_cancel_subagent_test.exs
@@ -126,7 +126,7 @@ defmodule Sagents.AgentCancelSubAgentTest do
       )
 
     {:ok, _server, _ref_main} = AgentServer.subscribe(agent_id)
-    {:ok, _server, _ref_debug} = AgentServer.subscribe_debug(agent_id)
+    {:ok, _server, _ref_debug} = AgentServer.subscribe(agent_id, :debug)
 
     assert :ok = AgentServer.execute(agent_id)
 

--- a/test/sagents/agent_server_debug_pubsub_test.exs
+++ b/test/sagents/agent_server_debug_pubsub_test.exs
@@ -32,21 +32,24 @@ defmodule Sagents.AgentServerDebugPubSubTest do
     end
   end
 
-  describe "subscribe_debug/1" do
+  describe "subscribe/3 debug channel" do
     test "subscribes to debug events successfully" do
       agent = create_test_agent()
       agent_id = agent.agent_id
 
       {:ok, _pid} = AgentServer.start_link(agent: agent)
 
-      assert {:ok, server_pid, ref} = AgentServer.subscribe_debug(agent_id)
+      assert {:ok, server_pid, ref} = AgentServer.subscribe(agent_id, :debug)
       assert is_pid(server_pid)
       assert is_reference(ref)
     end
 
     test "returns process_not_found when no AgentServer is running" do
       assert {:error, :process_not_found} =
-               AgentServer.subscribe_debug("never-started-#{System.unique_integer([:positive])}")
+               AgentServer.subscribe(
+                 "never-started-#{System.unique_integer([:positive])}",
+                 :debug
+               )
     end
   end
 
@@ -57,7 +60,7 @@ defmodule Sagents.AgentServerDebugPubSubTest do
 
       {:ok, _pid} = AgentServer.start_link(agent: agent)
 
-      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent_id)
+      {:ok, _pid, _ref} = AgentServer.subscribe(agent_id, :debug)
 
       :ok = AgentServer.notify_middleware(agent_id, TestMiddleware, :test_message)
 
@@ -99,7 +102,7 @@ defmodule Sagents.AgentServerDebugPubSubTest do
         %{server_state | status: :running, execution_seq: 1}
       end)
 
-      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent_id)
+      {:ok, _pid, _ref} = AgentServer.subscribe(agent_id, :debug)
 
       injected_user = Message.new_user!("synthetic kickoff")
       injected_assistant = Message.new_assistant!("synthetic reference dump")
@@ -133,7 +136,7 @@ defmodule Sagents.AgentServerDebugPubSubTest do
         %{server_state | status: :running, execution_seq: 5}
       end)
 
-      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent_id)
+      {:ok, _pid, _ref} = AgentServer.subscribe(agent_id, :debug)
 
       stale_state = State.new!(%{messages: [Message.new_user!("from old run")]})
 
@@ -155,7 +158,7 @@ defmodule Sagents.AgentServerDebugPubSubTest do
       {:ok, _pid} = AgentServer.start_link(agent: agent)
 
       # Server starts in :idle.
-      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent_id)
+      {:ok, _pid, _ref} = AgentServer.subscribe(agent_id, :debug)
 
       prepared_state = State.new!(%{messages: [Message.new_user!("ignored")]})
 
@@ -195,7 +198,7 @@ defmodule Sagents.AgentServerDebugPubSubTest do
                  agent_id: new_agent_id
                )
 
-      assert {:ok, _pid, _ref} = AgentServer.subscribe_debug(new_agent_id)
+      assert {:ok, _pid, _ref} = AgentServer.subscribe(new_agent_id, :debug)
     end
   end
 
@@ -208,7 +211,7 @@ defmodule Sagents.AgentServerDebugPubSubTest do
       {:ok, _pid2} = AgentServer.start_link(agent: agent2)
 
       # Subscribe to agent1's debug events only
-      {:ok, _pid, _ref} = AgentServer.subscribe_debug(agent1.agent_id)
+      {:ok, _pid, _ref} = AgentServer.subscribe(agent1.agent_id, :debug)
 
       # Send message to agent2 — we should not see its events
       :ok = AgentServer.notify_middleware(agent2.agent_id, TestMiddleware, :test_message)
@@ -217,6 +220,80 @@ defmodule Sagents.AgentServerDebugPubSubTest do
       # Send message to agent1 — we should see this one
       :ok = AgentServer.notify_middleware(agent1.agent_id, TestMiddleware, :test_message)
       assert_receive {:agent, {:debug, {:agent_state_update, TestMiddleware, %State{}}}}, 100
+    end
+  end
+
+  describe "subscribe/3 with explicit subscriber_pid" do
+    test "delivers events to the foreign pid, not the caller" do
+      agent = create_test_agent(middleware: [{TestMiddleware, []}])
+      agent_id = agent.agent_id
+      {:ok, _pid} = AgentServer.start_link(agent: agent)
+
+      parent = self()
+
+      foreign =
+        spawn_link(fn ->
+          send(parent, :foreign_ready)
+
+          receive do
+            msg -> send(parent, {:foreign_got, msg})
+          end
+        end)
+
+      assert_receive :foreign_ready
+
+      {:ok, _server, _ref} = AgentServer.subscribe(agent_id, :debug, foreign)
+
+      :ok = AgentServer.notify_middleware(agent_id, TestMiddleware, :test_message)
+
+      # The foreign pid receives the wrapped debug event...
+      assert_receive {:foreign_got,
+                      {:agent, {:debug, {:agent_state_update, TestMiddleware, %State{}}}}},
+                     200
+
+      # ...but the caller, who subscribed on behalf of the foreign pid,
+      # does not receive it directly.
+      refute_receive {:agent, {:debug, {:agent_state_update, _, _}}}, 50
+    end
+  end
+
+  describe "subscribe/3 idempotency" do
+    test "re-subscribing returns the same monitor_ref" do
+      agent = create_test_agent()
+      agent_id = agent.agent_id
+      {:ok, _pid} = AgentServer.start_link(agent: agent)
+
+      {:ok, server_pid_1, ref_1} = AgentServer.subscribe(agent_id, :debug)
+      {:ok, server_pid_2, ref_2} = AgentServer.subscribe(agent_id, :debug)
+
+      assert server_pid_1 == server_pid_2
+      assert ref_1 == ref_2
+    end
+  end
+
+  describe "unsubscribe/3" do
+    test "stops debug delivery on the :debug channel" do
+      agent = create_test_agent(middleware: [{TestMiddleware, []}])
+      agent_id = agent.agent_id
+      {:ok, _pid} = AgentServer.start_link(agent: agent)
+
+      {:ok, _server, _ref} = AgentServer.subscribe(agent_id, :debug)
+
+      :ok = AgentServer.notify_middleware(agent_id, TestMiddleware, :test_message)
+      assert_receive {:agent, {:debug, {:agent_state_update, _, _}}}, 100
+
+      :ok = AgentServer.unsubscribe(agent_id, :debug)
+
+      :ok = AgentServer.notify_middleware(agent_id, TestMiddleware, :test_message)
+      refute_receive {:agent, {:debug, {:agent_state_update, _, _}}}, 100
+    end
+
+    test "returns :ok when the AgentServer is not running" do
+      assert :ok =
+               AgentServer.unsubscribe(
+                 "never-started-#{System.unique_integer([:positive])}",
+                 :debug
+               )
     end
   end
 end

--- a/test/sagents/agent_server_middleware_messaging_test.exs
+++ b/test/sagents/agent_server_middleware_messaging_test.exs
@@ -315,7 +315,7 @@ defmodule Sagents.AgentServerMiddlewareMessagingTest do
           name: AgentServer.get_name(agent_id)
         )
 
-      {:ok, _server, _ref} = AgentServer.subscribe_debug(agent_id)
+      {:ok, _server, _ref} = AgentServer.subscribe(agent_id, :debug)
 
       # Send message that updates state
       send(

--- a/test/sagents/agent_server_test.exs
+++ b/test/sagents/agent_server_test.exs
@@ -977,7 +977,7 @@ defmodule Sagents.AgentServerTest do
 
       # Subscribe to both main and debug channels
       {:ok, _pid, _ref} = AgentServer.subscribe(agent_id)
-      AgentServer.subscribe_debug(agent_id)
+      AgentServer.subscribe(agent_id, :debug)
 
       {:ok, agent: agent, agent_id: agent_id}
     end
@@ -1154,7 +1154,7 @@ defmodule Sagents.AgentServerTest do
         )
 
       # Subscribe to debug events
-      AgentServer.subscribe_debug(agent_id)
+      AgentServer.subscribe(agent_id, :debug)
 
       # Publish a middleware action debug event
       test_event = {:middleware_action, TestMiddleware, {:test_action, "test_data"}}

--- a/test/sagents/middleware/conversation_title_integration_test.exs
+++ b/test/sagents/middleware/conversation_title_integration_test.exs
@@ -60,7 +60,7 @@ defmodule Sagents.Middleware.ConversationTitleIntegrationTest do
         )
 
       AgentServer.subscribe(agent_id)
-      AgentServer.subscribe_debug(agent_id)
+      AgentServer.subscribe(agent_id, :debug)
 
       # Made NOT LIVE here
       #
@@ -115,7 +115,7 @@ defmodule Sagents.Middleware.ConversationTitleIntegrationTest do
         )
 
       AgentServer.subscribe(agent_id)
-      AgentServer.subscribe_debug(agent_id)
+      AgentServer.subscribe(agent_id, :debug)
 
       # Mock ChatAnthropic responses:
       # - First call (agent response) succeeds
@@ -170,7 +170,7 @@ defmodule Sagents.Middleware.ConversationTitleIntegrationTest do
         )
 
       AgentServer.subscribe(agent_id)
-      AgentServer.subscribe_debug(agent_id)
+      AgentServer.subscribe(agent_id, :debug)
 
       # Pre-populate the conversation with an existing title by sending a middleware message
       existing_title = "Existing Conversation Title"
@@ -217,7 +217,7 @@ defmodule Sagents.Middleware.ConversationTitleIntegrationTest do
         )
 
       AgentServer.subscribe(agent_id)
-      AgentServer.subscribe_debug(agent_id)
+      AgentServer.subscribe(agent_id, :debug)
 
       # First message: expect 2 calls (agent response + title generation)
       expect(ChatAnthropic, :call, 2, fn _model, messages, _tools ->

--- a/test/sagents/sub_agent_server_broadcast_test.exs
+++ b/test/sagents/sub_agent_server_broadcast_test.exs
@@ -26,7 +26,7 @@ defmodule Sagents.SubAgentServerBroadcastTest do
 
     {:ok, _pid} = AgentServer.start_link(agent: parent_agent)
 
-    {:ok, _server_pid, _ref} = AgentServer.subscribe_debug(parent_agent.agent_id)
+    {:ok, _server_pid, _ref} = AgentServer.subscribe(parent_agent.agent_id, :debug)
 
     parent_agent
   end

--- a/test/support/testing_helpers.ex
+++ b/test/support/testing_helpers.ex
@@ -233,14 +233,14 @@ defmodule Sagents.TestingHelpers do
         # Subscribe the calling test process to the agent's main + debug channels
         # via direct subscribe (the new Sagents.Publisher transport).
         _result = AgentServer.subscribe(agent_id)
-        _result = AgentServer.subscribe_debug(agent_id)
+        _result = AgentServer.subscribe(agent_id, :debug)
         {:ok, %{agent_id: agent_id, pid: pid}}
 
       {:error, {:already_started, _supervisor_pid}} ->
         # Already started - return existing pid
         pid = AgentServer.get_pid(agent_id)
         _result = AgentServer.subscribe(agent_id)
-        _result = AgentServer.subscribe_debug(agent_id)
+        _result = AgentServer.subscribe(agent_id, :debug)
         {:ok, %{agent_id: agent_id, pid: pid}}
 
       {:error, reason} ->


### PR DESCRIPTION
## Problem

The `AgentServer` pub/sub API had grown into four parallel functions — `subscribe/1`, `unsubscribe/1`, `subscribe_debug/1`, `unsubscribe_debug/1` — each hard-coding both the channel (`:main` vs `:debug`) and the subscriber pid (always `self()`). That left no way to subscribe a foreign pid (e.g. a bridge GenServer proxying events to another transport) without dropping down to the low-level `Sagents.Publisher` API and hand-resolving the via-tuple. It also made the entry-point hierarchy hard to discover: nothing in `Publisher`'s docs pointed callers at the higher-level wrappers, so new code tended to call `Publisher.subscribe/3` directly even when `AgentServer.subscribe/1` would have been the right choice.

## Solution

Collapse the four functions into two parameterized ones:

- `AgentServer.subscribe(agent_id, channel \\ :main, subscriber_pid \\ nil)`
- `AgentServer.unsubscribe(agent_id, channel \\ :main, subscriber_pid \\ nil)`

Both default to the previous behaviour (`:main` channel, `self()` as the subscriber when `subscriber_pid` is `nil`), so existing single-arg call sites keep working unchanged. The new shape additionally supports `:debug` and explicit foreign-pid subscriptions in a single call.

`Sagents.Subscriber` now routes through `AgentServer.subscribe/3` instead of calling `Publisher.subscribe/3` with a hand-built via-tuple — eating its own dog food and keeping the via-tuple resolution in one place.

`Sagents.Publisher`'s @moduledoc grew a 'Typical entry points' section that explicitly steers callers to `AgentServer.subscribe/3`, `FileSystemServer.subscribe/1`, or `Sagents.Subscriber`, and explains when reaching for `Publisher.subscribe/3` directly is actually appropriate (only when implementing a new producer module).

## Changes

- \`lib/sagents/agent_server.ex\` — Replaced \`subscribe/1\`, \`unsubscribe/1\`, \`subscribe_debug/1\`, \`unsubscribe_debug/1\` with parameterized \`subscribe/3\` and \`unsubscribe/3\`. Merged and rewrote the @doc to cover all three arguments with examples for the common case, the debug channel, and the foreign-pid case.
- \`lib/sagents/publisher.ex\` (@moduledoc) — Added a 'Typical entry points' section pointing callers at the higher-level wrappers and clarifying when direct \`Publisher\` use is warranted.
- \`lib/sagents/subscriber.ex\` — Switched the internal subscribe call from \`Publisher.subscribe(AgentServer.get_name(...), ...)\` to \`AgentServer.subscribe(agent_id, channel, subscriber_pid)\`.
- \`test/sagents/agent_server_debug_pubsub_test.exs\` — Renamed the \`subscribe_debug/1\` describe block to \`subscribe/3 debug channel\`, updated all call sites, and added three new describe blocks: \`subscribe/3 with explicit subscriber_pid\` (verifies foreign-pid delivery and that the caller does *not* also receive events), \`subscribe/3 idempotency\` (re-subscribing returns the same monitor_ref), and \`unsubscribe/3\` (debug-channel teardown plus the not-running case).
- \`test/sagents/agent_server_test.exs\`, \`test/sagents/agent_cancel_subagent_test.exs\`, \`test/sagents/agent_server_middleware_messaging_test.exs\`, \`test/sagents/conversation_title_integration_test.exs\`, \`test/sagents/sub_agent_server_broadcast_test.exs\`, \`test/support/testing_helpers.ex\` — Mechanical migration from \`subscribe_debug(agent_id)\` to \`subscribe(agent_id, :debug)\`.

## Testing

\`mix test\` covers the migration: every existing call site was updated and the existing debug-channel tests still pass under the new API. The new \`subscribe/3\` describe blocks specifically exercise the previously-unreachable behaviours — foreign-pid delivery, idempotent re-subscribe returning the same monitor_ref, and \`unsubscribe/3\` cleanly stopping delivery on the \`:debug\` channel (including the not-running case).