### PR TITLE
Clear stale interrupt state on every non-interrupted status transition

### DIFF
--- a/lib/sagents/agent_utils.ex
+++ b/lib/sagents/agent_utils.ex
@@ -207,6 +207,41 @@ defmodule Sagents.AgentUtils do
   def interrupt_session_changes(interrupt_data), do: present_hitl_tools(interrupt_data)
 
   @doc """
+  Changes that fully clear all interrupt-derived host state.
+
+  Single source of truth for the complete set of `pending_*` /
+  interrupt-related keys a host carries. Merge this into any status
+  transition that lands on a **non-interrupted** status (`:running`,
+  `:idle`, `:cancelled`, `:error`, `:not_running`) to enforce the
+  invariant: *any status other than `:interrupted` means there is no
+  pending interrupt UI.*
+
+  This prevents a dismissed/superseded interrupt's derived keys (e.g. a
+  `:pending_halt`) from surviving invisibly behind a
+  `status == :interrupted` render guard and re-appearing on the next
+  transition back into `:interrupted`.
+
+  ## Example
+
+      def handle_status_idle,
+        do: Map.merge(AgentUtils.cleared_interrupt_changes(),
+              %{loading: false, agent_status: :idle, streaming_delta: nil})
+
+  """
+  @spec cleared_interrupt_changes() :: map()
+  def cleared_interrupt_changes do
+    %{
+      pending_tools: [],
+      pending_question: nil,
+      pending_halt: nil,
+      remaining_questions: [],
+      question_responses: [],
+      hitl_decisions: [],
+      interrupt_data: nil
+    }
+  end
+
+  @doc """
   Compute the state transition for a single HITL approve/reject decision
   in a host's pending-tool list.
 
@@ -277,14 +312,16 @@ defmodule Sagents.AgentUtils do
       pending_question: first,
       remaining_questions: rest,
       question_responses: [],
-      pending_tools: []
+      pending_tools: [],
+      pending_halt: nil
     }
   end
 
   defp present_hitl_tools(interrupt_data) do
     %{
       pending_tools: extract_action_requests(interrupt_data),
-      pending_question: nil
+      pending_question: nil,
+      pending_halt: nil
     }
   end
 

--- a/priv/templates/agent_subscriber_session.ex.eex
+++ b/priv/templates/agent_subscriber_session.ex.eex
@@ -79,16 +79,31 @@ defmodule <%= module %> do
   # Status handlers
   # ===========================================================================
 
+  # Every non-interrupted status merges `AgentUtils.cleared_interrupt_changes/0`
+  # to enforce the invariant: any status other than `:interrupted` means there
+  # is no pending interrupt UI. This stops a dismissed/superseded interrupt's
+  # derived keys (e.g. `:pending_halt`) from re-appearing on the next
+  # transition back into `:interrupted`.
+
   @doc "Status changed to :running."
-  def handle_status_running, do: %{agent_status: :running}
+  def handle_status_running,
+    do: Map.merge(AgentUtils.cleared_interrupt_changes(), %{agent_status: :running})
 
   @doc "Status changed to :idle (execution completed)."
   def handle_status_idle,
-    do: %{loading: false, agent_status: :idle, streaming_delta: nil}
+    do:
+      Map.merge(
+        AgentUtils.cleared_interrupt_changes(),
+        %{loading: false, agent_status: :idle, streaming_delta: nil}
+      )
 
   @doc "Status changed to :cancelled (user cancelled execution)."
   def handle_status_cancelled,
-    do: %{loading: false, agent_status: :cancelled, streaming_delta: nil}
+    do:
+      Map.merge(
+        AgentUtils.cleared_interrupt_changes(),
+        %{loading: false, agent_status: :cancelled, streaming_delta: nil}
+      )
 
   @doc """
   Status changed to :error.
@@ -98,7 +113,11 @@ defmodule <%= module %> do
   `format_error_message/1` for a consistent message.
   """
   def handle_status_error(_reason),
-    do: %{loading: false, agent_status: :error, streaming_delta: nil}
+    do:
+      Map.merge(
+        AgentUtils.cleared_interrupt_changes(),
+        %{loading: false, agent_status: :error, streaming_delta: nil}
+      )
 
   @doc """
   Status changed to :interrupted (waiting for human input).
