### PR TITLE
Add :halt interrupt type for terminal tool-driven workflow stops

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -2480,6 +2480,13 @@ defmodule Sagents.AgentServer do
     # :multiple_interrupts wrappers that contain a halt.
     maybe_emit_halt_telemetry(updated_state, interrupt_data)
 
+    # Persist the halt's message as a synthetic assistant transcript
+    # entry so the user's recommended-actions text survives dismissal
+    # and page reload. Broadcasts {:display_message_saved, _} before the
+    # :status_changed broadcast below so the transcript renders ahead
+    # of the halt banner.
+    maybe_persist_halt_messages(updated_state, interrupt_data)
+
     # Persist agent state on interrupt
     updated_state = maybe_persist_state(updated_state, :on_interrupt)
 
@@ -2982,6 +2989,46 @@ defmodule Sagents.AgentServer do
     )
 
     :ok
+  end
+
+  # Persist the halt's :message text as a synthetic assistant display
+  # message so it survives dismissal, page reload, and any later turn.
+  # The interrupt UI (:pending_halt) is transient; this transcript entry
+  # is the user's permanent record of the halt's recommended actions.
+  #
+  # Fires only at the original halt-emit moment in
+  # handle_execution_result/2. Cold-start re-surface (Haltable.handle_resume/5
+  # with resume_data == nil) does NOT re-persist — the original emit's
+  # display message is already in the persisted log.
+  defp maybe_persist_halt_messages(%ServerState{} = server_state, %{type: :halt} = data) do
+    persist_halt_message(server_state, data)
+  end
+
+  defp maybe_persist_halt_messages(
+         %ServerState{} = server_state,
+         %{type: :multiple_interrupts, interrupts: subs}
+       )
+       when is_list(subs) do
+    Enum.each(subs, fn
+      %{type: :halt} = halt -> persist_halt_message(server_state, halt)
+      _other -> :ok
+    end)
+  end
+
+  defp maybe_persist_halt_messages(_server_state, _interrupt_data), do: :ok
+
+  defp persist_halt_message(%ServerState{} = server_state, %{type: :halt} = halt) do
+    case Map.get(halt, :message) do
+      msg when is_binary(msg) and byte_size(msg) > 0 ->
+        maybe_save_synthetic_and_broadcast(server_state, %{
+          message_type: "assistant",
+          content_type: "text",
+          content: %{"text" => msg}
+        })
+
+      _empty_or_nil ->
+        :ok
+    end
   end
 
   # Fire display updates on resume for interrupt types that DON'T go through

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -787,6 +787,30 @@ defmodule Sagents.AgentServer do
   end
 
   @doc """
+  Dismiss a terminal `:halt` interrupt and transition the server back to `:idle`.
+
+  Used to acknowledge a halt (e.g., user clicked "Dismiss" on the halt panel)
+  without sending a new message. Clears `interrupt_data`, calls
+  `State.cancel_pending_interrupts/1`, transitions status to `:idle`, and
+  broadcasts the status change.
+
+  Only valid when status is `:interrupted` and the pending interrupt is a
+  halt (or a `:multiple_interrupts` batch containing a halt). Other interrupt
+  types — HITL approvals, `ask_user_question` — require an explicit response
+  via `resume/2` (which the relevant middleware interprets), so this function
+  returns `{:error, "interrupt requires explicit response (use resume)"}`
+  for those.
+
+  ## Examples
+
+      :ok = AgentServer.dismiss_interrupt("my-agent-1")
+  """
+  @spec dismiss_interrupt(String.t()) :: :ok | {:error, term()}
+  def dismiss_interrupt(agent_id) do
+    safe_call(agent_id, :dismiss_interrupt)
+  end
+
+  @doc """
   Resume agent execution after an interrupt.
 
   ## Parameters
@@ -1590,6 +1614,40 @@ defmodule Sagents.AgentServer do
   end
 
   @impl true
+  def handle_call(
+        :dismiss_interrupt,
+        _from,
+        %ServerState{status: :interrupted, interrupt_data: interrupt_data} = server_state
+      ) do
+    if halt_interrupt?(interrupt_data) do
+      new_state = State.cancel_pending_interrupts(server_state.state)
+
+      updated_server_state = %{
+        server_state
+        | state: new_state,
+          status: :idle,
+          interrupt_data: nil,
+          execution_seq: server_state.execution_seq + 1,
+          error: nil
+      }
+
+      broadcast_event(updated_server_state, {:status_changed, :idle, nil})
+      update_presence_status(updated_server_state, :idle)
+
+      {:reply, :ok, updated_server_state}
+    else
+      {:reply, {:error, "interrupt requires explicit response (use resume)"}, server_state}
+    end
+  end
+
+  @impl true
+  def handle_call(:dismiss_interrupt, _from, server_state) do
+    {:reply,
+     {:error, "Cannot dismiss, server is not interrupted (status: #{server_state.status})"},
+     server_state}
+  end
+
+  @impl true
   def handle_call(:get_state, _from, server_state) do
     {:reply, server_state.state, server_state}
   end
@@ -2126,6 +2184,18 @@ defmodule Sagents.AgentServer do
 
   ## Private Functions
 
+  # A halt interrupt is dismissable via dismiss_interrupt/1. Other interrupt
+  # types (HITL, ask_user_question) require explicit responses via resume/2.
+  # A :multiple_interrupts batch containing a halt is dismissable because the
+  # halt-wins policy makes the whole batch terminal.
+  defp halt_interrupt?(%{type: :halt}), do: true
+
+  defp halt_interrupt?(%{type: :multiple_interrupts, interrupts: subs}) when is_list(subs) do
+    Enum.any?(subs, &(&1.type == :halt))
+  end
+
+  defp halt_interrupt?(_other), do: false
+
   defp handle_task_down(:normal, server_state) do
     # Task process exited normally, already handled by the {ref, result} clause.
     {:noreply, server_state}
@@ -2403,6 +2473,12 @@ defmodule Sagents.AgentServer do
 
     # Update sub-agent tool call display message to "interrupted"
     maybe_update_interrupt_tool_display(updated_state, interrupt_data, :interrupted)
+
+    # Halts represent gate decisions — higher signal than ordinary pauses,
+    # so they get their own telemetry event in addition to the generic
+    # :status_changed broadcast. Fires for direct halts and for
+    # :multiple_interrupts wrappers that contain a halt.
+    maybe_emit_halt_telemetry(updated_state, interrupt_data)
 
     # Persist agent state on interrupt
     updated_state = maybe_persist_state(updated_state, :on_interrupt)
@@ -2841,6 +2917,24 @@ defmodule Sagents.AgentServer do
     maybe_resolve_tool_result(server_state, tool_call_id, "Question answered")
   end
 
+  # --- Halt ---
+  # A halt is terminal: there is no :completed/:failed transition because
+  # the tool call is never re-executed. The user's next message demotes
+  # the interrupted tool result via State.cancel_pending_interrupts/1.
+  defp maybe_update_interrupt_tool_display(
+         server_state,
+         %{type: :halt, tool_call_id: tool_call_id},
+         :interrupted
+       )
+       when is_binary(tool_call_id) do
+    broadcast_tool_event(server_state, :interrupted, %{
+      call_id: tool_call_id,
+      display_text: "Workflow halted"
+    })
+  end
+
+  defp maybe_update_interrupt_tool_display(_server_state, %{type: :halt}, _status), do: :ok
+
   # --- Multiple interrupts: update each inner interrupt ---
   defp maybe_update_interrupt_tool_display(
          server_state,
@@ -2854,6 +2948,41 @@ defmodule Sagents.AgentServer do
 
   # Not a recognized interrupt type -- no tool display update needed
   defp maybe_update_interrupt_tool_display(_server_state, _interrupt_data, _status), do: :ok
+
+  # Emit `[:sagents, :agent, :halt]` telemetry for halt-typed interrupts.
+  # Halts are gate decisions, so observability tooling typically wants to
+  # treat them differently from ordinary `:interrupted` transitions.
+  defp maybe_emit_halt_telemetry(%ServerState{} = server_state, %{type: :halt} = data) do
+    emit_halt_telemetry(server_state, data)
+  end
+
+  defp maybe_emit_halt_telemetry(
+         %ServerState{} = server_state,
+         %{type: :multiple_interrupts, interrupts: subs}
+       )
+       when is_list(subs) do
+    Enum.each(subs, fn
+      %{type: :halt} = halt -> emit_halt_telemetry(server_state, halt)
+      _other -> :ok
+    end)
+  end
+
+  defp maybe_emit_halt_telemetry(_server_state, _interrupt_data), do: :ok
+
+  defp emit_halt_telemetry(%ServerState{} = server_state, %{type: :halt} = data) do
+    :telemetry.execute(
+      [:sagents, :agent, :halt],
+      %{count: 1},
+      %{
+        agent_id: server_state.agent.agent_id,
+        source_tool: Map.get(data, :source_tool) || Map.get(data, :source),
+        tool_call_id: Map.get(data, :tool_call_id),
+        message: Map.get(data, :message)
+      }
+    )
+
+    :ok
+  end
 
   # Fire display updates on resume for interrupt types that DON'T go through
   # LLMChain tool re-execution (and thus don't fire on_tool_execution_completed).

--- a/lib/sagents/agent_utils.ex
+++ b/lib/sagents/agent_utils.ex
@@ -149,11 +149,13 @@ defmodule Sagents.AgentUtils do
   Map an interrupt-data payload to the assigns/state changes a host
   (LiveView, GenServer, etc.) should merge to display the interrupt.
 
-  Routes the three sagents-internal interrupt variants to their UI shapes:
+  Routes the four sagents-internal interrupt variants to their UI shapes:
 
+  - `:halt` — surface as a terminal halt with `:pending_halt`
   - `:ask_user_question` — pull the single question to the front
-  - `:multiple_interrupts` — present as questions if all are questions,
-    otherwise as a HITL tool batch
+  - `:multiple_interrupts` — "halt wins": if any sub-interrupt is `:halt`,
+    surface as a halt; otherwise present as questions if all are
+    questions, or as a HITL tool batch
   - `:subagent_hitl` — unwrap the inner `action_requests`
   - any other map — treat as a generic HITL tool batch
 
@@ -161,6 +163,9 @@ defmodule Sagents.AgentUtils do
   unconditionally on top of base assigns.
 
   ## Returned keys
+
+  When a halt is present:
+  `:pending_halt`, `:pending_question`, `:pending_tools`
 
   When questions are present:
   `:pending_question`, `:remaining_questions`, `:question_responses`, `:pending_tools`
@@ -177,15 +182,25 @@ defmodule Sagents.AgentUtils do
   @spec interrupt_session_changes(map() | nil) :: map()
   def interrupt_session_changes(nil), do: %{}
 
+  def interrupt_session_changes(%{type: :halt} = halt), do: present_halt(halt)
+
   def interrupt_session_changes(%{type: :ask_user_question} = question) do
     present_questions([question])
   end
 
   def interrupt_session_changes(%{type: :multiple_interrupts, interrupts: interrupts}) do
-    if Enum.all?(interrupts, &(&1.type == :ask_user_question)) do
-      present_questions(interrupts)
-    else
-      present_hitl_tools(interrupts)
+    cond do
+      Enum.any?(interrupts, &(&1.type == :halt)) ->
+        # Halt wins: surface the first halt sibling and ignore the rest.
+        # The other interrupts are moot because the workflow is over.
+        halt = Enum.find(interrupts, &(&1.type == :halt))
+        present_halt(halt)
+
+      Enum.all?(interrupts, &(&1.type == :ask_user_question)) ->
+        present_questions(interrupts)
+
+      true ->
+        present_hitl_tools(interrupts)
     end
   end
 
@@ -244,6 +259,18 @@ defmodule Sagents.AgentUtils do
   end
 
   # Private helpers
+
+  defp present_halt(halt) do
+    %{
+      pending_halt: %{
+        message: Map.get(halt, :message),
+        source_tool: Map.get(halt, :source_tool) || Map.get(halt, :source),
+        tool_call_id: Map.get(halt, :tool_call_id)
+      },
+      pending_question: nil,
+      pending_tools: []
+    }
+  end
 
   defp present_questions([first | rest]) do
     %{

--- a/lib/sagents/middleware.ex
+++ b/lib/sagents/middleware.ex
@@ -124,6 +124,39 @@ defmodule Sagents.Middleware do
   Anything you place in `interrupt_data` should be *data*, not *behaviour*:
   atoms, strings, numbers, lists, maps, tuples are fine. Functions, PIDs,
   references, ports — never. None of those round-trip through serialization.
+
+  ## Interrupt-data catalog
+
+  The framework ships with a small set of well-known interrupt types,
+  identified by the `:type` atom on `interrupt_data`. Each is owned by a
+  specific middleware (the one that pattern-matches on `:type` in
+  `restorable_interrupt?/1`):
+
+  | Type | Owner | Intent | Resume payload | Required keys |
+  | --- | --- | --- | --- | --- |
+  | `:ask_user_question` | `Sagents.Middleware.AskUserQuestion` | Pause for a typed response, then slot the answer into the halted tool call | `%{type: :answer, ...}` or `%{type: :cancel}` | `:question`, `:response_type`, `:options`, `:allow_other`, `:allow_cancel`, `:context`, `:tool_call_id` |
+  | `:halt` | `Sagents.Middleware.Haltable` | **Terminate the workflow.** Surface a message; do not invoke the LLM again. The user's next message is a fresh turn — not a continuation of the halted tool call. | None (the user's next free-text message demotes the halt via `Sagents.State.cancel_pending_interrupts/1`) | `:type`, `:message` (String), `:source_tool` (String, or `:source` for non-tool emitters); `:tool_call_id` is added by the framework |
+  | `:subagent_hitl` | `Sagents.Middleware.SubAgent` | Propagate a HITL approval up from an inner sub-agent | `[%{type: :approve | :reject | ...}]` matching the original action requests | `:inner` (the wrapped HITL interrupt), `:tool_call_id` |
+  | HITL action-request map (no `:type`) | `Sagents.Middleware.HumanInTheLoop` | Request approval for one or more sensitive tool calls | `[%{type: :approve | :reject | ...}]` per action request | `:action_requests`, `:review_configs` |
+  | `:multiple_interrupts` | (none — wrapper) | Two or more parallel tool calls each emitted an interrupt in the same turn | A list of resume payloads (one per sub-interrupt), or the framework's "halt wins" demotion if any sub is `:halt` | `:interrupts` (list of sub-interrupt maps) |
+
+  ### `:halt` specifics
+
+  A `:halt` is structurally different from the other types: it does not
+  pause for a response. The tool that emits it is declaring the workflow
+  *over*. The framework does not invoke the LLM again, and the integrator
+  surfaces the halt's `:message` to the user. When the user sends a new
+  free-text message, `Sagents.AgentServer` demotes the interrupted tool
+  result (preserving the halt's message in the demoted content) and
+  transitions back to `:idle` so the new message proceeds as a fresh
+  turn. See `Sagents.Middleware.Haltable` for the full semantics.
+
+  ### "Halt wins" inside `:multiple_interrupts`
+
+  If a `:multiple_interrupts` wrapper contains any `:halt` sub-interrupt,
+  the surrounding UI and the cold-start restoration both treat the whole
+  batch as a halt. Sibling `:ask_user_question` / HITL sub-interrupts are
+  moot because the workflow is over.
   """
   alias Sagents.State
   alias Sagents.MiddlewareEntry

