### PR TITLE
Add inline display mode for TodoList middleware

### DIFF
--- a/lib/sagents/middleware/todo_list.ex
+++ b/lib/sagents/middleware/todo_list.ex
@@ -21,14 +21,54 @@ defmodule Sagents.Middleware.TodoList do
     internally by the agent (e.g. self-organization during an onboarding
     flow) and the default label would leak implementation detail to users.
 
+  - `:inline` - Controls how todo updates surface to the UI. Defaults to
+    `false`. See "Display modes" below.
+
+  ## Display modes
+
+  Every successful `write_todos` call produces a state change. Two delivery
+  channels are available — the choice is purely about *where* in the UI the
+  todo list appears:
+
+  - **Default (`inline: false`)** — only emits the `{:todos_updated, todos}`
+    event over the AgentServer's broadcast channel. Subscribers (typically a
+    sidebar or status panel in the LiveView) re-render from that snapshot.
+    The chat transcript itself shows nothing about the todo list; the
+    transcript stays focused on the agent's textual reasoning and tool
+    calls. Best when the UI has dedicated "task list" real estate, or when
+    todos are an internal planning detail you don't want surfacing to the
+    end user.
+
+  - **Inline (`inline: true`)** — emits the same `{:todos_updated, todos}`
+    event *and additionally* persists a synthetic display message
+    (content_type `"todo_snapshot"`) into the conversation transcript. Each
+    snapshot is a separate message, so the chat shows the plan evolving
+    over time threaded with the agent's other output. Best when there is no
+    sidebar, or when seeing the plan unfold inside the conversation is part
+    of the desired UX.
+
+  Inline mode requires the AgentServer to be configured with a
+  `Sagents.DisplayMessagePersistence` module that implements
+  `save_synthetic_message/3`. Without it the inline-mode call is a silent
+  no-op (the existing `{:todos_updated, _}` broadcast still fires).
+
   ## Usage
 
