### PR TITLE
Add Sagents.AgentResult helper for structured extraction

### DIFF
--- a/lib/sagents/agent_result.ex
+++ b/lib/sagents/agent_result.ex
@@ -1,0 +1,257 @@
+defmodule Sagents.AgentResult do
+  @moduledoc """
+  Helpers for reading structured results out of an `Sagents.Agent.execute/3`
+  return value.
+
+  `Agent.execute/3` can return any of:
+
+    * `{:ok, %State{}}` — normal completion. Last message may be assistant prose
+      or an assistant tool call followed by tool results.
+    * `{:ok, %State{}, %ToolResult{}}` — `until_tool` completion. The third
+      element is the `LangChain.Message.ToolResult` produced by the target tool.
+    * `{:interrupt, %State{}, interrupt_data}` — paused for HITL/ask-user.
+    * `{:pause, %State{}}` — infrastructure pause.
+    * `{:error, term()}` — execution failed.
+
+  This module's job is to translate those shapes into a focused payload for
+  callers doing structured-extraction or single-invocation workflows. It is
+  intentionally a thin read layer — it does not validate, retry, or coerce. It
+  mirrors
+  `LangChain.Utils.ChainResult`, which serves the same role for `LLMChain`.
+
+  ## Functions
+
+    * `tool_result/1` — pull the `%ToolResult{}` out of a 3-tuple, or find the
+      last tool result in `state.messages` for the 2-tuple case.
+    * `tool_arguments/1` — the LLM-supplied arguments map. This is what
+      structured-extraction callers want 95% of the time.
+    * `processed_content/1` — the native-Elixir payload, when the tool's body
+      returned `{:ok, "string", native_term}`.
+    * `to_string/1` — extract a final assistant text response (for executions
+      that ended in prose rather than a tool call). Mirrors
+      `LangChain.Utils.ChainResult.to_string/1`.
+
+  All functions accept either an `execute/3` return value or a bare `%State{}`.
+  Error tuples pass straight through unchanged so callers can pipe.
+
+  ## Examples
+
+      iex> {:ok, _state, _tool_result} = result =
+      ...>   Sagents.Agent.execute(agent, state, until_tool: "submit")
+      iex> {:ok, args} = Sagents.AgentResult.tool_arguments(result)
+
+      iex> {:ok, state} = Sagents.Agent.execute(agent, state)
+      iex> {:ok, text} = Sagents.AgentResult.to_string({:ok, state})
+  """
+
+  alias LangChain.LangChainError
+  alias LangChain.Message
+  alias LangChain.Message.ContentPart
+  alias LangChain.Message.ToolCall
+  alias LangChain.Message.ToolResult
+  alias Sagents.State
+
+  @typedoc "Anything `Agent.execute/3` can return, or a bare State."
+  @type execute_return ::
+          State.t()
+          | {:ok, State.t()}
+          | {:ok, State.t(), ToolResult.t()}
+          | {:interrupt, State.t(), any()}
+          | {:pause, State.t()}
+          | {:error, any()}
+
+  @doc """
+  Return the `%ToolResult{}` carried by an `until_tool` 3-tuple.
+
+  For a 2-tuple or bare `%State{}`, walks back through `state.messages` and
+  returns the most recent successful (non-error) tool result, if any. Returns
+  `{:error, %LangChainError{}}` when no usable tool result is present.
+  """
+  @spec tool_result(execute_return()) ::
+          {:ok, ToolResult.t()} | {:error, LangChainError.t()} | {:error, any()}
+  def tool_result({:ok, %State{}, %ToolResult{} = tr}), do: {:ok, tr}
+
+  def tool_result({:ok, %State{} = state}), do: tool_result(state)
+
+  def tool_result(%State{messages: messages}) do
+    case last_tool_result(messages) do
+      nil ->
+        {:error,
+         LangChainError.exception(
+           type: "no_tool_result",
+           message: "No tool result found in state.messages"
+         )}
+
+      %ToolResult{} = tr ->
+        {:ok, tr}
+    end
+  end
+
+  def tool_result({:interrupt, _state, _data} = passthrough), do: passthrough_error(passthrough)
+  def tool_result({:pause, _state} = passthrough), do: passthrough_error(passthrough)
+  def tool_result({:error, _reason} = err), do: err
+
+  @doc """
+  Return the LLM-supplied arguments map from the result tool call.
+
+  Prefers `tool_call.arguments` from the assistant message that produced the
+  tool result (this is what the LLM actually emitted, already parsed from JSON
+  by LangChain). Falls back to the 3-tuple's `%ToolResult{}` when the matching
+  tool call can't be located.
+
+  This is the right call for structured-extraction workflows where the schema
+  *is* the tool's `parameters_schema`.
+  """
+  @spec tool_arguments(execute_return()) ::
+          {:ok, map()} | {:error, LangChainError.t()} | {:error, any()}
+  def tool_arguments({:ok, %State{} = state, %ToolResult{tool_call_id: id}}) do
+    case find_tool_call(state.messages, id) do
+      %ToolCall{arguments: args} when is_map(args) -> {:ok, args}
+      _other -> {:error, no_arguments_error()}
+    end
+  end
+
+  def tool_arguments({:ok, %State{} = state}), do: tool_arguments(state)
+
+  def tool_arguments(%State{messages: messages}) do
+    case last_assistant_tool_call(messages) do
+      %ToolCall{arguments: args} when is_map(args) -> {:ok, args}
+      _other -> {:error, no_arguments_error()}
+    end
+  end
+
+  def tool_arguments({:interrupt, _state, _data} = passthrough),
+    do: passthrough_error(passthrough)
+
+  def tool_arguments({:pause, _state} = passthrough), do: passthrough_error(passthrough)
+  def tool_arguments({:error, _reason} = err), do: err
+
+  @doc """
+  Return the `processed_content` of the result tool — the native Elixir term a
+  tool body can attach by returning `{:ok, "string for LLM", native_term}`.
+
+  Useful when the tool wants to hand back something richer than a JSON-parseable
+  argument map (a struct, a tuple, etc.).
+  """
+  @spec processed_content(execute_return()) ::
+          {:ok, any()} | {:error, LangChainError.t()} | {:error, any()}
+  def processed_content(input) do
+    case tool_result(input) do
+      {:ok, %ToolResult{processed_content: nil}} ->
+        {:error,
+         LangChainError.exception(
+           type: "no_processed_content",
+           message: "Tool result has no processed_content set"
+         )}
+
+      {:ok, %ToolResult{processed_content: content}} ->
+        {:ok, content}
+
+      {:error, _reason} = err ->
+        err
+    end
+  end
+
+  @doc """
+  Return the final assistant message content as a string.
+
+  Mirrors `LangChain.Utils.ChainResult.to_string/1`. For executions that ended
+  with prose rather than a tool call.
+
+  Returns `{:error, %LangChainError{}}` if the last message is not a complete
+  assistant message.
+  """
+  @spec to_string(execute_return()) ::
+          {:ok, String.t()} | {:error, LangChainError.t()} | {:error, any()}
+  def to_string({:ok, %State{} = state}), do: __MODULE__.to_string(state)
+  def to_string({:ok, %State{} = state, _extra}), do: __MODULE__.to_string(state)
+
+  def to_string(%State{messages: messages}) do
+    case List.last(messages) do
+      %Message{role: :assistant, status: :complete, content: content} ->
+        {:ok, content_to_string(content)}
+
+      %Message{role: :assistant, status: status} ->
+        {:error,
+         LangChainError.exception(
+           type: "to_string",
+           message: "Assistant message is incomplete (status: #{inspect(status)})"
+         )}
+
+      %Message{role: role} ->
+        {:error,
+         LangChainError.exception(
+           type: "to_string",
+           message: "Last message is not from assistant (role: #{inspect(role)})"
+         )}
+
+      nil ->
+        {:error, LangChainError.exception(type: "to_string", message: "No messages in state")}
+    end
+  end
+
+  def to_string({:interrupt, _state, _data} = passthrough), do: passthrough_error(passthrough)
+  def to_string({:pause, _state} = passthrough), do: passthrough_error(passthrough)
+  def to_string({:error, _reason} = err), do: err
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp last_tool_result(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %Message{role: :tool, tool_results: results} when is_list(results) ->
+        Enum.find(results, fn r -> not r.is_error end) || List.last(results)
+
+      _other ->
+        nil
+    end)
+  end
+
+  defp last_assistant_tool_call(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %Message{role: :assistant, tool_calls: [_head | _rest] = calls} -> List.last(calls)
+      _other -> nil
+    end)
+  end
+
+  defp find_tool_call(messages, tool_call_id) do
+    messages
+    |> Enum.find_value(fn
+      %Message{role: :assistant, tool_calls: calls} when is_list(calls) ->
+        Enum.find(calls, &(&1.call_id == tool_call_id))
+
+      _other ->
+        nil
+    end)
+  end
+
+  defp content_to_string(content) when is_binary(content), do: content
+  defp content_to_string(content) when is_list(content), do: ContentPart.parts_to_string(content)
+  defp content_to_string(nil), do: ""
+
+  defp no_arguments_error do
+    LangChainError.exception(
+      type: "no_tool_arguments",
+      message: "No assistant tool call with arguments found"
+    )
+  end
+
+  defp passthrough_error({:interrupt, _state, _data}) do
+    {:error,
+     LangChainError.exception(
+       type: "interrupted",
+       message: "Agent was interrupted; cannot extract result"
+     )}
+  end
+
+  defp passthrough_error({:pause, _state}) do
+    {:error,
+     LangChainError.exception(
+       type: "paused",
+       message: "Agent was paused; cannot extract result"
+     )}
+  end
+end

