### PR TITLE
Log middleware initialization failures at error level

### DIFF
--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -293,6 +293,7 @@ defmodule Sagents.Agent do
         put_change(changeset, :middleware, initialized)
 
       {:error, reason} ->
+        Logger.error("Middleware initialization failed: #{reason}")
         add_error(changeset, :middleware, "initialization failed: #{inspect(reason)}")
     end
   end

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -290,6 +290,27 @@ defmodule Sagents.AgentTest do
       assert message =~ "find_in_file"
     end
 
+    test "Agent.new logs middleware init failures so hosts see the cause without inspecting the changeset" do
+      log =
+        capture_log(fn ->
+          {:error, _changeset} =
+            Agent.new(
+              %{
+                model: mock_model(),
+                middleware: [
+                  {Sagents.Middleware.FileSystem,
+                   [agent_id: "test", enabled_tools: ["bogus_tool_name"]]}
+                ]
+              },
+              replace_default_middleware: true
+            )
+        end)
+
+      assert log =~ "Middleware initialization failed"
+      assert log =~ "Sagents.Middleware.FileSystem"
+      assert log =~ "bogus_tool_name"
+    end
+
     test "Agent.new! raises with a useful message when a middleware init/1 fails" do
       assert_raise LangChainError, ~r/bogus_tool_name/, fn ->
         Agent.new!(


### PR DESCRIPTION
## Problem

When middleware `init/1` fails inside `Sagents.Agent.new/2`, the failure currently surfaces only as a changeset error. Host applications that don't introspect the changeset (or that call `Agent.new/2` from places where the error is swallowed/transformed) had no visible signal that something went wrong during middleware initialization, making these failures painful to diagnose.

## Solution

Emit an explicit `Logger.error/1` call in the middleware-initialization branch of the agent changeset pipeline before adding the changeset error. The changeset error is still returned as before, so existing callers keep their current contract — the log line is purely additive and gives host apps a clear, grep-able signal that middleware init failed and why.

## Changes

- `lib/sagents/agent.ex` — Log `"Middleware initialization failed: #{reason}"` at error level when middleware initialization returns `{:error, reason}`, in addition to adding the changeset error.
- `test/sagents/agent_test.exs` — New test using `capture_log/1` to verify the error log is emitted and contains the failing middleware module and the offending config (e.g. the bad tool name).

## Testing

- Added a unit test that triggers a middleware init failure (invalid `enabled_tools` on `Sagents.Middleware.FileSystem`) and asserts the captured log contains both the failure prefix and the underlying reason.
- The existing `Agent.new!` raise-on-failure test continues to cover the bang variant.