@@ -177,12 +196,13 @@ defmodule <%= module %> do
   subs map doesn't carry a stale entry.
   """
   def handle_agent_shutdown(state, _shutdown_data) do
-    base = %{
-      agent_id: nil,
-      agent_status: :not_running,
-      loading: false,
-      streaming_delta: nil
-    }
+    base =
+      Map.merge(AgentUtils.cleared_interrupt_changes(), %{
+        agent_id: nil,
+        agent_status: :not_running,
+        loading: false,
+        streaming_delta: nil
+      })
 
     case Map.get(state, :agent_id) do
       nil ->
@@ -326,7 +346,7 @@ defmodule <%= module %> do
       {:ok, _ref} ->
         :ok
 
-      {:error, {:already_tracked, _, _, _}} ->
+      {:error, {:already_tracked, _topic, _key, _meta}} ->
         :ok
 
       {:error, reason} ->

--- a/priv/templates/sagents.gen.persistence/context.ex.eex
+++ b/priv/templates/sagents.gen.persistence/context.ex.eex
@@ -196,10 +196,10 @@ defmodule <%= @context_module %> do
       {:ok, %{"state" => %{"todos" => todos}}} when is_list(todos) ->
         case Todo.list_from_maps(todos) do
           {:ok, parsed} -> parsed
-          {:error, _} -> []
+          {:error, _reason} -> []
         end
 
-      {:ok, _} ->
+      {:ok, _other} ->
         []
 
       {:error, :not_found} ->

--- a/priv/templates/sagents.gen.persistence/context.ex.eex
+++ b/priv/templates/sagents.gen.persistence/context.ex.eex
@@ -194,14 +194,10 @@ defmodule <%= @context_module %> do
   def load_todos(%Scope{} = scope, conversation_id) do
     case load_agent_state(scope, conversation_id) do
       {:ok, %{"state" => %{"todos" => todos}}} when is_list(todos) ->
-        todos
-        |> Enum.map(fn todo_map ->
-          case Todo.from_map(todo_map) do
-            {:ok, todo} -> todo
-            {:error, _} -> nil
-          end
-        end)
-        |> Enum.reject(&is_nil/1)
+        case Todo.list_from_maps(todos) do
+          {:ok, parsed} -> parsed
+          {:error, _} -> []
+        end
 
       {:ok, _} ->
         []

--- a/priv/templates/sagents.gen.persistence/display_message.ex.eex
+++ b/priv/templates/sagents.gen.persistence/display_message.ex.eex
@@ -232,5 +232,5 @@ defmodule <%= @context_module %>.DisplayMessage do
     "Todo list (#{length(todos)} items)"
   end
 
-  def to_text(_), do: ""
+  def to_text(_message), do: ""
 end

--- a/test/sagents/agent_utils_test.exs
+++ b/test/sagents/agent_utils_test.exs
@@ -470,7 +470,8 @@ defmodule Sagents.AgentUtilsTest do
                pending_question: ^question,
                remaining_questions: [],
                question_responses: [],
-               pending_tools: []
+               pending_tools: [],
+               pending_halt: nil
              } = AgentUtils.interrupt_session_changes(question)
     end
 
@@ -488,6 +489,7 @@ defmodule Sagents.AgentUtilsTest do
       assert result.remaining_questions == [q2]
       assert result.question_responses == []
       assert result.pending_tools == []
+      refute result.pending_halt
     end
 
     test "presents :multiple_interrupts containing any non-question as HITL tools" do
@@ -522,8 +524,62 @@ defmodule Sagents.AgentUtilsTest do
       action_requests = [%{tool_call_id: "abc"}]
       interrupt = %{action_requests: action_requests}
 
-      assert %{pending_tools: ^action_requests, pending_question: nil} =
+      assert %{pending_tools: ^action_requests, pending_question: nil, pending_halt: nil} =
                AgentUtils.interrupt_session_changes(interrupt)
+    end
+
+    test "question derivation clears any prior pending_halt (regression)" do
+      # A bare :ask_user_question must emit pending_halt: nil so a stale halt
+      # from a prior :interrupted state cannot survive an
+      # :interrupted -> :interrupted transition.
+      question = %{type: :ask_user_question, question: "Continue?"}
+      assert %{pending_halt: nil} = AgentUtils.interrupt_session_changes(question)
+    end
+
+    test "HITL-tool derivation clears any prior pending_halt (regression)" do
+      interrupt = %{action_requests: [%{tool_call_id: "abc"}]}
+      assert %{pending_halt: nil} = AgentUtils.interrupt_session_changes(interrupt)
+    end
+  end
+
+  describe "cleared_interrupt_changes/0" do
+    test "empties every interrupt-derived key" do
+      assert AgentUtils.cleared_interrupt_changes() == %{
+               pending_tools: [],
+               pending_question: nil,
+               pending_halt: nil,
+               remaining_questions: [],
+               question_responses: [],
+               hitl_decisions: [],
+               interrupt_data: nil
+             }
+    end
+
+    test "merged over a state carrying a stale pending_halt clears it" do
+      # Mirrors what the non-interrupted status handlers do: a state left with
+      # a dismissed halt's derived keys must come out fully cleared.
+      stale = %{
+        agent_status: :idle,
+        pending_halt: %{message: "dismissed", source_tool: "x", tool_call_id: "1"},
+        pending_question: %{type: :ask_user_question},
+        pending_tools: [%{tool_call_id: "y"}],
+        remaining_questions: [%{}],
+        question_responses: [%{}],
+        hitl_decisions: [%{type: :approve}],
+        interrupt_data: %{type: :halt}
+      }
+
+      cleared = Map.merge(stale, AgentUtils.cleared_interrupt_changes())
+
+      assert cleared.pending_halt == nil
+      assert cleared.pending_question == nil
+      assert cleared.pending_tools == []
+      assert cleared.remaining_questions == []
+      assert cleared.question_responses == []
+      assert cleared.hitl_decisions == []
+      assert cleared.interrupt_data == nil
+      # non-interrupt keys are untouched
+      assert cleared.agent_status == :idle
     end
 
     test "presents a single :halt as a pending halt" do


### PR DESCRIPTION
## Problem

A host app could render a **dismissed interrupt's UI again** on a later, unrelated interrupt. Concretely: an agent halts (`:halt`), the user dismisses it, sends a new message, and the agent later raises an `ask_user_question`. The question UI appears — and the already-dismissed halt UI reappears beside it.

The root cause is a leaked invariant. A host's interrupt UI is driven by a set of mutually-exclusive assigns (`pending_halt`, `pending_question`, `pending_tools`, plus `remaining_questions`, `question_responses`, `hitl_decisions`, `interrupt_data`). The generated status handlers only set status/loading/delta and never clear those `pending_*` keys, so a dismissed halt's derived state survived invisibly behind the host's `status == :interrupted AND pending_x != nil` render guard, then resurfaced on the next transition back into `:interrupted`.

## Solution

Enforce one invariant everywhere: *any status other than `:interrupted` means there is no pending interrupt UI.*

- Added `Sagents.AgentUtils.cleared_interrupt_changes/0` as the single source of truth for the complete set of interrupt-derived keys. Each non-interrupted status transition merges it in, so adding a future `pending_*` key only requires updating one place.
- Updated the generated `agent_subscriber_session.ex.eex` template so `handle_status_running/idle/cancelled/error` and `handle_agent_shutdown` all merge `cleared_interrupt_changes/0` over their result.
- Hardened the interrupt-derivation path itself: both the question and HITL-tool branches now explicitly emit `pending_halt: nil`, so a stale halt cannot survive an `:interrupted -> :interrupted` transition even before a non-interrupted status intervenes.

Separately, the persistence template's `load_todos/2` now restores todos via the canonical `Todo.list_from_maps/1` instead of a hand-rolled `Enum.map |> reject(&is_nil/1)`, delegating partial-parse handling to the library.

## Changes

- `lib/sagents/agent_utils.ex` — Added `cleared_interrupt_changes/0`; both interrupt-derivation branches now emit `pending_halt: nil`
- `priv/templates/agent_subscriber_session.ex.eex` — All non-interrupted status handlers and `handle_agent_shutdown` merge `cleared_interrupt_changes/0`; documented the invariant in a comment; named previously-ignored tuple binds in the `:already_tracked` clause
- `priv/templates/sagents.gen.persistence/context.ex.eex` — `load_todos/2` restores via `Todo.list_from_maps/1`
- `priv/templates/sagents.gen.persistence/display_message.ex.eex` — Named the ignored arg in the fallback `to_text/1` clause
- `test/sagents/agent_utils_test.exs` — Added regression tests asserting both interrupt-derivation branches clear `pending_halt`; added a `cleared_interrupt_changes/0` describe block covering the full key set and the merge-over-stale-state case

## Testing

Added unit tests in `test/sagents/agent_utils_test.exs`:
- Regression tests that a bare `:ask_user_question` and a HITL-tool interrupt each emit `pending_halt: nil`.
- A `cleared_interrupt_changes/0` describe block asserting it empties every interrupt-derived key, and that merging it over a state still carrying a dismissed halt's keys fully clears them while leaving non-interrupt keys (e.g. `agent_status`) untouched.

The template (`.eex`) changes are exercised at the generated-host level; the underlying `cleared_interrupt_changes/0` they depend on is covered directly by the tests above.