--- a/test/sagents/agent_result_test.exs
+++ b/test/sagents/agent_result_test.exs
@@ -1,0 +1,182 @@
+defmodule Sagents.AgentResultTest do
+  use ExUnit.Case, async: true
+
+  alias LangChain.LangChainError
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+  alias LangChain.Message.ToolResult
+  alias Sagents.AgentResult
+  alias Sagents.State
+
+  defp tool_call(call_id, name, args) do
+    ToolCall.new!(%{call_id: call_id, name: name, arguments: args})
+  end
+
+  defp tool_result(call_id, name, processed \\ nil) do
+    %ToolResult{
+      tool_call_id: call_id,
+      name: name,
+      content: "ok",
+      processed_content: processed
+    }
+  end
+
+  defp state_with_extraction_call(args, processed \\ nil) do
+    call = tool_call("call_1", "submit", args)
+    assistant = Message.new_assistant!(%{tool_calls: [call]})
+
+    tool_msg =
+      Message.new_tool_result!(%{tool_results: [tool_result("call_1", "submit", processed)]})
+
+    State.new!(%{messages: [Message.new_user!("hi"), assistant, tool_msg]})
+  end
+
+  describe "tool_result/1" do
+    test "extracts the third element from a 3-tuple" do
+      state = State.new!()
+      tr = tool_result("call_1", "submit")
+      assert {:ok, ^tr} = AgentResult.tool_result({:ok, state, tr})
+    end
+
+    test "walks state.messages for a 2-tuple" do
+      state = state_with_extraction_call(%{"x" => 1})
+      assert {:ok, %ToolResult{name: "submit"}} = AgentResult.tool_result({:ok, state})
+    end
+
+    test "accepts a bare State" do
+      state = state_with_extraction_call(%{"x" => 1})
+      assert {:ok, %ToolResult{name: "submit"}} = AgentResult.tool_result(state)
+    end
+
+    test "returns an error when no tool result is present" do
+      state = State.new!(%{messages: [Message.new_user!("hi")]})
+
+      assert {:error, %LangChainError{type: "no_tool_result"}} =
+               AgentResult.tool_result(state)
+    end
+
+    test "prefers a non-error result over an error result" do
+      err = %ToolResult{tool_call_id: "1", name: "a", content: "bad", is_error: true}
+      ok = %ToolResult{tool_call_id: "2", name: "b", content: "good"}
+
+      msg = Message.new_tool_result!(%{tool_results: [err, ok]})
+      state = State.new!(%{messages: [msg]})
+
+      assert {:ok, %ToolResult{name: "b"}} = AgentResult.tool_result(state)
+    end
+
+    test "passes through error tuples unchanged" do
+      err = {:error, :boom}
+      assert ^err = AgentResult.tool_result(err)
+    end
+
+    test "translates :interrupt into an error" do
+      assert {:error, %LangChainError{type: "interrupted"}} =
+               AgentResult.tool_result({:interrupt, State.new!(), %{}})
+    end
+
+    test "translates :pause into an error" do
+      assert {:error, %LangChainError{type: "paused"}} =
+               AgentResult.tool_result({:pause, State.new!()})
+    end
+  end
+
+  describe "tool_arguments/1" do
+    test "returns the arguments map from the 3-tuple's matching tool call" do
+      state = state_with_extraction_call(%{"title" => "hello"})
+      tr = tool_result("call_1", "submit")
+
+      assert {:ok, %{"title" => "hello"}} =
+               AgentResult.tool_arguments({:ok, state, tr})
+    end
+
+    test "falls back to last assistant tool call for 2-tuple" do
+      state = state_with_extraction_call(%{"title" => "hello"})
+
+      assert {:ok, %{"title" => "hello"}} =
+               AgentResult.tool_arguments({:ok, state})
+    end
+
+    test "returns error when no tool call is present" do
+      state =
+        State.new!(%{
+          messages: [
+            Message.new_user!("hi"),
+            Message.new_assistant!("just text")
+          ]
+        })
+
+      assert {:error, %LangChainError{type: "no_tool_arguments"}} =
+               AgentResult.tool_arguments(state)
+    end
+
+    test "passes error tuples through" do
+      err = {:error, :nope}
+      assert ^err = AgentResult.tool_arguments(err)
+    end
+  end
+
+  describe "processed_content/1" do
+    test "returns the processed_content of the result tool" do
+      state = state_with_extraction_call(%{"x" => 1}, %{x: 1, native: true})
+      tr = tool_result("call_1", "submit", %{x: 1, native: true})
+
+      assert {:ok, %{x: 1, native: true}} =
+               AgentResult.processed_content({:ok, state, tr})
+    end
+
+    test "errors when processed_content is nil" do
+      state = state_with_extraction_call(%{"x" => 1})
+      tr = tool_result("call_1", "submit", nil)
+
+      assert {:error, %LangChainError{type: "no_processed_content"}} =
+               AgentResult.processed_content({:ok, state, tr})
+    end
+
+    test "propagates a missing-tool-result error" do
+      state = State.new!(%{messages: [Message.new_user!("hi")]})
+
+      assert {:error, %LangChainError{type: "no_tool_result"}} =
+               AgentResult.processed_content(state)
+    end
+  end
+
+  describe "to_string/1" do
+    test "returns the last assistant text" do
+      state =
+        State.new!(%{
+          messages: [
+            Message.new_user!("hi"),
+            Message.new_assistant!("hello there")
+          ]
+        })
+
+      assert {:ok, "hello there"} = AgentResult.to_string({:ok, state})
+    end
+
+    test "errors when the last message is not an assistant message" do
+      state = State.new!(%{messages: [Message.new_user!("hi")]})
+
+      assert {:error, %LangChainError{type: "to_string"}} =
+               AgentResult.to_string(state)
+    end
+
+    test "errors with no messages" do
+      assert {:error, %LangChainError{type: "to_string"}} =
+               AgentResult.to_string(State.new!())
+    end
+
+    test "works against a 3-tuple by ignoring the extra" do
+      state =
+        State.new!(%{
+          messages: [
+            Message.new_user!("hi"),
+            Message.new_assistant!("hello")
+          ]
+        })
+
+      tr = tool_result("c", "n")
+      assert {:ok, "hello"} = AgentResult.to_string({:ok, state, tr})
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Callers using `Sagents.Agent.execute/3` for single-invocation or structured-extraction workflows — particularly the `until_tool:` mode — need to dig into the return value to pull out the LLM's tool arguments, a tool's `processed_content`, or the final assistant text. Today this means pattern-matching across four different return shapes (`{:ok, state}`, `{:ok, state, tool_result}`, `{:interrupt, ...}`, `{:pause, ...}`) and walking `state.messages` by hand, which every caller reinvents.