-      # default label
+      # default: only the {:todos_updated, todos} broadcast — sidebar UIs
       {:ok, agent} = Agent.new(middleware: [TodoList])
 
       # custom label for a user-facing flow where todos are internal
       {:ok, agent} = Agent.new(
         middleware: [{TodoList, display_text: "Updating my notes"}]
+      )
+
+      # inline mode: also emit a todo_snapshot display message per update
+      # so the plan appears inline in the chat transcript
+      {:ok, agent} = Agent.new(middleware: [{TodoList, inline: true}])
+
+      # inline mode + custom label, both options together
+      {:ok, agent} = Agent.new(
+        middleware: [{TodoList, inline: true, display_text: "Replanning"}]
       )
   """
 
@@ -129,8 +169,12 @@ defmodule Sagents.Middleware.TodoList do
 
   @impl true
   def init(opts) do
-    display_text = Keyword.get(opts, :display_text, @default_display_text)
-    {:ok, %{display_text: display_text}}
+    config = %{
+      display_text: Keyword.get(opts, :display_text, @default_display_text),
+      inline: Keyword.get(opts, :inline, false)
+    }
+
+    {:ok, config}
   end
 
   @impl true
@@ -157,6 +201,12 @@ defmodule Sagents.Middleware.TodoList do
       case config do
         %{display_text: text} when is_binary(text) -> text
         _other -> @default_display_text
+      end
+
+    inline =
+      case config do
+        %{inline: value} when is_boolean(value) -> value
+        _other -> false
       end
 
     Function.new!(%{
@@ -197,11 +247,11 @@ defmodule Sagents.Middleware.TodoList do
         },
         required: ["merge", "todos"]
       },
-      function: &execute_write_todos/2
+      function: fn args, context -> execute_write_todos(args, context, inline) end
     })
   end
 
-  defp execute_write_todos(args, context) do
+  defp execute_write_todos(args, context, inline) do
     # Args come from LLM as string-keyed map
     merge = get_boolean_arg(args, "merge", false)
     todos_data = get_arg(args, "todos")
@@ -209,14 +259,28 @@ defmodule Sagents.Middleware.TodoList do
     # Parse TODO data from tool call
     case parse_todos(todos_data) do
       {:ok, parsed_todos} ->
-        updated_state =
-          context.state
-          |> update_todos(parsed_todos, merge)
-          |> clear_if_all_completed()
+        # Compute the post-update state, then apply the auto-clear that
+        # collapses a fully-completed list. We hold both: the inline-mode
+        # snapshot uses the pre-clear state (so the chat preserves the
+        # final celebratory checked list), while the actual state delta
+        # and sidebar broadcast use the post-clear state (so the agent
+        # and sidebar see the list as resolved).
+        state_after_update = update_todos(context.state, parsed_todos, merge)
+        updated_state = clear_if_all_completed(state_after_update)
 
         # Broadcast todos immediately for real-time UI updates
         # This is the point where todos are actually committed to state
         broadcast_todos(context.state.agent_id, updated_state.todos)
+
+        # Inline mode: persist a synthetic display message so the snapshot
+        # appears inline in the chat transcript. Snapshot the pre-clear
+        # state so the user sees the completed list, not an empty card.
+        # The AgentServer guards on display_message_persistence +
+        # conversation_id being configured; without them the call is a
+        # silent no-op.
+        if inline do
+          save_todo_snapshot(context.state.agent_id, state_after_update.todos)
+        end
 
         # Return only the state changes (todos), not messages
         state_delta = %State{todos: updated_state.todos}
@@ -226,6 +290,50 @@ defmodule Sagents.Middleware.TodoList do
       {:error, reason} ->
         {:error, "Failed to parse TODOs: #{reason}"}
     end
+  end
+
+  defp save_todo_snapshot(nil, _todos), do: :ok
+
+  defp save_todo_snapshot(agent_id, todos) do
+    # Mirror the broadcast_todos guard: only emit when AgentServer is running.
+    # AgentServer.save_synthetic_message_from is itself a no-op when the
+    # server lacks display_message_persistence/conversation_id, but checking
+    # here keeps unit tests free of a live AgentServer process.
+    case GenServer.whereis(AgentServer.get_name(agent_id)) do
+      nil ->
+        :ok
+
+      _pid ->
+        AgentServer.save_synthetic_message_from(agent_id, %{
+          message_type: "system",
+          content_type: "todo_snapshot",
+          content: build_todo_snapshot_content(todos)
+        })
+    end
+  end
+
+  defp build_todo_snapshot_content(todos) do
+    %{
+      "todos" =>
+        Enum.map(todos, fn todo ->
+          %{
+            "id" => todo.id,
+            "content" => todo.content,
+            "status" => to_string(todo.status)
+          }
+        end),
+      "summary" => %{
+        "total" => length(todos),
+        "pending" => count_status(todos, :pending),
+        "in_progress" => count_status(todos, :in_progress),
+        "completed" => count_status(todos, :completed),
+        "cancelled" => count_status(todos, :cancelled)
+      }
+    }
+  end
+
+  defp count_status(todos, status) do
+    Enum.count(todos, fn todo -> todo.status == status end)
   end
 
   defp get_arg(args, key) when is_map(args) do

--- a/test/sagents/middleware/todo_list_test.exs
+++ b/test/sagents/middleware/todo_list_test.exs
@@ -383,6 +383,116 @@ defmodule Sagents.Middleware.TodoListTest do
     end
   end
 
+  describe "inline mode" do
+    # Each test registers self() under the AgentServer's via-tuple name in the
+    # real Sagents.Registry so the middleware's whereis guard sees a "live"
+    # AgentServer and the GenServer.cast lands on this test process. We can
+    # then assert_received the cast payload to verify the synthetic-message
+    # save call.
+    setup do
+      agent_id = "todo-list-inline-test-#{System.unique_integer([:positive])}"
+      {:ok, _owner} = Registry.register(Sagents.Registry, {:agent_server, agent_id}, nil)
+      {:ok, agent_id: agent_id}
+    end
+
+    test "inline: false (default) does not save a synthetic message", %{agent_id: agent_id} do
+      {:ok, config} = TodoList.init([])
+      [tool] = TodoList.tools(config)
+
+      state = State.new!(%{agent_id: agent_id})
+
+      params = %{
+        merge: false,
+        todos: [%{"id" => "1", "content" => "Task", "status" => "pending"}]
+      }
+
+      {:ok, _msg, _state} = tool.function.(params, %{state: state})
+
+      refute_received {:"$gen_cast", {:save_synthetic_message, _attrs}}
+    end
+
+    test "inline: true saves a todo_snapshot synthetic message", %{agent_id: agent_id} do
+      {:ok, config} = TodoList.init(inline: true)
+      [tool] = TodoList.tools(config)
+
+      state = State.new!(%{agent_id: agent_id})
+
+      params = %{
+        merge: false,
+        todos: [
+          %{"id" => "1", "content" => "Task A", "status" => "pending"},
+          %{"id" => "2", "content" => "Task B", "status" => "in_progress"},
+          %{"id" => "3", "content" => "Task C", "status" => "completed"}
+        ]
+      }
+
+      {:ok, _msg, _state} = tool.function.(params, %{state: state})
+
+      assert_received {:"$gen_cast", {:save_synthetic_message, attrs}}
+      assert attrs.message_type == "system"
+      assert attrs.content_type == "todo_snapshot"
+
+      assert [%{"id" => "1"}, %{"id" => "2"}, %{"id" => "3"}] = attrs.content["todos"]
+      assert Enum.find(attrs.content["todos"], &(&1["id"] == "2"))["status"] == "in_progress"
+
+      assert attrs.content["summary"]["total"] == 3
+      assert attrs.content["summary"]["pending"] == 1
+      assert attrs.content["summary"]["in_progress"] == 1
+      assert attrs.content["summary"]["completed"] == 1
+    end
+
+    test "inline: true snapshots the pre-clear state when auto-clear fires",
+         %{agent_id: agent_id} do
+      # When all todos are completed, the agent's state is auto-cleared, but
+      # the inline snapshot should still show the fully-checked list — that
+      # final completed roster is the celebratory "everything done" view we
+      # want preserved in the transcript.
+      {:ok, config} = TodoList.init(inline: true)
+      [tool] = TodoList.tools(config)
+
+      state = State.new!(%{agent_id: agent_id})
+
+      params = %{
+        merge: false,
+        todos: [
+          %{"id" => "1", "content" => "Task A", "status" => "completed"},
+          %{"id" => "2", "content" => "Task B", "status" => "completed"}
+        ]
+      }
+
+      {:ok, _msg, returned_state} = tool.function.(params, %{state: state})
+
+      # Returned state delta still reflects the auto-clear (sidebar collapses).
+      assert returned_state.todos == []
+
+      # But the inline snapshot preserves the completed list.
+      assert_received {:"$gen_cast", {:save_synthetic_message, attrs}}
+      assert attrs.content_type == "todo_snapshot"
+      assert length(attrs.content["todos"]) == 2
+      assert Enum.all?(attrs.content["todos"], &(&1["status"] == "completed"))
+      assert attrs.content["summary"]["total"] == 2
+      assert attrs.content["summary"]["completed"] == 2
+    end
+
+    test "inline: true is a silent no-op when no AgentServer is registered" do
+      # No Registry registration here — agent_id is not associated with any
+      # process. The whereis guard in save_todo_snapshot/2 should short-circuit.
+      {:ok, config} = TodoList.init(inline: true)
+      [tool] = TodoList.tools(config)
+
+      state = State.new!(%{agent_id: "todo-list-no-server-#{System.unique_integer([:positive])}"})
+
+      params = %{
+        merge: false,
+        todos: [%{"id" => "1", "content" => "Task", "status" => "pending"}]
+      }
+
+      assert {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
+      assert length(updated_state.todos) == 1
+      refute_received {:"$gen_cast", {:save_synthetic_message, _attrs}}
+    end
+  end
+
   describe "auto-cleanup when all todos completed" do
     test "clears todo list when all todos marked as completed in replace mode" do
       state = State.new!()


### PR DESCRIPTION
## Problem

The `TodoList` middleware emits a `{:todos_updated, todos}` broadcast on every `write_todos` call, which works well when the host UI has a dedicated sidebar or status panel rendering the todo list out-of-band. It does not, however, work for UIs that have no sidebar real estate, or for UX where seeing the plan unfold inside the chat transcript itself is part of the experience. There was no way to surface todo updates inline in the conversation without consumers building their own parallel persistence path.

## Solution

Add an `:inline` option (default `false`) to `Sagents.Middleware.TodoList`. When `inline: true`, every successful `write_todos` call additionally persists a synthetic display message of `content_type: "todo_snapshot"` into the conversation transcript via `AgentServer.save_synthetic_message_from/2`, in addition to the existing broadcast. The two channels are independent — sidebar consumers keep working unchanged, and inline consumers get per-update snapshots threaded with the agent's other output.

A small but important nuance: the inline snapshot captures the **pre-clear** state, while the actual state delta and broadcast use the **post-clear** state. This means when an agent marks the last remaining todo complete (triggering the existing auto-cleanup that collapses a fully-done list), the chat transcript still shows the celebratory fully-checked roster, while the sidebar correctly collapses to empty. The reasoning is documented inline in `execute_write_todos/3`.

The feature is gracefully degraded: if the AgentServer is not registered, or it has no `display_message_persistence` / `conversation_id` configured, the inline call is a silent no-op — the existing `{:todos_updated, _}` broadcast still fires.

**NOTE:** This does not provide any UI for rendering the changes. The following is from the [agents_demo project](https://github.com/sagents-ai/agents_demo/pull/13) where there is UI for rendering it inline. You would customize according to your own application.

<img width="634" height="663" alt="image" src="https://github.com/user-attachments/assets/6a33e58d-1744-485f-b11c-bf495ac29016" />

## Changes

- [lib/sagents/middleware/todo_list.ex](lib/sagents/middleware/todo_list.ex) — Added `:inline` config option, threaded through `init/1` and the tool closure; new `save_todo_snapshot/2` helper guards on `Registry.whereis` and casts to the AgentServer; new `build_todo_snapshot_content/1` helper builds the `"todos"` + `"summary"` payload (totals by status); auto-clear logic split so the snapshot uses the pre-clear state.
- [lib/sagents/middleware/todo_list.ex](lib/sagents/middleware/todo_list.ex) (@moduledoc) — Documented the two display modes (default broadcast vs. inline transcript), when to pick each, and the persistence requirement for inline mode. Added usage examples for `inline: true` alone and combined with `display_text`.
- [test/sagents/middleware/todo_list_test.exs](test/sagents/middleware/todo_list_test.exs) — New "inline mode" describe block with four tests: default-off, default-on snapshot shape, pre-clear state preservation when auto-clear fires, and the no-AgentServer no-op path. Tests register `self()` under the AgentServer's via-tuple in `Sagents.Registry` so `GenServer.cast` lands on the test process and can be asserted via `assert_received`.

## Testing

- New unit tests covering all four behavioural paths (default off, on, on + auto-clear, on with no AgentServer).
- Existing TodoList tests continue to pass — the `:inline` option defaults to `false`, so all existing call sites are unaffected.
- No live API tests needed; the change is local to middleware behaviour and persistence wiring.