### PR TITLE
Fix ExDoc warnings for unqualified function references

### DIFF
--- a/lib/sagents/agent_result.ex
+++ b/lib/sagents/agent_result.ex
@@ -3,7 +3,7 @@ defmodule Sagents.AgentResult do
   Helpers for reading structured results out of an `Sagents.Agent.execute/3`
   return value.
 
-  `Agent.execute/3` can return any of:
+  `Sagents.Agent.execute/3` can return any of:
 
     * `{:ok, %State{}}` — normal completion. Last message may be assistant prose
       or an assistant tool call followed by tool results.
@@ -51,7 +51,7 @@ defmodule Sagents.AgentResult do
   alias LangChain.Message.ToolResult
   alias Sagents.State
 
-  @typedoc "Anything `Agent.execute/3` can return, or a bare State."
+  @typedoc "Anything `Sagents.Agent.execute/3` can return, or a bare State."
   @type execute_return ::
           State.t()
           | {:ok, State.t()}

--- a/lib/sagents/extract.ex
+++ b/lib/sagents/extract.ex
@@ -56,13 +56,13 @@ defmodule Sagents.Extract do
       callback processes them).
     * `{:error, term()}` — A `LangChainError` if the LLM never successfully
       called the submit tool within `max_runs`, if a same-named tool already
-      exists on the agent, or anything else that `Agent.execute/3` would surface.
+      exists on the agent, or anything else that `Sagents.Agent.execute/3` would surface.
 
   ## Provider-side `tool_choice`
 
   Anthropic and OpenAI both let you require the model to call a specific tool
   via `tool_choice`. Setting this on your `ChatAnthropic` / `ChatOpenAI` model
-  before passing it to `Agent.new/2` materially improves single-call
+  before passing it to `Sagents.Agent.new/2` materially improves single-call
   reliability. **The name in `tool_choice` must match the submit tool's name**
   — which is whatever you pass as `:tool_name` (or `"submit_result"` if you
   don't). Mismatched names still work — `until_tool` catches whichever tool

--- a/lib/sagents/middleware/haltable.ex
+++ b/lib/sagents/middleware/haltable.ex
@@ -69,8 +69,8 @@ defmodule Sagents.Middleware.Haltable do
     (or `:source` if the emitter is not a tool)
 
   The framework also fills in `:tool_call_id` when the halt comes from
-  inside a tool execution (set by LangChain's
-  `Function.normalize_execution_result/2`).
+  inside a tool execution (set by LangChain when it normalizes the tool
+  function's return value).
 
   ## Adoption
 


### PR DESCRIPTION
## Problem

Generating docs for the next release emitted 5 warnings about unresolved function references (`Agent.execute/3`, `Agent.new/2`, `Function.normalize_execution_result/2`). ExDoc resolves bare `Module.fun/arity` references relative to the current module, so `Agent.execute/3` inside `Sagents.AgentResult` was searched as `Sagents.AgentResult.Agent.execute/3` and failed.

## Solution

Fully qualified the `Sagents.Agent` references in the affected `@moduledoc` and `@typedoc` strings. The `LangChain.Function.normalize_execution_result/2` reference cannot be linked at all (it is a `defp` in LangChain), so that mention was rephrased to descriptive prose while keeping the same explanation of who fills in `:tool_call_id`.

## Changes

- `lib/sagents/agent_result.ex` - qualified two `Agent.execute/3` references in `@moduledoc` and the `execute_return` `@typedoc`
- `lib/sagents/extract.ex` - qualified `Agent.execute/3` and `Agent.new/2` references in `@moduledoc`
- `lib/sagents/middleware/haltable.ex` - removed the broken backtick-link to the private `Function.normalize_execution_result/2` and replaced it with prose describing the same behavior

## Testing

Ran `mix docs` against the updated tree. All 5 prior warnings are gone; docs generate cleanly with no warnings.