--- a/lib/sagents/middleware/haltable.ex
+++ b/lib/sagents/middleware/haltable.ex
@@ -1,0 +1,175 @@
+defmodule Sagents.Middleware.Haltable do
+  @moduledoc """
+  Adds the ability for an agent's tools to *halt* the agent's workflow.
+
+  Adding `Sagents.Middleware.Haltable` to a middleware stack expresses
+  "this agent is haltable" — any tool the agent can invoke is then
+  allowed to emit a `:halt` interrupt, which terminates the agent loop
+  inside the framework (no further LLM call) and surfaces a user-facing
+  message. This middleware claims those interrupts so they survive
+  cold start and are re-surfaced to integrators on AgentServer reboot.
+
+  ## What a halt is
+
+  A `:halt` interrupt is a *terminal* interrupt: a tool has decided the
+  enclosing workflow should stop, and the framework should NOT invoke the
+  LLM again. There is no "next turn" for the orchestrator to weigh the
+  halt against — it is a structural gate, not a persuasive one.
+
+  Contrast with `Sagents.Middleware.AskUserQuestion`:
+
+  | | `:ask_user_question` | `:halt` |
+  | --- | --- | --- |
+  | Intent | Pause for a typed response | Terminate the workflow |
+  | Resume payload | A response slotted back into the halted tool call | None |
+  | `handle_resume/5` behavior | Process the answer, continue the tool call | None — the tool call is dead |
+  | User's next message | Slotted in as a tool result | A new turn; the halted call is demoted |
+
+  ## How resume works (and where `Halt` is NOT involved)
+
+  When a user sends a new free-text message after a halt,
+  `Sagents.AgentServer.handle_call({:add_message, _})` calls
+  `Sagents.State.cancel_pending_interrupts/1`, which demotes every
+  `is_interrupt: true` tool result in the log to an error result and
+  clears `state.interrupt_data`. The agent transitions back to `:idle`
+  and the new message proceeds as a fresh turn.
+
+  **This means `Halt.handle_resume/5` is never called for the "user moved
+  on" leg.** This middleware only handles cold-start re-surface: when an
+  AgentServer boots from persisted state that has a surviving `:halt`
+  interrupt, `handle_resume/5` is called with `resume_data: nil`, and
+  this middleware re-emits the interrupt so UIs can re-render the halt
+  message.
+
+  ## Emitting a halt
+
+  Tool authors emit a halt via the standard `{:interrupt, msg, data}`
+  return tuple, with `type: :halt` in the data:
+
+      def execute(args, _ctx) do
+        case gate_check(args) do
+          :ok ->
+            {:ok, result}
+
+          {:gate_failed, reason} ->
+            {:interrupt, "Workflow halted: \#{reason}",
+             %{
+               type: :halt,
+               source_tool: "scout_outline",
+               message: "Author-facing explanation of what to fix."
+             }}
+        end
+      end
+
+  ## Required keys in interrupt_data
+
+  - `:type` — must be `:halt`
+  - `:message` — `String.t()`, the user-facing reason for the halt
+  - `:source_tool` — `String.t()` identifying which tool emitted the halt
+    (or `:source` if the emitter is not a tool)
+
+  The framework also fills in `:tool_call_id` when the halt comes from
+  inside a tool execution (set by LangChain's
+  `Function.normalize_execution_result/2`).
+
+  ## Adoption
+
+  Add this middleware to your agent's middleware stack:
+
+      middleware: [
+        # ... existing middleware ...
+        Sagents.Middleware.Haltable,
+        # ... rest of stack ...
+      ]
+
+  Any tool that returns `{:interrupt, _, %{type: :halt, ...}}` will then
+  produce a restorable halt interrupt.
+
+  ## "Halt wins" in `:multiple_interrupts`
+
+  When multiple parallel tools emit interrupts in the same turn and at
+  least one is `:halt`, the workflow is over — there is no point asking
+  the user to answer the sibling `ask_user` questions or approve the
+  sibling HITL action requests. This middleware enforces that at
+  cold-start time by claiming `:multiple_interrupts` wrappers that
+  contain any `:halt` sub-interrupt. The UI layer (see
+  `Sagents.AgentUtils.interrupt_session_changes/1`) enforces it at
+  render time.
+  """
+
+  @behaviour Sagents.Middleware
+
+  alias Sagents.State
+
+  @impl true
+  def init(opts), do: {:ok, Map.new(opts)}
+
+  @impl true
+  def system_prompt(_config), do: ""
+
+  @impl true
+  def tools(_config), do: []
+
+  # A halt is pure data: a message, a source, and (optionally) a tool_call_id.
+  # Nothing process-bound. Safe to restore from cold start.
+  @impl true
+  def restorable_interrupt?(%{type: :halt}), do: true
+
+  # Claim `:multiple_interrupts` wrappers IFF they contain a :halt
+  # sub-interrupt. Halt wins: if even one sibling is a halt, the workflow
+  # is terminating and the whole batch should survive cold start so the
+  # UI can render the halt message.
+  def restorable_interrupt?(%{type: :multiple_interrupts, interrupts: subs})
+      when is_list(subs) do
+    Enum.any?(subs, fn
+      %{type: :halt} -> true
+      _other -> false
+    end)
+  end
+
+  def restorable_interrupt?(_other), do: false
+
+  # Cold-start re-surface: AgentServer is booting from persisted state with
+  # a surviving halt. Hand the interrupt back out so the integrator's UI
+  # can re-render the halt message. There is no resume_data because the
+  # user hasn't acted yet — the agent is just back in the :interrupted
+  # state it was in before the process restart.
+  @impl true
+  def handle_resume(
+        _agent,
+        %State{interrupt_data: %{type: :halt} = data} = state,
+        nil,
+        _config,
+        _opts
+      ) do
+    {:interrupt, state, data}
+  end
+
+  # `:multiple_interrupts` cold-start re-surface, with the "halt wins"
+  # policy: if any sub-interrupt is a halt, the whole batch re-surfaces as
+  # the interrupt. The sibling questions/HITL approvals are moot because
+  # the workflow is over.
+  def handle_resume(
+        _agent,
+        %State{interrupt_data: %{type: :multiple_interrupts, interrupts: subs}} = state,
+        nil,
+        _config,
+        _opts
+      )
+      when is_list(subs) do
+    if Enum.any?(subs, &(&1.type == :halt)) do
+      {:interrupt, state, state.interrupt_data}
+    else
+      {:cont, state}
+    end
+  end
+
+  # There is no "user supplied resume_data" clause. A halt is terminal —
+  # the user's next message goes through AgentServer's add_message path,
+  # which demotes the interrupt via State.cancel_pending_interrupts/1
+  # without calling handle_resume/5. If an integrator does call
+  # Agent.resume/3 on a halted state with a payload, falling through to
+  # {:cont, state} is the right behaviour: no middleware will claim the
+  # resume and Agent.resume/3 returns an error from its no-handler path.
+  def handle_resume(_agent, state, _resume_data, _config, _opts), do: {:cont, state}
+end