`LangChain.Utils.ChainResult` solves the same problem one layer down for `LLMChain`, but it doesn't understand agent-level concepts like the `until_tool` 3-tuple or interrupts.

## Solution

Adds a new `Sagents.AgentResult` module that mirrors `LangChain.Utils.ChainResult` for the agent layer. It's a thin read layer: no validation, no retries, no coercion. Each function accepts any `Agent.execute/3` return value (or a bare `%State{}`), and `:error` tuples pass straight through unchanged so callers can pipe.

Four functions cover the common payload shapes:

- `tool_result/1` — returns the `%ToolResult{}` from the `until_tool` 3-tuple, or walks `state.messages` for the most recent successful tool result. Prefers non-error results over error ones.
- `tool_arguments/1` — returns the LLM-supplied arguments map. Prefers `ToolCall.arguments` from the matching assistant message (already parsed from JSON by LangChain) over the `ToolResult`. This is the right call for structured-extraction workflows where the schema *is* the tool's `parameters_schema`.
- `processed_content/1` — returns the native Elixir term a tool body attached via `{:ok, \"string\", native_term}`.
- `to_string/1` — returns the final assistant message content as a string. Mirrors `LangChain.Utils.ChainResult.to_string/1` for executions that ended in prose rather than a tool call.

`:interrupt` and `:pause` tuples are translated into typed `LangChainError` results (`type: \"interrupted\"`, `type: \"paused\"`) so callers don't have to special-case them.

## Changes

- `lib/sagents/agent_result.ex` — New module with the four extraction helpers and a full `@moduledoc` explaining when to reach for each one.
- `test/sagents/agent_result_test.exs` — Unit tests covering: 3-tuple and 2-tuple inputs, bare `%State{}` inputs, missing tool results, non-error-preference behaviour, error pass-through, and `:interrupt` / `:pause` translation.

## Testing

Unit tests only — `mix test test/sagents/agent_result_test.exs`. No external API calls; the module is pure and operates on already-materialised `State` / `Message` structs.