### PR TITLE
Make Todo IDs integers to fix lexicographic sort order

### DIFF
--- a/lib/sagents/middleware/todo_list.ex
+++ b/lib/sagents/middleware/todo_list.ex
@@ -227,8 +227,9 @@ defmodule Sagents.Middleware.TodoList do
               type: "object",
               properties: %{
                 id: %{
-                  type: "string",
-                  description: "Unique identifier for the TODO"
+                  type: "integer",
+                  description:
+                    "Positive integer that is unique within this todo list. If omitted, IDs are assigned from list order (first item = 1)."
                 },
                 content: %{
                   type: "string",
@@ -351,21 +352,7 @@ defmodule Sagents.Middleware.TodoList do
   end
 
   defp parse_todos(todos_data) when is_list(todos_data) do
-    results =
-      Enum.map(todos_data, fn todo_map ->
-        Todo.from_map(todo_map)
-      end)
-
-    # Check if any failed
-    case Enum.find(results, fn result -> match?({:error, _changeset}, result) end) do
-      nil ->
-        todos = Enum.map(results, fn {:ok, todo} -> todo end)
-        {:ok, todos}
-
-      {:error, changeset} ->
-        errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
-        {:error, inspect(errors)}
-    end
+    Todo.list_from_maps(todos_data)
   end
 
   defp parse_todos(_other), do: {:error, "todos must be an array"}

--- a/lib/sagents/persistence/state_serializer.ex
+++ b/lib/sagents/persistence/state_serializer.ex
@@ -136,10 +136,8 @@ defmodule Sagents.Persistence.StateSerializer do
     todos =
       case data["todos"] do
         todos when is_list(todos) ->
-          Enum.map(todos, fn todo_map ->
-            {:ok, todo} = Todo.from_map(todo_map)
-            todo
-          end)
+          {:ok, parsed} = Todo.list_from_maps(todos)
+          parsed
 
         _other ->
           []

--- a/lib/sagents/state.ex
+++ b/lib/sagents/state.ex
@@ -395,7 +395,7 @@ defmodule Sagents.State do
   @doc """
   Get a TODO by ID.
   """
-  def get_todo(%State{} = state, todo_id) when is_binary(todo_id) do
+  def get_todo(%State{} = state, todo_id) when is_integer(todo_id) do
     Enum.find(state.todos, fn
       %{id: ^todo_id} -> true
       _other -> false
@@ -405,7 +405,7 @@ defmodule Sagents.State do
   @doc """
   Remove a TODO by ID.
   """
-  def delete_todo(%State{} = state, todo_id) when is_binary(todo_id) do
+  def delete_todo(%State{} = state, todo_id) when is_integer(todo_id) do
     updated_todos =
       Enum.reject(state.todos, fn
         %{id: ^todo_id} -> true

--- a/lib/sagents/todo.ex
+++ b/lib/sagents/todo.ex
@@ -5,6 +5,14 @@ defmodule Sagents.Todo do
   TODOs help agents break down complex tasks into manageable steps and track
   progress through multi-step workflows.
 
+  ## Identity
+
+  Each TODO's `id` is a positive integer that is unique **within a single
+  list**. There is no global ID space — IDs only need to distinguish items
+  within the same conversation's todo list. When building a list, prefer
+  `list_from_maps/1`, which assigns positional IDs (1..N) for any item that
+  doesn't supply one.
+
   ## Status Values
 
   - `:pending` - Task not yet started
@@ -14,18 +22,15 @@ defmodule Sagents.Todo do
 
   ## Usage
 
-      # Create a new TODO
-      {:ok, todo} = Todo.new(%{
-        content: "Implement user authentication",
-        status: :pending
-      })
+      # Create a single TODO (id is required)
+      {:ok, todo} = Todo.new(%{id: 1, content: "Implement user authentication"})
 
-      # Update status
-      {:ok, updated} = Todo.new(%{
-        id: todo.id,
-        content: todo.content,
-        status: :in_progress
-      })
+      # Build a list, letting positional defaults assign IDs
+      {:ok, todos} = Todo.list_from_maps([
+        %{"content" => "Task A", "status" => "pending"},
+        %{"content" => "Task B", "status" => "pending"}
+      ])
+      # todos[0].id == 1, todos[1].id == 2
   """
 
   use Ecto.Schema
@@ -34,7 +39,7 @@ defmodule Sagents.Todo do
 
   @primary_key false
   embedded_schema do
-    field :id, :string
+    field :id, :integer
     field :content, :string
 
     field :status, Ecto.Enum,
@@ -43,7 +48,7 @@ defmodule Sagents.Todo do
   end
 
   @type t :: %Todo{
-          id: String.t(),
+          id: integer(),
           content: String.t(),
           status: :pending | :in_progress | :completed | :cancelled
         }
@@ -51,16 +56,21 @@ defmodule Sagents.Todo do
   @doc """
   Create a new TODO item with validation.
 
-  Generates a unique ID if not provided.
+  Requires an explicit positive-integer `id`. There is no auto-generation —
+  callers building a list should use `list_from_maps/1` instead, which
+  assigns positional IDs.
+
+  Stringified integer ids (e.g. `"5"`) are coerced to integers so payloads
+  arriving from JSON tool calls keep working.
 
   ## Examples
 
-      {:ok, todo} = Todo.new(%{content: "Write tests"})
-      {:ok, todo} = Todo.new(%{id: "custom-id", content: "Task", status: :completed})
+      {:ok, todo} = Todo.new(%{id: 1, content: "Write tests"})
+      {:ok, todo} = Todo.new(%{id: "1", content: "Write tests"})  # coerced
   """
   def new(attrs \\ %{}) do
     attrs
-    |> ensure_id()
+    |> coerce_id()
     |> cast_and_validate()
   end
 
@@ -69,7 +79,7 @@ defmodule Sagents.Todo do
 
   ## Examples
 
-      todo = Todo.new!(%{content: "Deploy to production"})
+      todo = Todo.new!(%{id: 1, content: "Deploy to production"})
   """
   def new!(attrs \\ %{}) do
     case new(attrs) do
@@ -83,9 +93,9 @@ defmodule Sagents.Todo do
 
   ## Examples
 
-      todo = Todo.new!(%{content: "Task"})
+      todo = Todo.new!(%{id: 1, content: "Task"})
       map = Todo.to_map(todo)
-      # => %{"id" => "...", "content" => "Task", "status" => "pending"}
+      # => %{"id" => 1, "content" => "Task", "status" => "pending"}
   """
   def to_map(%Todo{} = todo) do
     %{
@@ -96,12 +106,16 @@ defmodule Sagents.Todo do
   end
 
   @doc """
-  Create a TODO from a map (for deserialization).
+  Create a single TODO from a map (for deserialization).
+
+  Coerces a stringified integer id to an integer. A missing or non-numeric
+  id is an error from this entry point; callers handling a whole list
+  should use `list_from_maps/1` to get positional ID defaults.
 
   ## Examples
 
-      map = %{"id" => "123", "content" => "Task", "status" => "pending"}
-      {:ok, todo} = Todo.from_map(map)
+      {:ok, todo} = Todo.from_map(%{"id" => 1, "content" => "Task", "status" => "pending"})
+      {:ok, todo} = Todo.from_map(%{"id" => "1", "content" => "Task"})
   """
   def from_map(map) when is_map(map) do
     attrs = %{
@@ -113,25 +127,92 @@ defmodule Sagents.Todo do
     new(attrs)
   end
 
+  @doc """
+  Build a list of TODOs from an ordered list of maps.
+
+  This is the canonical ingest point for any list of incoming todo data:
+  tool calls, persisted state, conversation rehydrate. It guarantees every
+  TODO has a positive integer id by assigning positional defaults:
+
+  - Missing, nil, or non-numeric id → `id = index + 1` (1-based).
+  - Positive integer id → kept as is.
+  - Numeric-string id (e.g. `"5"`, `"01"`) → coerced to integer.
+
+  The non-numeric fallback exists for backward compatibility with snapshots
+  persisted before IDs were typed as integers (which used random base64
+  strings). Those legacy IDs lose their original identity on reload, but
+  in-list order is preserved.
+
+  Returns `{:ok, [Todo.t()]}` if every item parses, or `{:error, reason}`
+  on the first failure.
+  """
+  def list_from_maps(todos) when is_list(todos) do
+    results =
+      todos
+      |> Enum.with_index()
+      |> Enum.map(fn {map, index} ->
+        map
+        |> assign_positional_id(index)
+        |> from_map()
+      end)
+
+    case Enum.find(results, fn result -> match?({:error, _changeset}, result) end) do
+      nil ->
+        {:ok, Enum.map(results, fn {:ok, todo} -> todo end)}
+
+      {:error, changeset} ->
+        errors = Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
+        {:error, inspect(errors)}
+    end
+  end
+
   # Private functions
 
-  defp ensure_id(%{id: id} = attrs) when is_binary(id) and byte_size(id) > 0, do: attrs
+  defp assign_positional_id(map, index) when is_map(map) do
+    raw = map["id"] || map[:id]
 
-  defp ensure_id(attrs) do
-    Map.put(attrs, :id, generate_id())
+    case coerce_to_positive_integer(raw) do
+      {:ok, _int} ->
+        # Keep the original key shape; coerce_id/1 in `new/1` handles it.
+        map
+
+      :error ->
+        # Missing or non-numeric → assign positional default.
+        positional = index + 1
+
+        if Map.has_key?(map, "id") do
+          Map.put(map, "id", positional)
+        else
+          Map.put(map, :id, positional)
+        end
+    end
   end
 
-  # Generate a simple unique ID
-  defp generate_id do
-    :crypto.strong_rand_bytes(16)
-    |> Base.url_encode64(padding: false)
-    |> String.slice(0, 22)
+  defp coerce_id(%{id: id} = attrs) do
+    case coerce_to_positive_integer(id) do
+      {:ok, int} -> %{attrs | id: int}
+      :error -> attrs
+    end
   end
+
+  defp coerce_id(attrs), do: attrs
+
+  defp coerce_to_positive_integer(int) when is_integer(int) and int > 0, do: {:ok, int}
+
+  defp coerce_to_positive_integer(str) when is_binary(str) do
+    case Integer.parse(str) do
+      {int, ""} when int > 0 -> {:ok, int}
+      _other -> :error
+    end
+  end
+
+  defp coerce_to_positive_integer(_other), do: :error
 
   defp cast_and_validate(attrs) do
     %Todo{}
     |> cast(attrs, [:id, :content, :status])
     |> validate_required([:id, :content, :status])
+    |> validate_number(:id, greater_than: 0)
     |> validate_length(:content, min: 1, max: 1000)
     |> validate_inclusion(:status, [:pending, :in_progress, :completed, :cancelled])
     |> apply_action(:insert)

--- a/priv/templates/sagents.gen.persistence/display_message.ex.eex
+++ b/priv/templates/sagents.gen.persistence/display_message.ex.eex
@@ -191,7 +191,7 @@ defmodule <%= @context_module %>.DisplayMessage do
     do: {:error, "invalid structure for content_type #{content_type}"}
 
   defp valid_todo_entry?(%{"id" => id, "content" => content, "status" => status})
-       when is_binary(id) and is_binary(content) and is_binary(status) do
+       when is_integer(id) and is_binary(content) and is_binary(status) do
     status in @todo_statuses
   end
 

--- a/test/sagents/agent_server_persistence_test.exs
+++ b/test/sagents/agent_server_persistence_test.exs
@@ -20,7 +20,7 @@ defmodule Sagents.AgentServerPersistenceTest do
       msg1 = Message.new_user!("Hello")
       msg2 = Message.new_assistant!(%{content: "Hi there"})
 
-      {:ok, todo} = Todo.new(%{content: "Task 1", status: :in_progress})
+      {:ok, todo} = Todo.new(%{id: 1, content: "Task 1", status: :in_progress})
 
       state =
         State.new!(%{
@@ -286,9 +286,9 @@ defmodule Sagents.AgentServerPersistenceTest do
       msg1 = Message.new_user!("User message")
       msg2 = Message.new_assistant!(%{content: "Assistant response"})
 
-      {:ok, todo1} = Todo.new(%{content: "Task 1", status: :in_progress})
+      {:ok, todo1} = Todo.new(%{id: 1, content: "Task 1", status: :in_progress})
 
-      {:ok, todo2} = Todo.new(%{content: "Task 2", status: :completed})
+      {:ok, todo2} = Todo.new(%{id: 2, content: "Task 2", status: :completed})
 
       original_state =
         State.new!(%{
@@ -417,7 +417,7 @@ defmodule Sagents.AgentServerPersistenceTest do
       msg1 = Message.new_user!("Hello from original")
       msg2 = Message.new_assistant!(%{content: "Response from original"})
 
-      {:ok, todo} = Todo.new(%{content: "Original task", status: :in_progress})
+      {:ok, todo} = Todo.new(%{id: 1, content: "Original task", status: :in_progress})
 
       state =
         State.new!(%{

--- a/test/sagents/integration_test.exs
+++ b/test/sagents/integration_test.exs
@@ -38,12 +38,12 @@ defmodule Sagents.IntegrationTest do
                        "merge" => false,
                        "todos" => [
                          %{
-                           "id" => "task_1",
+                           "id" => 1,
                            "content" => "Write integration test",
                            "status" => "completed"
                          },
                          %{
-                           "id" => "task_2",
+                           "id" => 2,
                            "content" => "Verify state updates",
                            "status" => "in_progress"
                          }
@@ -82,8 +82,8 @@ defmodule Sagents.IntegrationTest do
       assert length(final_state.todos) == 2
 
       # Find the todos
-      task_1 = Enum.find(final_state.todos, &(&1.id == "task_1"))
-      task_2 = Enum.find(final_state.todos, &(&1.id == "task_2"))
+      task_1 = Enum.find(final_state.todos, &(&1.id == 1))
+      task_2 = Enum.find(final_state.todos, &(&1.id == 2))
 
       assert task_1.content == "Write integration test"
       assert task_1.status == :completed
@@ -369,12 +369,12 @@ defmodule Sagents.IntegrationTest do
                      arguments: %{
                        "merge" => false,
                        "todos" => [
-                         %{"id" => "1", "content" => "Task 1", "status" => "in_progress"},
-                         %{"id" => "2", "content" => "Task 2", "status" => "pending"},
-                         %{"id" => "3", "content" => "Task 3", "status" => "pending"},
-                         %{"id" => "4", "content" => "Task 4", "status" => "pending"},
-                         %{"id" => "5", "content" => "Task 5", "status" => "pending"},
-                         %{"id" => "6", "content" => "Task 6", "status" => "pending"}
+                         %{"id" => 1, "content" => "Task 1", "status" => "in_progress"},
+                         %{"id" => 2, "content" => "Task 2", "status" => "pending"},
+                         %{"id" => 3, "content" => "Task 3", "status" => "pending"},
+                         %{"id" => 4, "content" => "Task 4", "status" => "pending"},
+                         %{"id" => 5, "content" => "Task 5", "status" => "pending"},
+                         %{"id" => 6, "content" => "Task 6", "status" => "pending"}
                        ]
                      }
                    })
@@ -394,8 +394,8 @@ defmodule Sagents.IntegrationTest do
                      arguments: %{
                        "merge" => true,
                        "todos" => [
-                         %{"id" => "1", "content" => "Task 1", "status" => "completed"},
-                         %{"id" => "2", "content" => "Task 2", "status" => "in_progress"}
+                         %{"id" => 1, "content" => "Task 1", "status" => "completed"},
+                         %{"id" => 2, "content" => "Task 2", "status" => "in_progress"}
                        ]
                      }
                    })
@@ -420,17 +420,17 @@ defmodule Sagents.IntegrationTest do
       # because the custom_context.state is not updated between tool calls
       assert length(final_state.todos) == 6,
              "Expected 6 todos (bug: got #{length(final_state.todos)}). " <>
-               "IDs: #{Enum.map_join(final_state.todos, ", ", & &1.id)}"
+               "IDs: #{Enum.map_join(final_state.todos, ", ", &Integer.to_string(&1.id))}"
 
       # Verify todos 1 and 2 were updated
-      todo1 = Enum.find(final_state.todos, &(&1.id == "1"))
+      todo1 = Enum.find(final_state.todos, &(&1.id == 1))
       assert todo1.status == :completed
 
-      todo2 = Enum.find(final_state.todos, &(&1.id == "2"))
+      todo2 = Enum.find(final_state.todos, &(&1.id == 2))
       assert todo2.status == :in_progress
 
       # Verify todos 3-6 still exist
-      for id <- ["3", "4", "5", "6"] do
+      for id <- [3, 4, 5, 6] do
         todo = Enum.find(final_state.todos, &(&1.id == id))
         assert todo != nil, "Todo #{id} should still exist"
         assert todo.status == :pending

--- a/test/sagents/middleware/todo_list_test.exs
+++ b/test/sagents/middleware/todo_list_test.exs
@@ -36,6 +36,13 @@ defmodule Sagents.Middleware.TodoListTest do
       assert properties != nil
       assert required != nil
     end
+
+    test "write_todos tool declares id as integer" do
+      [tool] = TodoList.tools(nil)
+      properties = tool.parameters_schema[:properties]
+      items = properties[:todos][:items]
+      assert items[:properties][:id][:type] == "integer"
+    end
   end
 
   describe "display_text configuration" do
@@ -67,16 +74,16 @@ defmodule Sagents.Middleware.TodoListTest do
 
   describe "write_todos tool - replace mode" do
     test "replaces all todos when merge is false" do
-      state =
-        State.new!(%{todos: [%{"id" => "old", "content" => "Old task", "status" => "pending"}]})
+      old = Todo.new!(%{id: 99, content: "Old task", status: :pending})
+      state = State.new!(%{todos: [old]})
 
       [tool] = TodoList.tools(nil)
 
       params = %{
         merge: false,
         todos: [
-          %{"id" => "new1", "content" => "New task 1", "status" => "pending"},
-          %{"id" => "new2", "content" => "New task 2", "status" => "in_progress"}
+          %{"id" => 1, "content" => "New task 1", "status" => "pending"},
+          %{"id" => 2, "content" => "New task 2", "status" => "in_progress"}
         ]
       }
 
@@ -91,9 +98,9 @@ defmodule Sagents.Middleware.TodoListTest do
       assert Enum.all?(updated_state.todos, &match?(%Todo{}, &1))
 
       ids = Enum.map(updated_state.todos, & &1.id)
-      assert "new1" in ids
-      assert "new2" in ids
-      refute "old" in ids
+      assert 1 in ids
+      assert 2 in ids
+      refute 99 in ids
     end
 
     test "creates todos with proper status types" do
@@ -103,9 +110,9 @@ defmodule Sagents.Middleware.TodoListTest do
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task 1", "status" => "pending"},
-          %{"id" => "2", "content" => "Task 2", "status" => "in_progress"},
-          %{"id" => "3", "content" => "Task 3", "status" => "completed"}
+          %{"id" => 1, "content" => "Task 1", "status" => "pending"},
+          %{"id" => 2, "content" => "Task 2", "status" => "in_progress"},
+          %{"id" => 3, "content" => "Task 3", "status" => "completed"}
         ]
       }
 
@@ -115,12 +122,66 @@ defmodule Sagents.Middleware.TodoListTest do
       assert Enum.at(updated_state.todos, 1).status == :in_progress
       assert Enum.at(updated_state.todos, 2).status == :completed
     end
+
+    test "preserves declared order for double-digit IDs (regression for /draft)" do
+      # The original bug: ten todos with IDs 1..10 rendered as
+      # [1, 10, 2, 3, ...] because string IDs sorted lexicographically.
+      state = State.new!()
+      [tool] = TodoList.tools(nil)
+
+      params = %{
+        merge: false,
+        todos:
+          Enum.map(1..10, fn n ->
+            %{"id" => n, "content" => "Task #{n}", "status" => "pending"}
+          end)
+      }
+
+      {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
+
+      assert Enum.map(updated_state.todos, & &1.id) == Enum.to_list(1..10)
+    end
+
+    test "accepts stringified integer ids from LLM tool calls (back-compat)" do
+      state = State.new!()
+      [tool] = TodoList.tools(nil)
+
+      params = %{
+        merge: false,
+        todos: [
+          %{"id" => "1", "content" => "Task 1", "status" => "pending"},
+          %{"id" => "7", "content" => "Task 7", "status" => "pending"}
+        ]
+      }
+
+      {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
+
+      assert Enum.map(updated_state.todos, & &1.id) == [1, 7]
+    end
+
+    test "assigns positional ids when the agent omits them" do
+      state = State.new!()
+      [tool] = TodoList.tools(nil)
+
+      params = %{
+        merge: false,
+        todos: [
+          %{"content" => "First", "status" => "pending"},
+          %{"content" => "Second", "status" => "pending"},
+          %{"content" => "Third", "status" => "pending"}
+        ]
+      }
+
+      {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
+
+      assert Enum.map(updated_state.todos, & &1.id) == [1, 2, 3]
+    end
   end
 
   describe "write_todos tool - merge mode" do
     test "merges with existing todos by ID" do
-      existing_todo1 = Todo.new!(%{id: "1", content: "Keep me", status: :pending})
-      existing_todo2 = Todo.new!(%{id: "2", content: "Update me", status: :pending})
+      existing_todo1 = Todo.new!(%{id: 1, content: "Keep me", status: :pending})
+      existing_todo2 = Todo.new!(%{id: 2, content: "Update me", status: :pending})
 
       state = State.new!(%{todos: [existing_todo1, existing_todo2]})
       [tool] = TodoList.tools(nil)
@@ -128,8 +189,8 @@ defmodule Sagents.Middleware.TodoListTest do
       params = %{
         merge: true,
         todos: [
-          %{"id" => "2", "content" => "Updated task", "status" => "completed"},
-          %{"id" => "3", "content" => "New task", "status" => "pending"}
+          %{"id" => 2, "content" => "Updated task", "status" => "completed"},
+          %{"id" => 3, "content" => "New task", "status" => "pending"}
         ]
       }
 
@@ -138,78 +199,73 @@ defmodule Sagents.Middleware.TodoListTest do
       assert message =~ "merged"
       assert length(updated_state.todos) == 3
 
-      # Check that todo 1 was kept
-      todo1 = Enum.find(updated_state.todos, &(&1.id == "1"))
+      todo1 = Enum.find(updated_state.todos, &(&1.id == 1))
       assert todo1.content == "Keep me"
       assert todo1.status == :pending
 
-      # Check that todo 2 was updated
-      todo2 = Enum.find(updated_state.todos, &(&1.id == "2"))
+      todo2 = Enum.find(updated_state.todos, &(&1.id == 2))
       assert todo2.content == "Updated task"
       assert todo2.status == :completed
 
-      # Check that todo 3 was added
-      todo3 = Enum.find(updated_state.todos, &(&1.id == "3"))
+      todo3 = Enum.find(updated_state.todos, &(&1.id == 3))
       assert todo3.content == "New task"
     end
 
     test "preserves all existing todos when merging with only a subset" do
-      # This test reproduces the exact scenario from the bug report:
+      # This test reproduces the exact scenario from the original bug report:
       # 1. Create 6 todos with merge=false
       # 2. Update only 2 of them with merge=true
       # 3. All 6 todos should still exist (with 2 updated)
 
       [tool] = TodoList.tools(nil)
 
-      # Step 1: Create initial 6 todos (simulating first write_todos call)
       initial_state = State.new!()
 
       first_params = %{
         merge: false,
         todos: [
           %{
-            "id" => "1",
+            "id" => 1,
             "content" => "Create directory structure for the quantum physics curriculum",
             "status" => "in_progress"
           },
           %{
-            "id" => "2",
+            "id" => 2,
             "content" => "Create prerequisite mathematics document covering required topics",
             "status" => "pending"
           },
           %{
-            "id" => "3",
+            "id" => 3,
             "content" => "Create week-by-week study plan (16-week comprehensive curriculum)",
             "status" => "pending"
           },
           %{
-            "id" => "4",
+            "id" => 4,
             "content" => "Create 10 key concept explanation documents (separate files)",
             "status" => "pending"
           },
           %{
-            "id" => "5",
+            "id" => 5,
             "content" => "Create practice problem sets with varying difficulty levels",
             "status" => "pending"
           },
-          %{"id" => "6", "content" => "Create progress tracking sheet", "status" => "pending"}
+          %{"id" => 6, "content" => "Create progress tracking sheet", "status" => "pending"}
         ]
       }
 
       {:ok, _msg1, state_after_first_call} = tool.function.(first_params, %{state: initial_state})
       assert length(state_after_first_call.todos) == 6
 
-      # Step 2: Update only todos 1 and 2 with merge=true (simulating second write_todos call)
       second_params = %{
         merge: true,
         todos: [
           %{
-            "id" => "1",
+            "id" => 1,
             "content" => "Create directory structure for the quantum physics curriculum",
             "status" => "completed"
           },
           %{
-            "id" => "2",
+            "id" => 2,
             "content" => "Create prerequisite mathematics document covering required topics",
             "status" => "in_progress"
           }
@@ -219,47 +275,43 @@ defmodule Sagents.Middleware.TodoListTest do
       {:ok, msg2, state_after_second_call} =
         tool.function.(second_params, %{state: state_after_first_call})
 
-      # Step 3: Verify all 6 todos still exist
       assert msg2 =~ "merged"
 
       assert length(state_after_second_call.todos) == 6,
              "Expected 6 todos after merge, but got #{length(state_after_second_call.todos)}. " <>
-               "IDs present: #{Enum.map_join(state_after_second_call.todos, ", ", & &1.id)}"
+               "IDs present: #{Enum.map_join(state_after_second_call.todos, ", ", &Integer.to_string(&1.id))}"
 
-      # Verify todo 1 was updated to completed
-      todo1 = Enum.find(state_after_second_call.todos, &(&1.id == "1"))
-      assert todo1 != nil, "Todo with ID '1' should exist"
+      todo1 = Enum.find(state_after_second_call.todos, &(&1.id == 1))
+      assert todo1 != nil, "Todo with ID 1 should exist"
       assert todo1.status == :completed
 
-      # Verify todo 2 was updated to in_progress
-      todo2 = Enum.find(state_after_second_call.todos, &(&1.id == "2"))
-      assert todo2 != nil, "Todo with ID '2' should exist"
+      todo2 = Enum.find(state_after_second_call.todos, &(&1.id == 2))
+      assert todo2 != nil, "Todo with ID 2 should exist"
       assert todo2.status == :in_progress
 
-      # Verify todos 3-6 still exist and remain pending
-      for id <- ["3", "4", "5", "6"] do
+      for id <- [3, 4, 5, 6] do
         todo = Enum.find(state_after_second_call.todos, &(&1.id == id))
-        assert todo != nil, "Todo with ID '#{id}' should still exist"
+        assert todo != nil, "Todo with ID #{id} should still exist"
         assert todo.status == :pending
       end
     end
 
     test "preserves existing todos when merging with non-overlapping IDs" do
-      existing = Todo.new!(%{id: "keep", content: "Keep", status: :completed})
+      existing = Todo.new!(%{id: 100, content: "Keep", status: :completed})
       state = State.new!(%{todos: [existing]})
       [tool] = TodoList.tools(nil)
 
       params = %{
         merge: true,
-        todos: [%{"id" => "new", "content" => "New", "status" => "pending"}]
+        todos: [%{"id" => 200, "content" => "New", "status" => "pending"}]
       }
 
       {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
 
       assert length(updated_state.todos) == 2
       ids = Enum.map(updated_state.todos, & &1.id)
-      assert "keep" in ids
-      assert "new" in ids
+      assert 100 in ids
+      assert 200 in ids
     end
   end
 
@@ -270,7 +322,7 @@ defmodule Sagents.Middleware.TodoListTest do
 
       params = %{
         merge: false,
-        todos: [%{"id" => "1", "content" => "", "status" => "pending"}]
+        todos: [%{"id" => 1, "content" => "", "status" => "pending"}]
       }
 
       assert {:error, message} = tool.function.(params, %{state: state})
@@ -296,7 +348,7 @@ defmodule Sagents.Middleware.TodoListTest do
 
       params = %{
         merge: false,
-        todos: [%{"id" => "1", "content" => "Task", "status" => "invalid_status"}]
+        todos: [%{"id" => 1, "content" => "Task", "status" => "invalid_status"}]
       }
 
       # Invalid status defaults to pending
@@ -313,9 +365,9 @@ defmodule Sagents.Middleware.TodoListTest do
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task 1", "status" => "pending"},
-          %{"id" => "2", "content" => "Task 2", "status" => "pending"},
-          %{"id" => "3", "content" => "Task 3", "status" => "in_progress"}
+          %{"id" => 1, "content" => "Task 1", "status" => "pending"},
+          %{"id" => 2, "content" => "Task 2", "status" => "pending"},
+          %{"id" => 3, "content" => "Task 3", "status" => "in_progress"}
         ]
       }
 
@@ -332,7 +384,7 @@ defmodule Sagents.Middleware.TodoListTest do
 
       params = %{
         merge: true,
-        todos: [%{"id" => "1", "content" => "Task", "status" => "pending"}]
+        todos: [%{"id" => 1, "content" => "Task", "status" => "pending"}]
       }
 
       {:ok, merge_msg, _state} = tool.function.(params, %{state: state})
@@ -351,12 +403,12 @@ defmodule Sagents.Middleware.TodoListTest do
 
       params = %{
         merge: false,
-        todos: [%{"id" => "test-id", "content" => "Task", "status" => "pending"}]
+        todos: [%{"id" => 42, "content" => "Task", "status" => "pending"}]
       }
 
       {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
 
-      todo = State.get_todo(updated_state, "test-id")
+      todo = State.get_todo(updated_state, 42)
       assert todo.content == "Task"
     end
 
@@ -367,9 +419,9 @@ defmodule Sagents.Middleware.TodoListTest do
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task 1", "status" => "pending"},
-          %{"id" => "2", "content" => "Task 2", "status" => "completed"},
-          %{"id" => "3", "content" => "Task 3", "status" => "pending"}
+          %{"id" => 1, "content" => "Task 1", "status" => "pending"},
+          %{"id" => 2, "content" => "Task 2", "status" => "completed"},
+          %{"id" => 3, "content" => "Task 3", "status" => "pending"}
         ]
       }
 
@@ -384,11 +436,6 @@ defmodule Sagents.Middleware.TodoListTest do
   end
 
   describe "inline mode" do
-    # Each test registers self() under the AgentServer's via-tuple name in the
-    # real Sagents.Registry so the middleware's whereis guard sees a "live"
-    # AgentServer and the GenServer.cast lands on this test process. We can
-    # then assert_received the cast payload to verify the synthetic-message
-    # save call.
     setup do
       agent_id = "todo-list-inline-test-#{System.unique_integer([:positive])}"
       {:ok, _owner} = Registry.register(Sagents.Registry, {:agent_server, agent_id}, nil)
@@ -403,7 +450,7 @@ defmodule Sagents.Middleware.TodoListTest do
 
       params = %{
         merge: false,
-        todos: [%{"id" => "1", "content" => "Task", "status" => "pending"}]
+        todos: [%{"id" => 1, "content" => "Task", "status" => "pending"}]
       }
 
       {:ok, _msg, _state} = tool.function.(params, %{state: state})
@@ -420,9 +467,9 @@ defmodule Sagents.Middleware.TodoListTest do
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task A", "status" => "pending"},
-          %{"id" => "2", "content" => "Task B", "status" => "in_progress"},
-          %{"id" => "3", "content" => "Task C", "status" => "completed"}
+          %{"id" => 1, "content" => "Task A", "status" => "pending"},
+          %{"id" => 2, "content" => "Task B", "status" => "in_progress"},
+          %{"id" => 3, "content" => "Task C", "status" => "completed"}
         ]
       }
 
@@ -432,8 +479,8 @@ defmodule Sagents.Middleware.TodoListTest do
       assert attrs.message_type == "system"
       assert attrs.content_type == "todo_snapshot"
 
-      assert [%{"id" => "1"}, %{"id" => "2"}, %{"id" => "3"}] = attrs.content["todos"]
-      assert Enum.find(attrs.content["todos"], &(&1["id"] == "2"))["status"] == "in_progress"
+      assert [%{"id" => 1}, %{"id" => 2}, %{"id" => 3}] = attrs.content["todos"]
+      assert Enum.find(attrs.content["todos"], &(&1["id"] == 2))["status"] == "in_progress"
 
       assert attrs.content["summary"]["total"] == 3
       assert attrs.content["summary"]["pending"] == 1
@@ -443,10 +490,6 @@ defmodule Sagents.Middleware.TodoListTest do
 
     test "inline: true snapshots the pre-clear state when auto-clear fires",
          %{agent_id: agent_id} do
-      # When all todos are completed, the agent's state is auto-cleared, but
-      # the inline snapshot should still show the fully-checked list — that
-      # final completed roster is the celebratory "everything done" view we
-      # want preserved in the transcript.
       {:ok, config} = TodoList.init(inline: true)
       [tool] = TodoList.tools(config)
 
@@ -455,17 +498,15 @@ defmodule Sagents.Middleware.TodoListTest do
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task A", "status" => "completed"},
-          %{"id" => "2", "content" => "Task B", "status" => "completed"}
+          %{"id" => 1, "content" => "Task A", "status" => "completed"},
+          %{"id" => 2, "content" => "Task B", "status" => "completed"}
         ]
       }
 
       {:ok, _msg, returned_state} = tool.function.(params, %{state: state})
 
-      # Returned state delta still reflects the auto-clear (sidebar collapses).
       assert returned_state.todos == []
 
-      # But the inline snapshot preserves the completed list.
       assert_received {:"$gen_cast", {:save_synthetic_message, attrs}}
       assert attrs.content_type == "todo_snapshot"
       assert length(attrs.content["todos"]) == 2
@@ -475,8 +516,6 @@ defmodule Sagents.Middleware.TodoListTest do
     end
 
     test "inline: true is a silent no-op when no AgentServer is registered" do
-      # No Registry registration here — agent_id is not associated with any
-      # process. The whereis guard in save_todo_snapshot/2 should short-circuit.
       {:ok, config} = TodoList.init(inline: true)
       [tool] = TodoList.tools(config)
 
@@ -484,7 +523,7 @@ defmodule Sagents.Middleware.TodoListTest do
 
       params = %{
         merge: false,
-        todos: [%{"id" => "1", "content" => "Task", "status" => "pending"}]
+        todos: [%{"id" => 1, "content" => "Task", "status" => "pending"}]
       }
 
       assert {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
@@ -498,40 +537,33 @@ defmodule Sagents.Middleware.TodoListTest do
       state = State.new!()
       [tool] = TodoList.tools(nil)
 
-      # Create todos with all completed
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task 1", "status" => "completed"},
-          %{"id" => "2", "content" => "Task 2", "status" => "completed"}
+          %{"id" => 1, "content" => "Task 1", "status" => "completed"},
+          %{"id" => 2, "content" => "Task 2", "status" => "completed"}
         ]
       }
 
       {:ok, msg, updated_state} = tool.function.(params, %{state: state})
 
-      # List should be cleared since all todos are completed
       assert updated_state.todos == []
-      # Message should indicate list was cleared
       assert msg == "TODO list cleared - all tasks completed"
     end
 
     test "clears todo list when all todos marked as completed in merge mode" do
-      # Start with one pending todo
-      existing = Todo.new!(%{id: "1", content: "Task 1", status: :pending})
+      existing = Todo.new!(%{id: 1, content: "Task 1", status: :pending})
       state = State.new!(%{todos: [existing]})
       [tool] = TodoList.tools(nil)
 
-      # Update the todo to completed
       params = %{
         merge: true,
-        todos: [%{"id" => "1", "content" => "Task 1", "status" => "completed"}]
+        todos: [%{"id" => 1, "content" => "Task 1", "status" => "completed"}]
       }
 
       {:ok, msg, updated_state} = tool.function.(params, %{state: state})
 
-      # List should be cleared since all todos are completed
       assert updated_state.todos == []
-      # Message should indicate list was cleared
       assert msg == "TODO list cleared - all tasks completed"
     end
 
@@ -539,18 +571,16 @@ defmodule Sagents.Middleware.TodoListTest do
       state = State.new!()
       [tool] = TodoList.tools(nil)
 
-      # Create todos with mixed status
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task 1", "status" => "completed"},
-          %{"id" => "2", "content" => "Task 2", "status" => "pending"}
+          %{"id" => 1, "content" => "Task 1", "status" => "completed"},
+          %{"id" => 2, "content" => "Task 2", "status" => "pending"}
         ]
       }
 
       {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
 
-      # List should NOT be cleared since not all are completed
       assert length(updated_state.todos) == 2
     end
 
@@ -561,35 +591,30 @@ defmodule Sagents.Middleware.TodoListTest do
       params = %{
         merge: false,
         todos: [
-          %{"id" => "1", "content" => "Task 1", "status" => "completed"},
-          %{"id" => "2", "content" => "Task 2", "status" => "in_progress"}
+          %{"id" => 1, "content" => "Task 1", "status" => "completed"},
+          %{"id" => 2, "content" => "Task 2", "status" => "in_progress"}
         ]
       }
 
       {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
 
-      # List should NOT be cleared
       assert length(updated_state.todos) == 2
     end
 
     test "clears list immediately after completing final todo via merge" do
-      # Start with two todos, one completed and one pending
-      todo1 = Todo.new!(%{id: "1", content: "Task 1", status: :completed})
-      todo2 = Todo.new!(%{id: "2", content: "Task 2", status: :pending})
+      todo1 = Todo.new!(%{id: 1, content: "Task 1", status: :completed})
+      todo2 = Todo.new!(%{id: 2, content: "Task 2", status: :pending})
       state = State.new!(%{todos: [todo1, todo2]})
       [tool] = TodoList.tools(nil)
 
-      # Complete the final pending todo
       params = %{
         merge: true,
-        todos: [%{"id" => "2", "content" => "Task 2", "status" => "completed"}]
+        todos: [%{"id" => 2, "content" => "Task 2", "status" => "completed"}]
       }
 
       {:ok, msg, updated_state} = tool.function.(params, %{state: state})
 
-      # List should be cleared immediately
       assert updated_state.todos == []
-      # Message should indicate list was cleared
       assert msg == "TODO list cleared - all tasks completed"
     end
   end

--- a/test/sagents/persistence/state_serializer_test.exs
+++ b/test/sagents/persistence/state_serializer_test.exs
@@ -21,7 +21,7 @@ defmodule Sagents.Persistence.StateSerializerTest do
       msg1 = Message.new_user!("Hello")
       msg2 = Message.new_assistant!(%{content: "Hi there"})
 
-      {:ok, todo1} = Todo.new(%{content: "Task 1", status: :in_progress})
+      {:ok, todo1} = Todo.new(%{id: 1, content: "Task 1", status: :in_progress})
 
       state =
         State.new!(%{
@@ -170,6 +170,9 @@ defmodule Sagents.Persistence.StateSerializerTest do
               "status" => "in_progress"
             }
           ],
+          # Note: legacy `"todo-1"` string id will be renumbered to integer 1
+          # by Todo.list_from_maps/1's back-compat path. The assertion on
+          # `todo.id` below covers this.
           "metadata" => %{"session_id" => "session-1"}
         },
         "agent_config" => %{
@@ -192,6 +195,7 @@ defmodule Sagents.Persistence.StateSerializerTest do
       assert [%LangChain.Message.ContentPart{content: "Hello"}] = first_msg.content
 
       assert [todo] = state.todos
+      assert todo.id == 1
       assert todo.content == "Task 1"
       assert todo.status == :in_progress
 
@@ -531,8 +535,8 @@ defmodule Sagents.Persistence.StateSerializerTest do
       msg1 = Message.new_user!("Hello")
       msg2 = Message.new_assistant!(%{content: "Hi there"})
 
-      {:ok, todo1} = Todo.new(%{content: "Task 1", status: :in_progress})
-      {:ok, todo2} = Todo.new(%{content: "Task 2", status: :pending})
+      {:ok, todo1} = Todo.new(%{id: 1, content: "Task 1", status: :in_progress})
+      {:ok, todo2} = Todo.new(%{id: 2, content: "Task 2", status: :pending})
 
       state =
         State.new!(%{
@@ -647,7 +651,7 @@ defmodule Sagents.Persistence.StateSerializerTest do
         })
 
       msg = Message.new_user!("Hello")
-      {:ok, todo} = Todo.new(%{content: "Task", status: :pending})
+      {:ok, todo} = Todo.new(%{id: 1, content: "Task", status: :pending})
 
       state =
         State.new!(%{

--- a/test/sagents/state_test.exs
+++ b/test/sagents/state_test.exs
@@ -174,21 +174,21 @@ defmodule Sagents.StateTest do
       alias Sagents.Todo
 
       state = State.new!()
-      todo = Todo.new!(%{id: "1", content: "Task", status: :pending})
+      todo = Todo.new!(%{id: 1, content: "Task", status: :pending})
 
       updated = State.put_todo(state, todo)
 
       assert length(updated.todos) == 1
-      assert hd(updated.todos).id == "1"
+      assert hd(updated.todos).id == 1
     end
 
     test "replaces existing todo with same ID" do
       alias Sagents.Todo
 
-      todo1 = Todo.new!(%{id: "1", content: "Original", status: :pending})
+      todo1 = Todo.new!(%{id: 1, content: "Original", status: :pending})
       state = State.new!(%{todos: [todo1]})
 
-      todo2 = Todo.new!(%{id: "1", content: "Updated", status: :completed})
+      todo2 = Todo.new!(%{id: 1, content: "Updated", status: :completed})
       updated = State.put_todo(state, todo2)
 
       assert length(updated.todos) == 1
@@ -200,9 +200,9 @@ defmodule Sagents.StateTest do
       alias Sagents.Todo
 
       state = State.new!()
-      todo_c = Todo.new!(%{id: "c", content: "C"})
-      todo_a = Todo.new!(%{id: "a", content: "A"})
-      todo_b = Todo.new!(%{id: "b", content: "B"})
+      todo_c = Todo.new!(%{id: 3, content: "C"})
+      todo_a = Todo.new!(%{id: 1, content: "A"})
+      todo_b = Todo.new!(%{id: 2, content: "B"})
 
       updated =
         state
@@ -212,26 +212,26 @@ defmodule Sagents.StateTest do
 
       ids = Enum.map(updated.todos, & &1.id)
       # Insertion order is preserved, not sorted by ID
-      assert ids == ["c", "a", "b"]
+      assert ids == [3, 1, 2]
     end
 
     test "updating a todo maintains its position in the list" do
       alias Sagents.Todo
 
       # Create initial list of todos
-      todo1 = Todo.new!(%{id: "1", content: "First", status: :pending})
-      todo2 = Todo.new!(%{id: "2", content: "Second", status: :pending})
-      todo3 = Todo.new!(%{id: "3", content: "Third", status: :pending})
+      todo1 = Todo.new!(%{id: 1, content: "First", status: :pending})
+      todo2 = Todo.new!(%{id: 2, content: "Second", status: :pending})
+      todo3 = Todo.new!(%{id: 3, content: "Third", status: :pending})
 
       state = State.new!(%{todos: [todo1, todo2, todo3]})
 
       # Update the middle todo
-      updated_todo2 = Todo.new!(%{id: "2", content: "Second Updated", status: :completed})
+      updated_todo2 = Todo.new!(%{id: 2, content: "Second Updated", status: :completed})
       updated_state = State.put_todo(state, updated_todo2)
 
       # Check order is maintained
       ids = Enum.map(updated_state.todos, & &1.id)
-      assert ids == ["1", "2", "3"], "Order should be preserved when updating"
+      assert ids == [1, 2, 3], "Order should be preserved when updating"
 
       # Check the content was updated
       second = Enum.at(updated_state.todos, 1)
@@ -239,11 +239,11 @@ defmodule Sagents.StateTest do
       assert second.status == :completed
 
       # Update the first todo
-      updated_todo1 = Todo.new!(%{id: "1", content: "First Updated", status: :in_progress})
+      updated_todo1 = Todo.new!(%{id: 1, content: "First Updated", status: :in_progress})
       updated_state2 = State.put_todo(updated_state, updated_todo1)
 
       ids2 = Enum.map(updated_state2.todos, & &1.id)
-      assert ids2 == ["1", "2", "3"], "Order should still be preserved"
+      assert ids2 == [1, 2, 3], "Order should still be preserved"
 
       first = Enum.at(updated_state2.todos, 0)
       assert first.content == "First Updated"
@@ -255,17 +255,17 @@ defmodule Sagents.StateTest do
     test "retrieves todo by ID" do
       alias Sagents.Todo
 
-      todo = Todo.new!(%{id: "test", content: "Task"})
+      todo = Todo.new!(%{id: 42, content: "Task"})
       state = State.new!(%{todos: [todo]})
 
-      retrieved = State.get_todo(state, "test")
-      assert retrieved.id == "test"
+      retrieved = State.get_todo(state, 42)
+      assert retrieved.id == 42
       assert retrieved.content == "Task"
     end
 
     test "returns nil for non-existent ID" do
       state = State.new!()
-      assert State.get_todo(state, "missing") == nil
+      assert State.get_todo(state, 999) == nil
     end
   end
 
@@ -273,23 +273,23 @@ defmodule Sagents.StateTest do
     test "removes todo by ID" do
       alias Sagents.Todo
 
-      todo1 = Todo.new!(%{id: "1", content: "Keep"})
-      todo2 = Todo.new!(%{id: "2", content: "Remove"})
+      todo1 = Todo.new!(%{id: 1, content: "Keep"})
+      todo2 = Todo.new!(%{id: 2, content: "Remove"})
       state = State.new!(%{todos: [todo1, todo2]})
 
-      updated = State.delete_todo(state, "2")
+      updated = State.delete_todo(state, 2)
 
       assert length(updated.todos) == 1
-      assert hd(updated.todos).id == "1"
+      assert hd(updated.todos).id == 1
     end
 
     test "handles deleting non-existent todo" do
       alias Sagents.Todo
 
-      todo = Todo.new!(%{id: "1", content: "Task"})
+      todo = Todo.new!(%{id: 1, content: "Task"})
       state = State.new!(%{todos: [todo]})
 
-      updated = State.delete_todo(state, "missing")
+      updated = State.delete_todo(state, 999)
 
       assert length(updated.todos) == 1
     end
@@ -299,9 +299,9 @@ defmodule Sagents.StateTest do
     test "filters todos by status" do
       alias Sagents.Todo
 
-      todo1 = Todo.new!(%{id: "1", content: "Task 1", status: :pending})
-      todo2 = Todo.new!(%{id: "2", content: "Task 2", status: :completed})
-      todo3 = Todo.new!(%{id: "3", content: "Task 3", status: :pending})
+      todo1 = Todo.new!(%{id: 1, content: "Task 1", status: :pending})
+      todo2 = Todo.new!(%{id: 2, content: "Task 2", status: :completed})
+      todo3 = Todo.new!(%{id: 3, content: "Task 3", status: :pending})
 
       state = State.new!(%{todos: [todo1, todo2, todo3]})
 
@@ -317,7 +317,7 @@ defmodule Sagents.StateTest do
     test "returns empty list when no matches" do
       alias Sagents.Todo
 
-      todo = Todo.new!(%{id: "1", content: "Task", status: :pending})
+      todo = Todo.new!(%{id: 1, content: "Task", status: :pending})
       state = State.new!(%{todos: [todo]})
 
       completed = State.get_todos_by_status(state, :completed)
@@ -329,27 +329,27 @@ defmodule Sagents.StateTest do
     test "replaces all todos" do
       alias Sagents.Todo
 
-      old_todo = Todo.new!(%{id: "old", content: "Old"})
+      old_todo = Todo.new!(%{id: 99, content: "Old"})
       state = State.new!(%{todos: [old_todo]})
 
       new_todos = [
-        Todo.new!(%{id: "new1", content: "New 1"}),
-        Todo.new!(%{id: "new2", content: "New 2"})
+        Todo.new!(%{id: 1, content: "New 1"}),
+        Todo.new!(%{id: 2, content: "New 2"})
       ]
 
       updated = State.set_todos(state, new_todos)
 
       assert length(updated.todos) == 2
       ids = Enum.map(updated.todos, & &1.id)
-      assert "new1" in ids
-      assert "new2" in ids
-      refute "old" in ids
+      assert 1 in ids
+      assert 2 in ids
+      refute 99 in ids
     end
 
     test "can set empty list" do
       alias Sagents.Todo
 
-      todo = Todo.new!(%{id: "1", content: "Task"})
+      todo = Todo.new!(%{id: 1, content: "Task"})
       state = State.new!(%{todos: [todo]})
 
       updated = State.set_todos(state, [])

--- a/test/sagents/todo_test.exs
+++ b/test/sagents/todo_test.exs
@@ -6,45 +6,53 @@ defmodule Sagents.TodoTest do
   doctest Todo
 
   describe "new/1" do
-    test "creates a todo with default values" do
-      assert {:ok, todo} = Todo.new(%{content: "Test task"})
+    test "creates a todo with an integer id" do
+      assert {:ok, todo} = Todo.new(%{id: 1, content: "Test task"})
+      assert todo.id == 1
       assert todo.content == "Test task"
       assert todo.status == :pending
-      assert is_binary(todo.id)
-      assert String.length(todo.id) > 0
     end
 
-    test "creates a todo with custom ID" do
-      assert {:ok, todo} = Todo.new(%{id: "custom-123", content: "Task"})
-      assert todo.id == "custom-123"
+    test "coerces a stringified integer id to an integer" do
+      assert {:ok, todo} = Todo.new(%{id: "5", content: "Task"})
+      assert todo.id == 5
+    end
+
+    test "rejects a missing id (no auto-generation)" do
+      assert {:error, changeset} = Todo.new(%{content: "Task"})
+      assert "can't be blank" in errors_on(changeset).id
+    end
+
+    test "rejects a non-positive id" do
+      assert {:error, changeset} = Todo.new(%{id: 0, content: "Task"})
+      assert errors_on(changeset).id != []
+    end
+
+    test "rejects a non-numeric string id" do
+      assert {:error, changeset} = Todo.new(%{id: "abc", content: "Task"})
+      assert errors_on(changeset).id != []
     end
 
     test "creates a todo with specified status" do
-      assert {:ok, todo} = Todo.new(%{content: "Task", status: :in_progress})
+      assert {:ok, todo} = Todo.new(%{id: 1, content: "Task", status: :in_progress})
       assert todo.status == :in_progress
     end
 
     test "accepts all valid statuses" do
       for status <- [:pending, :in_progress, :completed, :cancelled] do
-        assert {:ok, todo} = Todo.new(%{content: "Task", status: status})
+        assert {:ok, todo} = Todo.new(%{id: 1, content: "Task", status: status})
         assert todo.status == status
       end
     end
 
-    test "generates unique IDs when not provided" do
-      {:ok, todo1} = Todo.new(%{content: "Task 1"})
-      {:ok, todo2} = Todo.new(%{content: "Task 2"})
-      assert todo1.id != todo2.id
-    end
-
     test "requires content" do
-      assert {:error, changeset} = Todo.new(%{})
+      assert {:error, changeset} = Todo.new(%{id: 1})
       assert "can't be blank" in errors_on(changeset).content
     end
 
     test "validates content length" do
       long_content = String.duplicate("a", 1001)
-      assert {:error, changeset} = Todo.new(%{content: long_content})
+      assert {:error, changeset} = Todo.new(%{id: 1, content: long_content})
       errors = errors_on(changeset).content
       assert is_list(errors)
       assert errors != []
@@ -52,41 +60,40 @@ defmodule Sagents.TodoTest do
     end
 
     test "rejects invalid status" do
-      assert {:error, changeset} = Todo.new(%{content: "Task", status: :invalid})
+      assert {:error, changeset} = Todo.new(%{id: 1, content: "Task", status: :invalid})
       assert "is invalid" in errors_on(changeset).status
     end
 
     test "rejects empty content" do
-      assert {:error, changeset} = Todo.new(%{content: ""})
+      assert {:error, changeset} = Todo.new(%{id: 1, content: ""})
       errors = errors_on(changeset).content
       assert is_list(errors)
       assert errors != []
-      # Either "can't be blank" or "should be at least 1 character(s)"
       assert hd(errors) =~ "blank" or hd(errors) =~ "at least"
     end
   end
 
   describe "new!/1" do
     test "creates a todo successfully" do
-      todo = Todo.new!(%{content: "Task"})
+      todo = Todo.new!(%{id: 1, content: "Task"})
       assert %Todo{} = todo
       assert todo.content == "Task"
     end
 
     test "raises on invalid data" do
       assert_raise LangChain.LangChainError, fn ->
-        Todo.new!(%{content: ""})
+        Todo.new!(%{id: 1, content: ""})
       end
     end
   end
 
   describe "to_map/1" do
-    test "converts todo to map" do
-      todo = Todo.new!(%{id: "123", content: "Task", status: :in_progress})
+    test "converts todo to map with integer id" do
+      todo = Todo.new!(%{id: 123, content: "Task", status: :in_progress})
       map = Todo.to_map(todo)
 
       assert map == %{
-               "id" => "123",
+               "id" => 123,
                "content" => "Task",
                "status" => "in_progress"
              }
@@ -94,7 +101,7 @@ defmodule Sagents.TodoTest do
 
     test "converts all statuses correctly" do
       for status <- [:pending, :in_progress, :completed, :cancelled] do
-        todo = Todo.new!(%{content: "Task", status: status})
+        todo = Todo.new!(%{id: 1, content: "Task", status: status})
         map = Todo.to_map(todo)
         assert map["status"] == Atom.to_string(status)
       end
@@ -102,46 +109,109 @@ defmodule Sagents.TodoTest do
   end
 
   describe "from_map/1" do
-    test "creates todo from string-keyed map" do
-      map = %{"id" => "123", "content" => "Task", "status" => "pending"}
+    test "creates todo from string-keyed map with integer id" do
+      map = %{"id" => 123, "content" => "Task", "status" => "pending"}
       assert {:ok, todo} = Todo.from_map(map)
-      assert todo.id == "123"
+      assert todo.id == 123
       assert todo.content == "Task"
       assert todo.status == :pending
     end
 
     test "creates todo from atom-keyed map" do
-      map = %{id: "123", content: "Task", status: "completed"}
+      map = %{id: 123, content: "Task", status: "completed"}
       assert {:ok, todo} = Todo.from_map(map)
-      assert todo.id == "123"
+      assert todo.id == 123
       assert todo.status == :completed
+    end
+
+    test "coerces a numeric-string id to an integer" do
+      map = %{"id" => "7", "content" => "Task"}
+      assert {:ok, todo} = Todo.from_map(map)
+      assert todo.id == 7
     end
 
     test "parses all status strings" do
       for status_str <- ["pending", "in_progress", "completed", "cancelled"] do
-        map = %{"content" => "Task", "status" => status_str}
+        map = %{"id" => 1, "content" => "Task", "status" => status_str}
         assert {:ok, todo} = Todo.from_map(map)
         assert is_atom(todo.status)
       end
     end
 
-    test "generates ID if not provided in map" do
+    test "errors when id is missing" do
       map = %{"content" => "Task"}
-      assert {:ok, todo} = Todo.from_map(map)
-      assert is_binary(todo.id)
-      assert String.length(todo.id) > 0
+      assert {:error, _changeset} = Todo.from_map(map)
+    end
+
+    test "errors when id is non-numeric" do
+      map = %{"id" => "abc-xyz", "content" => "Task"}
+      assert {:error, _changeset} = Todo.from_map(map)
     end
 
     test "defaults to pending for invalid status string" do
-      map = %{"content" => "Task", "status" => "invalid"}
+      map = %{"id" => 1, "content" => "Task", "status" => "invalid"}
       assert {:ok, todo} = Todo.from_map(map)
       assert todo.status == :pending
     end
   end
 
+  describe "list_from_maps/1" do
+    test "assigns positional ids 1..N when ids are missing" do
+      maps = [
+        %{"content" => "First"},
+        %{"content" => "Second"},
+        %{"content" => "Third"}
+      ]
+
+      assert {:ok, todos} = Todo.list_from_maps(maps)
+      assert Enum.map(todos, & &1.id) == [1, 2, 3]
+    end
+
+    test "preserves provided integer ids" do
+      maps = [
+        %{"id" => 7, "content" => "Seven"},
+        %{"id" => 3, "content" => "Three"}
+      ]
+
+      assert {:ok, todos} = Todo.list_from_maps(maps)
+      assert Enum.map(todos, & &1.id) == [7, 3]
+    end
+
+    test "coerces numeric-string ids to integers" do
+      maps = [
+        %{"id" => "01", "content" => "One"},
+        %{"id" => "02", "content" => "Two"}
+      ]
+
+      assert {:ok, todos} = Todo.list_from_maps(maps)
+      assert Enum.map(todos, & &1.id) == [1, 2]
+    end
+
+    test "renumbers non-numeric ids positionally (legacy random-base64 case)" do
+      maps = [
+        %{"id" => "A2c9-xyz", "content" => "Legacy 1"},
+        %{"id" => "Q0p1-abc", "content" => "Legacy 2"}
+      ]
+
+      assert {:ok, todos} = Todo.list_from_maps(maps)
+      assert Enum.map(todos, & &1.id) == [1, 2]
+    end
+
+    test "handles a mix of provided and missing ids" do
+      maps = [
+        %{"id" => 5, "content" => "Has id"},
+        %{"content" => "No id"},
+        %{"id" => 9, "content" => "Has id"}
+      ]
+
+      assert {:ok, todos} = Todo.list_from_maps(maps)
+      assert Enum.map(todos, & &1.id) == [5, 2, 9]
+    end
+  end
+
   describe "round-trip conversion" do
     test "to_map and from_map preserve data" do
-      original = Todo.new!(%{content: "Important task", status: :in_progress})
+      original = Todo.new!(%{id: 42, content: "Important task", status: :in_progress})
       map = Todo.to_map(original)
       {:ok, restored} = Todo.from_map(map)
 
@@ -151,7 +221,6 @@ defmodule Sagents.TodoTest do
     end
   end
 
-  # Helper to extract errors from changeset
   defp errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, _opts} -> message end)
   end


### PR DESCRIPTION
## Problem

Todo lists with 10 or more items sorted incorrectly because IDs were strings: `"10"` sorted before `"2"`, putting the 10th item between the 1st and 2nd in any ID-ordered display. The bug was visible to end users on any long plan the agent produced.

## Solution

Change `Sagents.Todo.id` from `:string` to `:integer` and propagate the type through every consumer. `Todo.new/1` now requires a positive integer id; the new `Todo.list_from_maps/1` becomes the canonical ingest point for tool-call payloads and persisted snapshots, assigning positional defaults (1..N) when an id is missing or not numeric. Stringified integer ids (`"5"`) are coerced for compatibility with JSON tool calls. `State.get_todo/2` and `State.delete_todo/2` switch their guards from `is_binary` to `is_integer` in lockstep, and `StateSerializer.deserialize/1` routes through `list_from_maps/1` so legacy persisted snapshots (which used random base64 strings) rehydrate with positional ids rather than crashing.

## Changes

- `lib/sagents/todo.ex` — Field type `:string` → `:integer`; added `list_from_maps/1` as the canonical list ingest with positional id defaults; added `coerce_id/1` and `coerce_to_positive_integer/1`; `new/1` now validates `greater_than: 0`.
- `lib/sagents/state.ex` — `get_todo/2` and `delete_todo/2` guards changed from `is_binary` to `is_integer`.
- `lib/sagents/persistence/state_serializer.ex` — Deserialization now uses `Todo.list_from_maps/1` so legacy string ids are replaced with positional ids on rehydrate instead of failing the changeset.
- `lib/sagents/middleware/todo_list.ex` — `write_todos` tool schema declares `id` as `integer`; the inline-mode `todo_snapshot` content emits integer ids.
- `priv/templates/sagents.gen.persistence/display_message.ex.eex` — `valid_todo_entry?/1` guard updated from `is_binary(id)` to `is_integer(id)` so new generations validate the new shape.
- Tests updated across `todo_test.exs`, `state_test.exs`, `todo_list_test.exs`, `state_serializer_test.exs`, `agent_server_persistence_test.exs`, and `integration_test.exs` for the new type contract and the positional-id ingest path.

## Migration required for host apps

This is a **breaking change for any host app that has already generated the persistence scaffolding via `mix sagents.gen.persistence`**. The template change only affects new generations; existing generated modules will reject every `todo_snapshot` insert with `"todo_snapshot has invalid todo entries"` until patched.

In your generated `DisplayMessage` schema module (e.g. `MyApp.Conversations.DisplayMessage`), update the `valid_todo_entry?/1` clause:

```elixir
# Before
defp valid_todo_entry?(%{"id" => id, "content" => content, "status" => status})
     when is_binary(id) and is_binary(content) and is_binary(status) do
  status in @todo_statuses
end

# After
defp valid_todo_entry?(%{"id" => id, "content" => content, "status" => status})
     when is_integer(id) and is_binary(content) and is_binary(status) do
  status in @todo_statuses
end
```

**CHANGE:** Change the guard clause from `is_binary(id)` to `is_integer(id)`.

Host-app callers of `Sagents.Todo.new/1`, `State.get_todo/2`, or `State.delete_todo/2` that pass string ids will also need to switch to integers. Code that builds todos from incoming maps should migrate to `Todo.list_from_maps/1`, which handles missing/non-numeric ids via positional defaults.

## Testing

Unit tests updated and passing across the touched modules: `todo_test.exs`, `state_test.exs`, `middleware/todo_list_test.exs`, `persistence/state_serializer_test.exs`, `agent_server_persistence_test.exs`, and `integration_test.exs`. The serializer change is exercised against legacy string-id snapshots to confirm rehydrate-with-positional-defaults works without manual migration of stored data.