--- a/lib/sagents/middleware/haltable.ex
+++ b/lib/sagents/middleware/haltable.ex
@@ -95,6 +95,30 @@ defmodule Sagents.Middleware.Haltable do
   contain any `:halt` sub-interrupt. The UI layer (see
   `Sagents.AgentUtils.interrupt_session_changes/1`) enforces it at
   render time.
+
+  ## Transcript persistence
+
+  When a halt fires and the AgentServer is configured with a
+  `DisplayMessagePersistence` module and a `conversation_id`, the
+  halt's `:message` field is automatically persisted as a synthetic
+  assistant display message in the conversation transcript. This means
+  the halt's recommended-actions text survives:
+
+  - the user dismissing the halt display,
+  - the user sending a follow-up message (which clears `:pending_halt`
+    via `Sagents.State.cancel_pending_interrupts/1`),
+  - page reload — the message is in the persisted display-message log
+    just like any other assistant turn.
+
+  Persistence fires *once*, at the original halt-emit moment. Cold-start
+  re-surface (this middleware's `handle_resume/5` re-emitting the
+  interrupt when an AgentServer reboots from persisted state) does NOT
+  re-persist — the transcript message is already there from the
+  original emit.
+
+  Halts with no `:message` (or an empty string) are skipped. So is the
+  case where the AgentServer has no persistence configured — no error,
+  just a silent no-op.
   """
 
   @behaviour Sagents.Middleware

--- a/lib/sagents/state.ex
+++ b/lib/sagents/state.ex
@@ -615,6 +615,26 @@ defmodule Sagents.State do
     }
   end
 
+  # Halt-specific demotion: preserve the original halt message in the
+  # demoted tool result so any future LLM turn sees *why* the gate fired
+  # rather than a generic cancellation. Without this, the LLM would have
+  # no halt-reason in history and might immediately re-attempt the gated
+  # operation.
+  defp demote(tr, {:halted, message}) when is_binary(message) and byte_size(message) > 0 do
+    %{
+      tr
+      | content:
+          "Tool halted: " <>
+            message <>
+            " The user has sent a new instruction - proceed with their new request.",
+        is_interrupt: false,
+        is_error: true,
+        interrupt_data: nil
+    }
+  end
+
+  defp demote(tr, {:halted, _empty_or_nil}), do: demote(tr, :user_cancelled)
+
   @doc """
   Demote every `is_interrupt: true` tool result in the message log to an
   error result, signaling to the LLM that the user abandoned the pending
