### PR TITLE
Support per-call `:initial_messages` on SubAgent invocations

### DIFF
--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -584,6 +584,18 @@ defmodule Sagents.Middleware.SubAgent do
     - `:descriptions` - Map of task_name -> description string
     - `:agent_id` - Parent agent ID
     - `:model` - Model configuration
+    - `:initial_messages` (optional) - List of `%LangChain.Message{}` structs
+      to slot between the sub-agent's system messages and the user instruction.
+      Use this to inject per-call reference content (e.g. a
+      `<references>` synthetic preamble) as established context for
+      the sub-agent's first turn. Empty list or omitted key means no
+      augmentation. Supported on all task types: for Compiled subagents,
+      these are appended *after* the registered `Compiled.initial_messages`.
+
+  ## Raises
+
+  - `ArgumentError` if `config[:initial_messages]` is supplied but is not a
+    list of `%LangChain.Message{}` structs.
 
   ## Returns
 
@@ -640,7 +652,7 @@ defmodule Sagents.Middleware.SubAgent do
   - For "general-purpose" type, tools and middleware are inherited from parent
   - SubAgents are supervised and cleaned up automatically
   """
-  @spec start_subagent(String.t(), String.t(), map(), map(), map()) ::
+  @spec start_subagent(String.t(), String.t(), args :: map(), context :: map(), config :: map()) ::
           {:ok, String.t()}
           | {:ok, String.t(), term()}
           | {:interrupt, map()}
@@ -648,11 +660,18 @@ defmodule Sagents.Middleware.SubAgent do
   def start_subagent(instructions, task_name, args, context, config) do
     Logger.debug("Starting SubAgent: #{task_name}")
 
+    per_call_initial = Map.get(config, :initial_messages, [])
+
+    if not valid_initial_messages?(per_call_initial) do
+      raise ArgumentError,
+            "config[:initial_messages] must be a list of LangChain.Message structs, got: #{inspect(per_call_initial)}"
+    end
+
     # Get agent from lookup map
     case Map.fetch(config.agent_map, task_name) do
       {:ok, :dynamic} ->
         # Handle "general-purpose" dynamic subagent with tool inheritance
-        start_dynamic_subagent(instructions, args, context, config)
+        start_dynamic_subagent(instructions, args, context, config, per_call_initial)
 
       {:ok, agent_config} ->
         # Look up until_tool configuration for this subagent type
@@ -673,12 +692,13 @@ defmodule Sagents.Middleware.SubAgent do
         subagent =
           case agent_config do
             %SubAgent.Compiled{} = compiled ->
-              # Use new_from_compiled to include initial_messages
+              final_initial = (compiled.initial_messages || []) ++ per_call_initial
+
               SubAgent.new_from_compiled(
                 parent_agent_id: config.agent_id,
                 instructions: instructions,
                 compiled_agent: compiled.agent,
-                initial_messages: compiled.initial_messages || [],
+                initial_messages: final_initial,
                 until_tool: until_tool,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
@@ -692,6 +712,7 @@ defmodule Sagents.Middleware.SubAgent do
                 parent_agent_id: config.agent_id,
                 instructions: instructions,
                 agent_config: agent,
+                initial_messages: per_call_initial,
                 until_tool: until_tool,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
@@ -735,9 +756,14 @@ defmodule Sagents.Middleware.SubAgent do
     end
   end
 
+  defp valid_initial_messages?(list) when is_list(list),
+    do: Enum.all?(list, &is_struct(&1, LangChain.Message))
+
+  defp valid_initial_messages?(_other), do: false
+
   ## Starting Dynamic SubAgent (general-purpose with tool inheritance)
 
-  defp start_dynamic_subagent(instructions, args, context, config) do
+  defp start_dynamic_subagent(instructions, args, context, config, per_call_initial) do
     Logger.debug("Starting dynamic general-purpose SubAgent")
 
     # Extract parent capabilities from context (set by Agent.build_chain)
@@ -787,6 +813,7 @@ defmodule Sagents.Middleware.SubAgent do
             parent_agent_id: config.agent_id,
             instructions: instructions,
             agent_config: agent_config,
+            initial_messages: per_call_initial,
             parent_tool_context: parent_tool_context,
             parent_metadata: parent_metadata,
             parent_runtime: parent_runtime,

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -170,6 +170,10 @@ defmodule Sagents.SubAgent do
   - `:parent_agent_id` - Parent's agent ID (required)
   - `:instructions` - Task description (required)
   - `:agent_config` - Agent struct with tools, model, middleware (required)
+  - `:initial_messages` - Optional list of `%LangChain.Message{}` structs to
+    slot between the system messages and the user instruction. Use this to
+    inject established context (e.g. a `<references>` synthetic
+    preamble) for the sub-agent's first turn. Defaults to `[]`.
   - `:parent_tool_context` - Parent's tool_context map to inherit (optional).
     Static, caller-supplied data (e.g., `user_id`, feature flags) that tools
     access as flat top-level keys on context. Defaults to `%{}`.
@@ -198,8 +202,11 @@ defmodule Sagents.SubAgent do
   def new_from_config(opts) do
     agent_config = Keyword.fetch!(opts, :agent_config)
     instructions = Keyword.fetch!(opts, :instructions)
+    initial_messages = Keyword.get(opts, :initial_messages, [])
 
-    messages = build_initial_messages(agent_config.assembled_system_prompt, instructions)
+    system_messages = build_initial_messages(agent_config.assembled_system_prompt)
+    user_message = Message.new_user!(instructions)
+    messages = system_messages ++ initial_messages ++ [user_message]
 
     build_subagent(agent_config, messages, opts)
   end
@@ -246,7 +253,7 @@ defmodule Sagents.SubAgent do
     instructions = Keyword.fetch!(opts, :instructions)
     initial_messages = Keyword.get(opts, :initial_messages, [])
 
-    system_messages = build_initial_messages(compiled_agent.assembled_system_prompt, nil)
+    system_messages = build_initial_messages(compiled_agent.assembled_system_prompt)
     user_message = Message.new_user!(instructions)
     messages = system_messages ++ initial_messages ++ [user_message]
 
@@ -636,19 +643,12 @@ defmodule Sagents.SubAgent do
 
   ## Private Helper Functions
 
-  defp build_initial_messages(system_prompt, instructions)
+  defp build_initial_messages(system_prompt)
        when is_binary(system_prompt) and system_prompt != "" do
-    case instructions do
-      nil -> [Message.new_system!(system_prompt)]
-      _other -> [Message.new_system!(system_prompt), Message.new_user!(instructions)]
-    end
+    [Message.new_system!(system_prompt)]
   end
 
-  defp build_initial_messages(_system_prompt, instructions) when is_binary(instructions) do
-    [Message.new_user!(instructions)]
-  end
-
-  defp build_initial_messages(_system_prompt, nil), do: []
+  defp build_initial_messages(_system_prompt), do: []
 
   # Extract interrupt_on configuration from middleware list
   defp extract_interrupt_on_from_middleware(middleware) when is_list(middleware) do

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -1450,6 +1450,295 @@ defmodule Sagents.Middleware.SubAgentTest do
     end
   end
 
+  describe "start_subagent/5 with config[:initial_messages]" do
+    setup do
+      agent_id = "parent-#{System.unique_integer([:positive])}"
+
+      {:ok, _sup} =
+        start_supervised({
+          SubAgentsDynamicSupervisor,
+          agent_id: agent_id
+        })
+
+      config_subagent = build_subagent_config("config_task", "Config-based task")
+
+      compiled_agent =
+        Agent.new!(%{
+          model: test_model(),
+          system_prompt: "Compiled prompt",
+          replace_default_middleware: true,
+          middleware: []
+        })
+
+      compiled_subagent =
+        SubAgent.Compiled.new!(%{
+          name: "compiled_task",
+          description: "Compiled task",
+          agent: compiled_agent,
+          initial_messages: [
+            Message.new_user!("registered foundation A"),
+            Message.new_assistant!("registered foundation B")
+          ]
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: agent_id,
+          model: test_model(),
+          middleware: [],
+          subagents: [config_subagent, compiled_subagent]
+        )
+
+      context = %{
+        agent_id: agent_id,
+        state: State.new!(%{messages: []}),
+        parent_middleware: []
+      }
+
+      parent = self()
+
+      LLMChain
+      |> stub(:run, fn chain, _opts ->
+        send(parent, {:chain_messages, chain.messages})
+
+        assistant_message = Message.new_assistant!(%{content: "done"})
+
+        updated_chain =
+          chain
+          |> Map.put(:messages, chain.messages ++ [assistant_message])
+          |> Map.put(:last_message, assistant_message)
+          |> Map.put(:needs_response, false)
+
+        {:ok, updated_chain}
+      end)
+
+      %{
+        agent_id: agent_id,
+        middleware_config: middleware_config,
+        context: context
+      }
+    end
+
+    test "Compiled task: omitted key is no-op (only registered initial_messages slot in)",
+         %{middleware_config: config, context: context} do
+      args = %{"instructions" => "Do work", "task_name" => "compiled_task"}
+
+      assert {:ok, _result} =
+               SubAgentMiddleware.start_subagent(
+                 "Do work",
+                 "compiled_task",
+                 args,
+                 context,
+                 config
+               )
+
+      assert_receive {:chain_messages, messages}
+
+      assert [
+               %Message{role: :system},
+               %Message{role: :user} = reg_a,
+               %Message{role: :assistant} = reg_b,
+               %Message{role: :user} = user
+             ] = messages
+
+      assert message_text(reg_a) == "registered foundation A"
+      assert message_text(reg_b) == "registered foundation B"
+      assert message_text(user) == "Do work"
+    end
+
+    test "Compiled task: empty list is identical to omitted key", %{
+      middleware_config: config,
+      context: context
+    } do
+      args = %{"instructions" => "Do work", "task_name" => "compiled_task"}
+      config = Map.put(config, :initial_messages, [])
+
+      assert {:ok, _result} =
+               SubAgentMiddleware.start_subagent(
+                 "Do work",
+                 "compiled_task",
+                 args,
+                 context,
+                 config
+               )
+
+      assert_receive {:chain_messages, messages}
+
+      assert [
+               %Message{role: :system},
+               %Message{role: :user} = reg_a,
+               %Message{role: :assistant} = reg_b,
+               %Message{role: :user} = user
+             ] = messages
+
+      assert message_text(reg_a) == "registered foundation A"
+      assert message_text(reg_b) == "registered foundation B"
+      assert message_text(user) == "Do work"
+    end
+
+    test "Compiled task: per-call messages append after registered ones", %{
+      middleware_config: config,
+      context: context
+    } do
+      msg_a = Message.new_user!("per-call A")
+      msg_b = Message.new_assistant!("per-call B")
+
+      args = %{"instructions" => "Do work", "task_name" => "compiled_task"}
+      config = Map.put(config, :initial_messages, [msg_a, msg_b])
+
+      assert {:ok, _result} =
+               SubAgentMiddleware.start_subagent(
+                 "Do work",
+                 "compiled_task",
+                 args,
+                 context,
+                 config
+               )
+
+      assert_receive {:chain_messages, messages}
+
+      assert [
+               %Message{role: :system},
+               %Message{role: :user} = reg_a,
+               %Message{role: :assistant} = reg_b,
+               %Message{role: :user} = pc_a,
+               %Message{role: :assistant} = pc_b,
+               %Message{role: :user} = user
+             ] = messages
+
+      assert message_text(reg_a) == "registered foundation A"
+      assert message_text(reg_b) == "registered foundation B"
+      assert message_text(pc_a) == "per-call A"
+      assert message_text(pc_b) == "per-call B"
+      assert message_text(user) == "Do work"
+    end
+
+    test "Config task: omitted key behaves as before", %{
+      middleware_config: config,
+      context: context
+    } do
+      args = %{"instructions" => "Do work", "task_name" => "config_task"}
+
+      assert {:ok, _result} =
+               SubAgentMiddleware.start_subagent(
+                 "Do work",
+                 "config_task",
+                 args,
+                 context,
+                 config
+               )
+
+      assert_receive {:chain_messages, messages}
+      roles = Enum.map(messages, & &1.role)
+
+      assert roles == [:system, :user]
+    end
+
+    test "Config task: per-call messages slot between system and user", %{
+      middleware_config: config,
+      context: context
+    } do
+      msg_a = Message.new_user!("per-call A")
+      msg_b = Message.new_assistant!("per-call B")
+
+      args = %{"instructions" => "Do work", "task_name" => "config_task"}
+      config = Map.put(config, :initial_messages, [msg_a, msg_b])
+
+      assert {:ok, _result} =
+               SubAgentMiddleware.start_subagent(
+                 "Do work",
+                 "config_task",
+                 args,
+                 context,
+                 config
+               )
+
+      assert_receive {:chain_messages, messages}
+      roles = Enum.map(messages, & &1.role)
+      contents = Enum.map(messages, &message_text/1)
+
+      assert roles == [:system, :user, :assistant, :user]
+      assert Enum.at(contents, 1) == "per-call A"
+      assert Enum.at(contents, 2) == "per-call B"
+      assert Enum.at(contents, 3) == "Do work"
+    end
+
+    test "Dynamic general-purpose task: per-call messages slot between system and user",
+         %{middleware_config: config, context: context} do
+      msg_a = Message.new_user!("per-call A")
+      msg_b = Message.new_assistant!("per-call B")
+
+      args = %{"instructions" => "Do work", "task_name" => "general-purpose"}
+      config = Map.put(config, :initial_messages, [msg_a, msg_b])
+
+      assert {:ok, _result} =
+               SubAgentMiddleware.start_subagent(
+                 "Do work",
+                 "general-purpose",
+                 args,
+                 context,
+                 config
+               )
+
+      assert_receive {:chain_messages, messages}
+      roles = Enum.map(messages, & &1.role)
+      contents = Enum.map(messages, &message_text/1)
+
+      assert roles == [:system, :user, :assistant, :user]
+      assert Enum.at(contents, 1) == "per-call A"
+      assert Enum.at(contents, 2) == "per-call B"
+      assert Enum.at(contents, 3) == "Do work"
+    end
+
+    test "raises ArgumentError when :initial_messages is not a list", %{
+      middleware_config: config,
+      context: context
+    } do
+      config = Map.put(config, :initial_messages, "nope")
+      args = %{"instructions" => "Do work", "task_name" => "compiled_task"}
+
+      assert_raise ArgumentError, ~r/must be a list of LangChain.Message structs/, fn ->
+        SubAgentMiddleware.start_subagent(
+          "Do work",
+          "compiled_task",
+          args,
+          context,
+          config
+        )
+      end
+    end
+
+    test "raises ArgumentError when list contains a non-Message element", %{
+      middleware_config: config,
+      context: context
+    } do
+      config =
+        Map.put(config, :initial_messages, [Message.new_assistant!("ok"), "not a message"])
+
+      args = %{"instructions" => "Do work", "task_name" => "compiled_task"}
+
+      assert_raise ArgumentError, ~r/must be a list of LangChain.Message structs/, fn ->
+        SubAgentMiddleware.start_subagent(
+          "Do work",
+          "compiled_task",
+          args,
+          context,
+          config
+        )
+      end
+    end
+  end
+
+  defp message_text(%Message{content: content}) when is_binary(content), do: content
+
+  defp message_text(%Message{content: parts}) when is_list(parts) do
+    parts
+    |> Enum.map_join("", fn
+      %LangChain.Message.ContentPart{type: :text, content: text} -> text
+      _other -> ""
+    end)
+  end
+
   describe "dynamic general-purpose subagent middleware filtering" do
     test "dynamic general-purpose subagent does not have task tool" do
       # This integration test verifies that when a general-purpose subagent is created,

--- a/test/sagents/sub_agent_test.exs
+++ b/test/sagents/sub_agent_test.exs
@@ -1685,6 +1685,40 @@ defmodule Sagents.SubAgentTest do
     end
   end
 
+  describe "new_from_config/1 with :initial_messages" do
+    test "defaults to no extra messages — chain is [system, user]" do
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "parent",
+          instructions: "Do work",
+          agent_config: test_agent()
+        )
+
+      assert [%LangChain.Message{role: :system}, %LangChain.Message{role: :user}] =
+               subagent.chain.messages
+    end
+
+    test "slots :initial_messages between system and user" do
+      msg_a = LangChain.Message.new_assistant!("preamble A")
+      msg_b = LangChain.Message.new_assistant!("preamble B")
+
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "parent",
+          instructions: "Do work",
+          agent_config: test_agent(),
+          initial_messages: [msg_a, msg_b]
+        )
+
+      assert [
+               %LangChain.Message{role: :system},
+               ^msg_a,
+               ^msg_b,
+               %LangChain.Message{role: :user}
+             ] = subagent.chain.messages
+    end
+  end
+
   # Helper function to extract errors from changeset
   defp errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->


### PR DESCRIPTION
## Problem

Host applications had no clean way to inject per-call reference content
(e.g. a `<references>` synthetic preamble built from caller-supplied
records) into a sub-agent's first turn. The only escape hatches were
mutating a shared registered `%SubAgent.Compiled{}` struct or jamming
content into the instructions string, both of which fight the existing
shape of the chain.

Compiled sub-agents could already carry registered `initial_messages`,
but those bake at registration time and get reused on every invocation —
not the same thing as per-call augmentation.

## Solution

Adds an optional `:initial_messages` key to the `config` map passed to
`Sagents.Middleware.SubAgent.start_subagent/5`. The value is a list of
`%LangChain.Message{}` structs slotted between the sub-agent's system
messages and the user instruction.

Supported uniformly across all three sub-agent branches:

- **Compiled** — appended *after* the registered
  `Compiled.initial_messages`.
- **Config-based** — slotted between system messages and the user
  message.
- **Dynamic general-purpose** — same slot, threaded through
  `start_dynamic_subagent/5`.

Achieving symmetry required teaching `Sagents.SubAgent.new_from_config/1`
to accept the same `:initial_messages` opt that `new_from_compiled/1`
already had. With that in place, `build_initial_messages/2` collapsed
to a single-arg helper since both call sites build the user message
directly.

The middleware validates format up-front (list of
`%LangChain.Message{}` structs) and raises `ArgumentError` on bad
input. Empty list / omitted key is a no-op everywhere, so existing
callers see byte-identical behaviour.

## Changes

- `lib/sagents/middleware/sub_agent.ex` — Read, validate, and plumb
  `config[:initial_messages]` through all three branches of
  `start_subagent/5`. `start_dynamic_subagent/4` → `/5` to thread the
  per-call list through to its `new_from_config/1` call. Added
  `valid_initial_messages?/1` predicate. `@doc` and `@spec` updated
  with the new option and a `## Raises` section.
- `lib/sagents/sub_agent.ex` — `new_from_config/1` now accepts
  `:initial_messages` (mirrors `new_from_compiled/1`). Simplified
  `build_initial_messages` from arity 2 to arity 1 since the user
  message is now built explicitly at both call sites. `@doc` updated.
- `test/sagents/sub_agent_test.exs` — New `describe` block covers
  `new_from_config/1` with and without `:initial_messages`.
- `test/sagents/middleware/sub_agent_test.exs` — New `describe` block
  covers all three sub-agent branches with and without per-call
  messages, plus both `ArgumentError` validation cases.

## Testing

`mix precommit` clean — 1417 tests pass (8 new), 0 dialyzer errors.

Tests use `Mimic` to stub `LLMChain.run/2` and capture the assembled
chain so assertions inspect the actual message ordering rather than
internal call details. Per-call messages in the new tests use
alternating `user`/`assistant` pairs so the resulting chain is a
realistic LLM-valid sequence (no consecutive same-role messages).