### PR TITLE
Add FileSystemServer.get_state/1 and fix CI-flaky subscriber test

### DIFF
--- a/lib/sagents/file_system_server.ex
+++ b/lib/sagents/file_system_server.ex
@@ -162,6 +162,13 @@ defmodule Sagents.FileSystemServer do
     ProcessRegistry.via_tuple({:filesystem_server, scope_key})
   end
 
+  # The `get_state/1` function is available to aid in testing and not intended as a general public API.
+  @doc false
+  @spec get_state(term()) :: FileSystemState.t()
+  def get_state(scope_key) do
+    GenServer.call(get_name(scope_key), :get_state)
+  end
+
   @doc """
   Write content to a file path.
 
@@ -505,6 +512,11 @@ defmodule Sagents.FileSystemServer do
   @impl true
   def handle_call(:get_scope, _from, state) do
     {:reply, {:ok, state.scope_key}, state}
+  end
+
+  @impl true
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
   end
 
   @impl true

--- a/test/sagents/file_system_server_test.exs
+++ b/test/sagents/file_system_server_test.exs
@@ -107,7 +107,7 @@ defmodule Sagents.FileSystemServerTest do
 
   describe "write_file/4" do
     test "writes a memory file", %{agent_id: agent_id} do
-      {:ok, pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
+      {:ok, _pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
 
       path = "/scratch/test.txt"
       content = "test content"
@@ -119,7 +119,7 @@ defmodule Sagents.FileSystemServerTest do
       assert {:ok, %{content: ^content}} = FileSystemServer.read_file({:agent, agent_id}, path)
 
       # Verify internal state
-      state = :sys.get_state(pid)
+      state = FileSystemServer.get_state({:agent, agent_id})
       entry = Map.get(state.files, path)
       assert entry.path == path
       assert entry.content == content
@@ -131,7 +131,7 @@ defmodule Sagents.FileSystemServerTest do
     test "writes to unconfigured directory as memory-only", %{
       agent_id: agent_id
     } do
-      {:ok, pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
+      {:ok, _pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
 
       path = "/Memories/important.txt"
       content = "important data"
@@ -141,7 +141,7 @@ defmodule Sagents.FileSystemServerTest do
 
       # No persistence config matched, so the file lives in memory only
       # (the state machine has nothing to persist it to)
-      state = :sys.get_state(pid)
+      state = FileSystemServer.get_state({:agent, agent_id})
       entry = Map.get(state.files, path)
       assert entry.dirty_content == false
     end
@@ -158,7 +158,7 @@ defmodule Sagents.FileSystemServerTest do
 
       config = make_config(TestPersistence, "Memories")
 
-      {:ok, pid} =
+      {:ok, _pid} =
         FileSystemServer.start_link(
           scope_key: {:agent, agent_id},
           configs: [config]
@@ -170,7 +170,7 @@ defmodule Sagents.FileSystemServerTest do
       assert {:ok, _entry} = FileSystemServer.write_file({:agent, agent_id}, path, content)
 
       # New file should be persisted immediately (dirty == false)
-      state = :sys.get_state(pid)
+      state = FileSystemServer.get_state({:agent, agent_id})
       entry = Map.get(state.files, path)
       assert entry.dirty_content == false
       assert entry.loaded == true
@@ -188,7 +188,7 @@ defmodule Sagents.FileSystemServerTest do
 
       config = make_config(TestPersistenceUpdate, "Memories")
 
-      {:ok, pid} =
+      {:ok, _pid} =
         FileSystemServer.start_link(
           scope_key: {:agent, agent_id},
           configs: [config]
@@ -198,12 +198,12 @@ defmodule Sagents.FileSystemServerTest do
 
       # Create file first (persists immediately)
       assert {:ok, _entry} = FileSystemServer.write_file({:agent, agent_id}, path, "initial")
-      state = :sys.get_state(pid)
+      state = FileSystemServer.get_state({:agent, agent_id})
       assert Map.get(state.files, path).dirty_content == false
 
       # Update existing file (should debounce)
       assert {:ok, _entry} = FileSystemServer.write_file({:agent, agent_id}, path, "updated")
-      state = :sys.get_state(pid)
+      state = FileSystemServer.get_state({:agent, agent_id})
       entry = Map.get(state.files, path)
       assert entry.dirty_content == true
 
@@ -211,7 +211,7 @@ defmodule Sagents.FileSystemServerTest do
       Process.sleep(150)
 
       # File should now be clean
-      state = :sys.get_state(pid)
+      state = FileSystemServer.get_state({:agent, agent_id})
       clean_entry = Map.get(state.files, path)
       assert clean_entry.dirty_content == false
     end
@@ -780,7 +780,7 @@ defmodule Sagents.FileSystemServerTest do
     end
 
     test "subscriber crash auto-cleans subscription", %{agent_id: agent_id} do
-      {:ok, server_pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
+      {:ok, _server_pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
 
       sub =
         spawn(fn ->
@@ -792,15 +792,25 @@ defmodule Sagents.FileSystemServerTest do
         end)
 
       # Synchronize: wait until the server has processed the subscribe call
-      _state = :sys.get_state(server_pid)
-      assert Sagents.Publisher.State.count(:sys.get_state(server_pid).publisher) == 1
+      assert Sagents.Publisher.State.count(
+               FileSystemServer.get_state({:agent, agent_id}).publisher
+             ) == 1
 
+      # Monitor `sub` from the test so we know when the kill has taken effect.
+      # This alone isn't enough — the test's DOWN and the server's DOWN are
+      # delivered independently by the runtime — so we follow up with a
+      # bounded poll on the publisher count. The server's DOWN handler runs
+      # within microseconds of ours in practice; the poll just absorbs any
+      # scheduling jitter (notably on slower CI runners).
+      ref = Process.monitor(sub)
       Process.exit(sub, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^sub, _}, 500
 
-      # Synchronize again: a follow-up call serializes after the :DOWN handler
-      _state1 = :sys.get_state(server_pid)
-      _state2 = :sys.get_state(server_pid)
-      assert Sagents.Publisher.State.count(:sys.get_state(server_pid).publisher) == 0
+      assert wait_until(fn ->
+               Sagents.Publisher.State.count(
+                 FileSystemServer.get_state({:agent, agent_id}).publisher
+               ) == 0
+             end)
     end
   end
 


### PR DESCRIPTION
## Problem

The `"subscriber crash auto-cleans subscription"` test in `file_system_server_test.exs` passed reliably locally but failed intermittently in CI with `left: 1, right: 0` when asserting the publisher subscriber count after killing a subscriber process.

The root cause is a cross-path message race. `Process.exit(sub, :kill)` is asynchronous, so the `{:DOWN, ref, ...}` message reaches the server via an independent path from the BEAM runtime, while the test process sends `:sys.get_state(server_pid)` directly. Erlang signal ordering only applies *within a single sender→receiver pair*, so two consecutive `:sys.get_state` calls can win the race against the DOWN — especially under CI scheduler load. The test's two-call "synchronization" was a misuse of FIFO semantics; `:sys.get_state` and `GenServer.call(:get_state)` both go through the same mailbox FIFO and have identical synchronization properties — neither orders messages from a *different* sender.

Separately, the existing tests reached into the server with `:sys.get_state(pid)` to peek at internal state. This is inconsistent with `AgentServer`, which exposes a `get_state/1` test helper that takes the scope identifier instead of a raw pid — better ergonomics and matches the project's CLAUDE.md guidance.

## Solution

Two changes, addressing both problems:

1. **New `FileSystemServer.get_state/1`** mirroring `AgentServer.get_state/1`: `@doc false`, takes a `scope_key`, resolves via `get_name/1`, calls into the server. Adds a tiny `handle_call(:get_state, ...)` clause that returns the internal `FileSystemState`. This is for testing only; not a general public API.

2. **Fix the flaky subscriber test** with a test-side monitor on `sub` plus a bounded poll via the existing `wait_until/1` helper. `Process.monitor(sub) + assert_receive {:DOWN, ...}` confirms the kill has taken effect, and `wait_until/1` absorbs the cross-path scheduling jitter on the server's own DOWN handler. The comment in the test explains why the monitor alone isn't sufficient — the two DOWN deliveries are independent — and why polling is the correct fix.

All other `:sys.get_state(pid)` sites in the file (six call sites in `write_file/4` tests) were swapped to the new API for consistency; their `pid` bindings from `start_link` were renamed to `_pid` since they're no longer used.

## Changes

- [lib/sagents/file_system_server.ex](lib/sagents/file_system_server.ex) — Added `get_state/1` (test-only helper, mirrors `AgentServer.get_state/1`) and the matching `handle_call(:get_state, ...)` clause
- [test/sagents/file_system_server_test.exs](test/sagents/file_system_server_test.exs) — Replaced 10 `:sys.get_state` call sites with `FileSystemServer.get_state({:agent, agent_id})`; renamed unused `pid`/`server_pid` bindings to `_pid`/`_server_pid`
- [test/sagents/file_system_server_test.exs](test/sagents/file_system_server_test.exs) (subscriber crash test) — Replaced the racy two-call synchronization with `Process.monitor` + `assert_receive {:DOWN, ...}` + `wait_until/1` bounded poll. Inline comment documents why the monitor alone isn't sufficient

## Testing

- `mix test test/sagents/file_system_server_test.exs` — all 44 tests pass locally
- The previously flaky test (`:782`) was run in isolation and passes
- `wait_until/1` is already available via `Sagents.BaseCase` (imported from `Sagents.TestingHelpers`); no new test infrastructure required