@@ -636,15 +656,7 @@ defmodule Sagents.State do
       Enum.map(state.messages, fn message ->
         case message do
           %LangChain.Message{role: :tool, tool_results: results} when is_list(results) ->
-            cancelled_results =
-              Enum.map(results, fn
-                %LangChain.Message.ToolResult{is_interrupt: true} = tr ->
-                  demote(tr, :user_cancelled)
-
-                other ->
-                  other
-              end)
-
+            cancelled_results = Enum.map(results, &demote_for_cancel/1)
             %{message | tool_results: cancelled_results}
 
           other ->
@@ -654,4 +666,18 @@ defmodule Sagents.State do
 
     %{state | messages: cancelled_messages, interrupt_data: nil}
   end
+
+  # Pick the demotion variant per tool result. Halt-typed interrupts
+  # preserve their reason so any future LLM turn sees why the gate fired;
+  # everything else gets the generic user-cancelled text. Each ToolResult
+  # carries its own (un-wrapped) `interrupt_data`; the `:multiple_interrupts`
+  # wrapper lives only at the State level, not per-result.
+  defp demote_for_cancel(%LangChain.Message.ToolResult{is_interrupt: true} = tr) do
+    case tr.interrupt_data do
+      %{type: :halt, message: msg} -> demote(tr, {:halted, msg})
+      _other -> demote(tr, :user_cancelled)
+    end
+  end
+
+  defp demote_for_cancel(other), do: other
 end

--- a/priv/templates/agent_subscriber_session.ex.eex
+++ b/priv/templates/agent_subscriber_session.ex.eex
@@ -66,6 +66,7 @@ defmodule <%= module %> do
       loading: false,
       pending_tools: [],
       pending_question: nil,
+      pending_halt: nil,
       remaining_questions: [],
       question_responses: [],
       interrupt_data: nil,

--- a/test/sagents/agent_server_halt_persistence_test.exs
+++ b/test/sagents/agent_server_halt_persistence_test.exs
@@ -1,0 +1,300 @@
+defmodule Sagents.AgentServerHaltPersistenceTest do
+  @moduledoc """
+  Integration tests for the `:halt` interrupt's automatic synthetic
+  assistant-message persistence.
+
+  When a tool emits a `:halt` interrupt, `AgentServer.handle_execution_result/2`
+  saves the halt's `:message` field as a synthetic assistant display
+  message so the user's recommended-actions text survives banner
+  dismissal, follow-up turns, and page reload. These tests exercise
+  that path end-to-end by mocking `Sagents.Agent.execute/3` to return
+  the desired `{:interrupt, state, halt_data}` shape and asserting on
+  the `DisplayMessagePersistence` callback + the broadcast.
+  """
+
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.{Agent, AgentServer, State}
+  alias Sagents.TestDisplayMessagePersistenceForwarding, as: Forwarder
+  alias Sagents.TestingHelpers
+  alias LangChain.Message
+
+  # Make mocks global since agent execution happens in a Task
+  setup :set_mimic_global
+
+  setup_all do
+    Mimic.copy(Agent)
+    :ok
+  end
+
+  setup do
+    Forwarder.register_test_process(self())
+    Forwarder.clear_synthetic_response()
+    on_exit(fn -> Forwarder.clear_synthetic_response() end)
+    :ok
+  end
+
+  defp expect_halt_interrupt(halt_data) do
+    expect(Agent, :execute, fn _agent, state, _callbacks ->
+      {:interrupt, state, halt_data}
+    end)
+  end
+
+  describe ":halt interrupt persists as synthetic assistant message" do
+    test "saves message_type=assistant, content_type=text with halt's :message text" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+      conversation_id = "conv-halt-1"
+
+      halt_text = "Subdivide the outline before drafting — add H2/H3 headers."
+
+      halt = %{
+        type: :halt,
+        message: halt_text,
+        source_tool: "scout_outline",
+        tool_call_id: "call_42"
+      }
+
+      expect_halt_interrupt(halt)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: conversation_id,
+          display_message_persistence: Forwarder
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("scout the outline"))
+
+      # The Forwarder receives the synthetic-message save with the halt's text.
+      assert_receive {:saved_synthetic_message, _scope, attrs, context}, 500
+      assert attrs.message_type == "assistant"
+      assert attrs.content_type == "text"
+      assert attrs.content == %{"text" => halt_text}
+      assert context.agent_id == agent_id
+      assert context.conversation_id == conversation_id
+
+      # And the broadcast fires for any subscribed LiveView.
+      assert_receive {:agent, {:display_message_saved, %{attrs: ^attrs}}}, 500
+
+      # Sanity: the agent is in the :interrupted state with the halt as the
+      # interrupt_data.
+      assert AgentServer.get_status(agent_id) == :interrupted
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "does not persist when halt :message is nil" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      halt = %{type: :halt, message: nil, source_tool: "scout"}
+      expect_halt_interrupt(halt)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-halt-nil",
+          display_message_persistence: Forwarder
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("go"))
+
+      # Wait for execution to settle by polling status (Forwarder send is sync,
+      # so if a save HAD fired we'd already have the message).
+      assert_receive {:agent, {:status_changed, :interrupted, _}}, 500
+
+      refute_received {:saved_synthetic_message, _, _, _}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "does not persist when halt :message is empty string" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      halt = %{type: :halt, message: "", source_tool: "scout"}
+      expect_halt_interrupt(halt)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-halt-empty",
+          display_message_persistence: Forwarder
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("go"))
+
+      assert_receive {:agent, {:status_changed, :interrupted, _}}, 500
+      refute_received {:saved_synthetic_message, _, _, _}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "no-op when display_message_persistence is not configured" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      halt = %{type: :halt, message: "stop", source_tool: "scout"}
+      expect_halt_interrupt(halt)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-no-persistence"
+          # no display_message_persistence
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("go"))
+
+      # Server still alive and interrupts correctly.
+      assert_receive {:agent, {:status_changed, :interrupted, %{type: :halt}}}, 500
+      refute_received {:saved_synthetic_message, _, _, _}
+      refute_received {:agent, {:display_message_saved, _}}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "no-op when conversation_id is not configured" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      halt = %{type: :halt, message: "stop", source_tool: "scout"}
+      expect_halt_interrupt(halt)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          display_message_persistence: Forwarder
+          # no conversation_id
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("go"))
+
+      assert_receive {:agent, {:status_changed, :interrupted, %{type: :halt}}}, 500
+      refute_received {:saved_synthetic_message, _, _, _}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "persists one synthetic message per halt inside :multiple_interrupts" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      halt_a = %{type: :halt, message: "halt A", source_tool: "scout_a"}
+      halt_b = %{type: :halt, message: "halt B", source_tool: "scout_b"}
+      question = %{type: :ask_user_question, question: "?"}
+
+      data = %{
+        type: :multiple_interrupts,
+        interrupts: [halt_a, question, halt_b]
+      }
+
+      expect_halt_interrupt(data)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-multi-halt",
+          display_message_persistence: Forwarder
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("go"))
+
+      assert_receive {:saved_synthetic_message, _s1, %{content: %{"text" => "halt A"}}, _c1}, 500
+
+      assert_receive {:saved_synthetic_message, _s2, %{content: %{"text" => "halt B"}}, _c2}, 500
+
+      # The sibling question does NOT get persisted via this path.
+      refute_received {:saved_synthetic_message, _, %{content: %{"text" => "?"}}, _}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+
+    test "non-halt interrupts do not trigger halt persistence" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      question = %{
+        type: :ask_user_question,
+        question: "Which DB?",
+        response_type: :single_select,
+        options: [],
+        allow_other: false,
+        allow_cancel: true,
+        tool_call_id: "call_q"
+      }
+
+      expect(Agent, :execute, fn _agent, state, _callbacks ->
+        {:interrupt, state, question}
+      end)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-question",
+          display_message_persistence: Forwarder
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("ask me"))
+
+      assert_receive {:agent, {:status_changed, :interrupted, %{type: :ask_user_question}}}, 500
+      refute_received {:saved_synthetic_message, _, _, _}
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+  end
+
+  describe "halt persistence survives cancellation" do
+    test "synthetic assistant message remains in transcript after cancel_pending_interrupts" do
+      agent_id = TestingHelpers.generate_test_agent_id()
+
+      halt_text = "Use H3 headers to split this scene."
+
+      halt = %{
+        type: :halt,
+        message: halt_text,
+        source_tool: "scout_outline",
+        tool_call_id: "call_persist_1"
+      }
+
+      # On the first execution, return the halt. On the second (after the
+      # user sends a new message and the agent transitions to :idle and
+      # re-executes), return a successful completion so the test doesn't
+      # hang waiting for further interrupts.
+      expect(Agent, :execute, fn _agent, state, _callbacks ->
+        {:interrupt, state, halt}
+      end)
+
+      expect(Agent, :execute, fn _agent, _state, _callbacks ->
+        {:ok, State.new!()}
+      end)
+
+      {:ok, %{agent_id: ^agent_id}} =
+        TestingHelpers.start_test_agent(
+          agent_id: agent_id,
+          pubsub: {Phoenix.PubSub, :test_pubsub},
+          conversation_id: "conv-cancel-halt",
+          display_message_persistence: Forwarder
+        )
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("scout"))
+
+      # Halt fires → synthetic message persisted.
+      assert_receive {:saved_synthetic_message, _scope, attrs, _context}, 500
+      assert attrs.content == %{"text" => halt_text}
+
+      # User moves on: send a follow-up. AgentServer demotes the interrupt
+      # via cancel_pending_interrupts and transitions to :idle. The synthetic
+      # message was already persisted by the prior step and is NOT undone.
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("ok, will fix"))
+
+      # No second persistence call for the halt (it only fires at emit time).
+      refute_received {:saved_synthetic_message, _, %{content: %{"text" => ^halt_text}}, _},
+                      "halt's transcript entry must not be re-persisted on follow-up"
+
+      TestingHelpers.stop_test_agent(agent_id)
+    end
+  end
+end

