### PR TITLE
Handle :interrupted tool-execution status in StreamingSession

### DIFF
--- a/lib/sagents/streaming_session.ex
+++ b/lib/sagents/streaming_session.ex
@@ -18,10 +18,14 @@ defmodule Sagents.StreamingSession do
       delta.
 
     * **Tool execution update** — fired as a tool moves through
-      `:executing → :completed | :failed`. Updates the call's execution
-      status metadata. The `:streaming_delta` is only cleared once every
-      tool call in the delta has reached a terminal status, so sibling
-      calls still in flight keep their UI state.
+      `:executing → :completed | :failed`, or pauses on `:interrupted`
+      (e.g. `ask_user` or a human-in-the-loop approval). Updates the
+      call's execution status metadata. The `:streaming_delta` is only
+      cleared once every tool call in the delta has reached a terminal
+      status (`"completed"` or `"failed"`); `:interrupted` is *not*
+      terminal — the call is paused, not finished — so sibling calls
+      still in flight (and the interrupted call itself) keep their UI
+      state.
 
   Both functions return an empty map (`%{}`) when the event has no
   `:call_id`, leaving the host's state untouched.
@@ -44,7 +48,7 @@ defmodule Sagents.StreamingSession do
           optional(:display_text) => String.t() | nil
         }
 
-  @type lifecycle_status :: :executing | :completed | :failed
+  @type lifecycle_status :: :executing | :completed | :failed | :interrupted
 
   @doc """
   Apply a "tool call identified" event to the session state. Returns a
@@ -97,14 +101,17 @@ defmodule Sagents.StreamingSession do
 
     * If there is no `:streaming_delta` to update, returns `%{}`.
     * Updates the matching call's `"execution_status"` metadata
-      (`"executing"`, `"completed"`, or `"failed"`).
-    * On `:executing`, also forwards `tool_info[:display_text]` so callers
-      can refine the UI label as the tool collects more context. Nil
+      (`"executing"`, `"completed"`, `"failed"`, or `"interrupted"`).
+    * On `:executing` or `:interrupted`, also forwards
+      `tool_info[:display_text]` so callers can refine the UI label as
+      the tool collects more context (or surface the paused state). Nil
       `display_text` is a no-op, preserving any prior value.
     * Once every tool call in the delta has reached a terminal status
       (`"completed"` or `"failed"`), returns `%{streaming_delta: nil}` to
-      clear the streaming UI. Until then the delta stays so sibling tool
-      calls still in flight keep their UI state.
+      clear the streaming UI. `:interrupted` is treated as paused, not
+      terminal, so the delta stays in place until the call resumes and
+      eventually completes or fails. Until then the delta also stays so
+      sibling tool calls still in flight keep their UI state.
     * If `tool_info[:call_id]` is nil, returns `%{}`.
   """
   @spec handle_tool_execution_update(map(), lifecycle_status(), tool_info()) :: map()
@@ -115,7 +122,7 @@ defmodule Sagents.StreamingSession do
       do: %{}
 
   def handle_tool_execution_update(state, status, tool_info)
-      when status in [:executing, :completed, :failed] do
+      when status in [:executing, :completed, :failed, :interrupted] do
     case Map.get(state, :streaming_delta) do
       nil ->
         %{}
@@ -137,12 +144,14 @@ defmodule Sagents.StreamingSession do
     end
   end
 
-  defp maybe_set_display_text(delta, :executing, call_id, display_text),
-    do: MessageDelta.set_tool_display_text(delta, call_id, display_text)
+  defp maybe_set_display_text(delta, status, call_id, display_text)
+       when status in [:executing, :interrupted],
+       do: MessageDelta.set_tool_display_text(delta, call_id, display_text)
 
   defp maybe_set_display_text(delta, _other, _call_id, _display_text), do: delta
 
   defp lifecycle_status_string(:executing), do: "executing"
   defp lifecycle_status_string(:completed), do: "completed"
   defp lifecycle_status_string(:failed), do: "failed"
+  defp lifecycle_status_string(:interrupted), do: "interrupted"
 end

--- a/test/sagents/streaming_session_test.exs
+++ b/test/sagents/streaming_session_test.exs
@@ -159,5 +159,84 @@ defmodule Sagents.StreamingSessionTest do
                  %{name: "read_file"}
                )
     end