--- a/test/sagents/agent_utils_test.exs
+++ b/test/sagents/agent_utils_test.exs
@@ -525,6 +525,55 @@ defmodule Sagents.AgentUtilsTest do
       assert %{pending_tools: ^action_requests, pending_question: nil} =
                AgentUtils.interrupt_session_changes(interrupt)
     end
+
+    test "presents a single :halt as a pending halt" do
+      halt = %{
+        type: :halt,
+        message: "Outline too coarse",
+        source_tool: "scout_outline",
+        tool_call_id: "call_42"
+      }
+
+      assert %{
+               pending_halt: %{
+                 message: "Outline too coarse",
+                 source_tool: "scout_outline",
+                 tool_call_id: "call_42"
+               },
+               pending_question: nil,
+               pending_tools: []
+             } = AgentUtils.interrupt_session_changes(halt)
+    end
+
+    test "halt wins inside :multiple_interrupts even with sibling questions" do
+      q = %{type: :ask_user_question, question: "Continue?"}
+
+      halt = %{
+        type: :halt,
+        message: "Gate fired",
+        source_tool: "scout",
+        tool_call_id: "call_99"
+      }
+
+      result =
+        AgentUtils.interrupt_session_changes(%{
+          type: :multiple_interrupts,
+          interrupts: [q, halt]
+        })
+
+      assert result.pending_halt.message == "Gate fired"
+      assert result.pending_halt.source_tool == "scout"
+      assert result.pending_halt.tool_call_id == "call_99"
+      assert result.pending_question == nil
+      assert result.pending_tools == []
+    end
+
+    test "halt prefers :source_tool but falls back to :source" do
+      halt = %{type: :halt, message: "msg", source: "external_gate"}
+
+      assert %{pending_halt: %{source_tool: "external_gate"}} =
+               AgentUtils.interrupt_session_changes(halt)
+    end
   end
 
   describe "advance_hitl_decisions/3" do

--- a/test/sagents/middleware/haltable_test.exs
+++ b/test/sagents/middleware/haltable_test.exs
@@ -1,0 +1,275 @@
+defmodule Sagents.Middleware.HaltableTest do
+  use ExUnit.Case, async: true
+
+  alias Sagents.Middleware
+  alias Sagents.Middleware.Haltable
+  alias Sagents.State
+
+  describe "init/1" do
+    test "accepts empty options" do
+      assert {:ok, %{}} = Haltable.init([])
+    end
+
+    test "accepts arbitrary opts as map" do
+      assert {:ok, %{custom: true}} = Haltable.init(custom: true)
+    end
+  end
+
+  describe "system_prompt/1 and tools/1" do
+    test "contributes no system prompt" do
+      assert Haltable.system_prompt(%{}) == ""
+    end
+
+    test "contributes no tools" do
+      assert Haltable.tools(%{}) == []
+    end
+  end
+
+  describe "restorable_interrupt?/1" do
+    test "returns true for :halt interrupt data" do
+      assert Haltable.restorable_interrupt?(%{type: :halt, message: "stop"})
+    end
+
+    test "returns true for :multiple_interrupts containing any :halt" do
+      data = %{
+        type: :multiple_interrupts,
+        interrupts: [
+          %{type: :ask_user_question, question: "?"},
+          %{type: :halt, message: "stop"}
+        ]
+      }
+
+      assert Haltable.restorable_interrupt?(data)
+    end
+
+    test "returns false for :multiple_interrupts with no :halt" do
+      data = %{
+        type: :multiple_interrupts,
+        interrupts: [%{type: :ask_user_question, question: "?"}]
+      }
+
+      refute Haltable.restorable_interrupt?(data)
+    end
+
+    test "returns false for unrelated interrupt types" do
+      refute Haltable.restorable_interrupt?(%{type: :ask_user_question})
+      refute Haltable.restorable_interrupt?(%{type: :subagent_hitl})
+      refute Haltable.restorable_interrupt?(%{})
+    end
+  end
+
+  describe "handle_resume/5 cold-start re-surface" do
+    test "re-emits the halt interrupt when resume_data is nil" do
+      halt = %{
+        type: :halt,
+        message: "Outline too coarse",
+        source_tool: "scout_outline",
+        tool_call_id: "call_1"
+      }
+
+      state = State.new!(%{interrupt_data: halt})
+
+      assert {:interrupt, ^state, ^halt} =
+               Haltable.handle_resume(nil, state, nil, %{}, [])
+    end
+
+    test "re-emits :multiple_interrupts when it contains a :halt" do
+      halt = %{type: :halt, message: "stop", source_tool: "scout"}
+      question = %{type: :ask_user_question, question: "?"}
+
+      data = %{type: :multiple_interrupts, interrupts: [question, halt]}
+      state = State.new!(%{interrupt_data: data})
+
+      assert {:interrupt, ^state, ^data} =
+               Haltable.handle_resume(nil, state, nil, %{}, [])
+    end
+
+    test "passes :multiple_interrupts without :halt through to next middleware" do
+      data = %{
+        type: :multiple_interrupts,
+        interrupts: [%{type: :ask_user_question, question: "?"}]
+      }
+
+      state = State.new!(%{interrupt_data: data})
+
+      assert {:cont, ^state} = Haltable.handle_resume(nil, state, nil, %{}, [])
+    end
+
+    test "does not claim non-halt single interrupts" do
+      state =
+        State.new!(%{interrupt_data: %{type: :ask_user_question, question: "?"}})
+
+      assert {:cont, ^state} = Haltable.handle_resume(nil, state, nil, %{}, [])
+    end
+
+    test "falls through when resume_data is supplied (no resume payload for halts)" do
+      halt = %{type: :halt, message: "stop", source_tool: "scout"}
+      state = State.new!(%{interrupt_data: halt})
+
+      # Any resume_data on a halt is a programmer error; the framework
+      # demotes via cancel_pending_interrupts on the add_message path,
+      # not via Agent.resume/3. Falling through to :cont lets
+      # Agent.resume/3 surface its "no middleware handled the resume"
+      # error.
+      assert {:cont, ^state} =
+               Haltable.handle_resume(nil, state, %{some: :payload}, %{}, [])
+    end
+  end
+
+  describe "middleware integration" do
+    test "registers via Middleware.init_middleware/1" do
+      entry = Middleware.init_middleware(Haltable)
+      assert entry.module == Haltable
+    end
+
+    test "Middleware.apply_restorable_interrupt? routes through this middleware" do
+      entry = Middleware.init_middleware(Haltable)
+
+      assert Middleware.apply_restorable_interrupt?(entry, %{type: :halt, message: "x"})
+      refute Middleware.apply_restorable_interrupt?(entry, %{type: :ask_user_question})
+    end
+
+    test "Middleware.apply_handle_resume re-surfaces a halt" do
+      entry = Middleware.init_middleware(Haltable)
+      halt = %{type: :halt, message: "stop", source_tool: "scout"}
+      state = State.new!(%{interrupt_data: halt})
+
+      assert {:interrupt, ^state, ^halt} =
+               Middleware.apply_handle_resume(nil, state, nil, entry, [])
+    end
+  end
+
+  describe "State.cancel_pending_interrupts/1 with halt" do
+    test "preserves the halt message in the demoted tool result content" do
+      halt = %{
+        type: :halt,
+        message: "Outline needs subdivision before drafting.",
+        source_tool: "scout_outline"
+      }
+
+      interrupt_result =
+        LangChain.Message.ToolResult.new!(%{
+          tool_call_id: "call_42",
+          content: "Workflow halted",
+          name: "scout_outline",
+          is_interrupt: true,
+          interrupt_data: halt
+        })
+
+      tool_msg =
+        LangChain.Message.new_tool_result!(%{content: nil, tool_results: [interrupt_result]})
+
+      state = State.new!(%{messages: [tool_msg], interrupt_data: halt})
+
+      cancelled = State.cancel_pending_interrupts(state)
+
+      [demoted] =
+        cancelled.messages
+        |> List.last()
+        |> Map.fetch!(:tool_results)
+
+      refute demoted.is_interrupt
+      assert demoted.is_error
+      assert demoted.interrupt_data == nil
+      assert demoted.content =~ "Tool halted:"
+      assert demoted.content =~ "Outline needs subdivision before drafting."
+      assert demoted.content =~ "proceed with their new request"
+      assert cancelled.interrupt_data == nil
+    end
+
+    test "non-halt interrupts still get the generic user-cancelled text" do
+      question = %{
+        type: :ask_user_question,
+        question: "Which DB?",
+        response_type: :single_select,
+        options: [],
+        allow_other: false,
+        allow_cancel: true,
+        tool_call_id: "call_99"
+      }
+
+      interrupt_result =
+        LangChain.Message.ToolResult.new!(%{
+          tool_call_id: "call_99",
+          content: "Waiting for user response...",
+          name: "ask_user",
+          is_interrupt: true,
+          interrupt_data: question
+        })
+
+      tool_msg =
+        LangChain.Message.new_tool_result!(%{content: nil, tool_results: [interrupt_result]})
+
+      state = State.new!(%{messages: [tool_msg], interrupt_data: question})
+
+      cancelled = State.cancel_pending_interrupts(state)
+
+      [demoted] =
+        cancelled.messages
+        |> List.last()
+        |> Map.fetch!(:tool_results)
+
+      assert demoted.content =~ "the user did not respond"
+      refute demoted.content =~ "Tool halted:"
+    end
+  end
+
+  describe "State.clean_stale_interrupts/2 cold-start restoration" do
+    test "preserves a halt interrupt when Haltable is in the stack" do
+      halt = %{type: :halt, message: "stop", source_tool: "scout"}
+
+      interrupt_result =
+        LangChain.Message.ToolResult.new!(%{
+          tool_call_id: "call_1",
+          content: "Workflow halted",
+          name: "scout_outline",
+          is_interrupt: true,
+          interrupt_data: halt
+        })
+
+      tool_msg =
+        LangChain.Message.new_tool_result!(%{content: nil, tool_results: [interrupt_result]})
+
+      state = State.new!(%{messages: [tool_msg]})
+      entry = Middleware.init_middleware(Haltable)
+
+      cleaned = State.clean_stale_interrupts(state, [entry])
+
+      [preserved] =
+        cleaned.messages
+        |> List.last()
+        |> Map.fetch!(:tool_results)
+
+      assert preserved.is_interrupt
+      assert preserved.interrupt_data == halt
+    end
+
+    test "demotes a halt interrupt when Haltable is NOT in the stack" do
+      halt = %{type: :halt, message: "stop", source_tool: "scout"}
+
+      interrupt_result =
+        LangChain.Message.ToolResult.new!(%{
+          tool_call_id: "call_1",
+          content: "Workflow halted",
+          name: "scout_outline",
+          is_interrupt: true,
+          interrupt_data: halt
+        })
+
+      tool_msg =
+        LangChain.Message.new_tool_result!(%{content: nil, tool_results: [interrupt_result]})
+
+      state = State.new!(%{messages: [tool_msg]})
+
+      cleaned = State.clean_stale_interrupts(state, [])
+
+      [demoted] =
+        cleaned.messages
+        |> List.last()
+        |> Map.fetch!(:tool_results)
+
+      refute demoted.is_interrupt
+      assert demoted.is_error
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Tools sometimes need to *stop* an agent workflow rather than pause it for a response. Examples: a validation tool that detects if something is ready or available. It's a gating operation. If it finds an issue, it needs to stop the workflow mid-process. LLMs are not consistent with honoring a stop request and will likely plow ahead trying to be helpful. We need the ability to have a hard-stop.