+
+    test "writes execution_status interrupted and forwards display_text without clearing delta" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [
+          %ToolCall{
+            call_id: "abc",
+            name: "ask_user",
+            metadata: %{"execution_status" => "executing"}
+          }
+        ]
+      }
+
+      assert %{streaming_delta: %MessageDelta{tool_calls: [tc]} = updated} =
+               StreamingSession.handle_tool_execution_update(
+                 %{streaming_delta: delta},
+                 :interrupted,
+                 %{call_id: "abc", name: "ask_user", display_text: "Waiting for user"}
+               )
+
+      assert tc.metadata["execution_status"] == "interrupted"
+      assert tc.display_text == "Waiting for user"
+      # interrupted is paused, not terminal — the delta is preserved
+      refute MessageDelta.all_tools_terminal?(updated)
+    end
+
+    test "preserves an in-flight sibling when one call is interrupted" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [
+          %ToolCall{call_id: "a", metadata: %{"execution_status" => "executing"}},
+          %ToolCall{call_id: "b", metadata: %{"execution_status" => "executing"}}
+        ]
+      }
+
+      assert %{streaming_delta: %MessageDelta{tool_calls: [a, b]}} =
+               StreamingSession.handle_tool_execution_update(
+                 %{streaming_delta: delta},
+                 :interrupted,
+                 %{call_id: "a", name: "ask_user"}
+               )
+
+      assert a.metadata["execution_status"] == "interrupted"
+      assert b.metadata["execution_status"] == "executing"
+    end
+
+    test "does not clear delta even when the only tool call is interrupted" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [
+          %ToolCall{call_id: "abc", metadata: %{"execution_status" => "executing"}}
+        ]
+      }
+
+      assert %{streaming_delta: %MessageDelta{tool_calls: [tc]}} =
+               StreamingSession.handle_tool_execution_update(
+                 %{streaming_delta: delta},
+                 :interrupted,
+                 %{call_id: "abc", name: "ask_user"}
+               )
+
+      assert tc.metadata["execution_status"] == "interrupted"
+    end
+
+    test "refines display_text on :interrupted without clobbering an existing value when new is nil" do
+      delta = %MessageDelta{
+        role: :assistant,
+        tool_calls: [%ToolCall{call_id: "abc", display_text: "Waiting"}]
+      }
+
+      assert %{streaming_delta: %MessageDelta{tool_calls: [tc]}} =
+               StreamingSession.handle_tool_execution_update(
+                 %{streaming_delta: delta},
+                 :interrupted,
+                 %{call_id: "abc", display_text: nil}
+               )
+
+      assert tc.display_text == "Waiting"
+    end
   end
 end


### PR DESCRIPTION
## Problem

`Sagents.StreamingSession.handle_tool_execution_update/3` only matched `:executing`, `:completed`, and `:failed`. But `Sagents.AgentServer` broadcasts `{:tool_execution_update, :interrupted, …}` whenever a tool call pauses for human input — e.g. when the LLM calls `ask_user` or hits a sub-agent HITL gate. Hosts that forwarded those broadcasts into `StreamingSession` (LiveView, GenServer bridges, etc.) crashed with `FunctionClauseError` the moment the model emitted an interrupting tool. The bug only surfaced after a few conversational turns — long enough for the model to reach a tool that pauses.

## Solution

Extend the lifecycle to recognise `:interrupted` as a first-class status that is *paused, not terminal*:

- Add `:interrupted` to the guard on `handle_tool_execution_update/3` so the broadcast no longer crashes.
- Write `"interrupted"` into the matching tool call's `execution_status` metadata via a new `lifecycle_status_string/1` clause.
- Forward `tool_info[:display_text]` on `:interrupted` (same behaviour as `:executing`) so callers can surface "Waiting for user" or similar labels.
- Preserve `:streaming_delta`: `MessageDelta.all_tools_terminal?/1` only treats `"completed"` and `"failed"` as terminal, so the interrupted call (and any siblings) keep their UI state until the call resumes and eventually finishes.
- Extend the `@type lifecycle_status` union and update the moduledoc + function doc to describe the paused-vs-terminal distinction.

## Changes

- `lib/sagents/streaming_session.ex` — Added `:interrupted` to the guard, `maybe_set_display_text/4`, and `lifecycle_status_string/1`; extended `@type lifecycle_status`; updated moduledoc and `handle_tool_execution_update/3` docstring to cover the paused semantics.
- `test/sagents/streaming_session_test.exs` — Added 4 unit tests covering `:interrupted`: status + display_text write, delta preserved when the only call is interrupted, sibling in-flight call preserved alongside an interrupted one, and nil `display_text` preserves a prior value.

## Testing

`mix test test/sagents/streaming_session_test.exs` — 15 tests, 0 failures (11 pre-existing + 4 new `:interrupted` tests).