## Solution

Introduces `:halt` as a first-class **terminal** interrupt type, owned by a new `Sagents.Middleware.Haltable` middleware.

The semantics are deliberately different from existing interrupts:

- The tool call that emits the halt is *dead*. The LLM is not re-invoked.
- There is no resume payload. The user's next free-text message goes through `AgentServer.add_message`, which calls `State.cancel_pending_interrupts/1` to demote the halt and proceeds as a fresh turn.
- The halt's `:message` is persisted as a synthetic assistant transcript entry, so it survives dismissal, follow-up messages, and page reload, distinct from the transient `:pending_halt` UI banner.
- A new `AgentServer.dismiss_interrupt/1` call lets a UI acknowledge the halt (and clear the `:interrupted` state) without sending a new message. It refuses to dismiss interrupt types that require an explicit response.
- Cold-start re-surface: if an `AgentServer` reboots from persisted state with a surviving halt, `Haltable.handle_resume/5` re-emits the interrupt so UIs can re-render — but does *not* re-persist the transcript message (the original emit already wrote it).

A **\"halt wins\"** policy is enforced for parallel-tool batches: if a `:multiple_interrupts` wrapper contains any `:halt` sub-interrupt, the whole batch is treated as terminal — at restore time (`Haltable.restorable_interrupt?/1`), at render time (`AgentUtils.interrupt_session_changes/1`), and at demotion time (`State.demote_for_cancel/1`). Sibling questions and HITL approvals are moot because the workflow is over.

`State.cancel_pending_interrupts/1` is updated so halt-typed tool results are demoted with their original reason preserved (`\"Tool halted: <message>. The user has sent a new instruction...\"`) rather than the generic user-cancelled text — without this, the LLM would lose the *why* and might immediately re-attempt the gated operation.

A `[:sagents, :agent, :halt]` telemetry event fires on halt emit for observability tooling that wants to distinguish gate decisions from ordinary `:interrupted` transitions.

## Changes

- `lib/sagents/middleware/haltable.ex` — New middleware. Owns the `:halt` interrupt type, claims `:multiple_interrupts` wrappers containing a halt, handles cold-start re-surface.
- `lib/sagents/agent_server.ex` — Adds `dismiss_interrupt/1` public API and its `handle_call` clauses. Adds `halt_interrupt?/1`, halt-aware tool display update, `[:sagents, :agent, :halt]` telemetry emission via `maybe_emit_halt_telemetry/2`, and synthetic transcript persistence via `maybe_persist_halt_messages/2`.
- `lib/sagents/state.ex` — Adds halt-preserving `demote/2` clause and `demote_for_cancel/1` selector so halt-typed `is_interrupt` tool results retain their reason in history after the user moves on.
- `lib/sagents/agent_utils.ex` — `interrupt_session_changes/1` learns the `:halt` shape, adds `present_halt/1`, enforces \"halt wins\" inside `:multiple_interrupts`.
- `lib/sagents/middleware.ex` — Documents the full interrupt-data catalog (`:ask_user_question`, `:halt`, `:subagent_hitl`, HITL action-request map, `:multiple_interrupts`) and the halt-wins policy.
- `priv/templates/agent_subscriber_session.ex.eex` — Adds `pending_halt: nil` to the generated subscriber session assigns so integrators get the new field for free on new projects.
- `test/sagents/middleware/haltable_test.exs` — New test file covering `restorable_interrupt?/1` for direct halts and multi-interrupt wrappers, cold-start re-surface via `handle_resume/5`, and the no-resume-payload fall-through.
- `test/sagents/agent_server_halt_persistence_test.exs` — New test file covering halt emit → synthetic transcript persistence, the dismiss flow, no double-persist on cold-start re-surface, and the `:multiple_interrupts` halt-wins path.
- `test/sagents/agent_utils_test.exs` — Adds coverage for the `:halt` render shape, halt-wins inside `:multiple_interrupts`, and the `:source_tool` / `:source` fallback.

## Testing

Three test files exercise the new behavior end-to-end:

- `test/sagents/middleware/haltable_test.exs` — middleware contract (restorable, cold-start re-surface, no-resume fall-through)
- `test/sagents/agent_server_halt_persistence_test.exs` — server lifecycle (transcript persistence, dismiss, telemetry, multi-interrupt wrapper)
- `test/sagents/agent_utils_test.exs` — UI projection (`:halt` shape, halt-wins, `:source` fallback)

All run as unit tests with no live API calls. Run with `mix test` from `sagents/`.