### PR TITLE
Always self-collect middleware callbacks across all entry points

### DIFF
--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -455,9 +455,11 @@ defmodule Sagents.Agent do
     key is fired by the agent directly after `before_model` hooks complete,
     before the LLM call — it receives the prepared state as its single argument.
 
-    When running via `AgentServer`, callbacks are built automatically:
-    PubSub callbacks (for broadcasting events) are combined with middleware
-    callbacks (from `Middleware.collect_callbacks/1`) into this list.
+    This agent's own middleware callbacks (from `Middleware.collect_callbacks/1`)
+    are always collected and run — supplying `:callbacks` adds to them rather
+    than replacing them, so an ad-hoc handler never silently disables middleware
+    callbacks. When running via `AgentServer`, the only callbacks passed here are
+    the PubSub broadcasting callbacks; middleware collection happens internally.
 
   ## Returns
 
@@ -659,28 +661,33 @@ defmodule Sagents.Agent do
   # Resolve the callback handler maps to run for this execution.
   #
   # Middleware callbacks (e.g. `on_message_processed`, `on_llm_token_usage`)
-  # only fire if their handler maps are added to the LLMChain. There are two
-  # entry paths into an agent, and the `:callbacks` option distinguishes them:
+  # only fire if their handler maps are added to the LLMChain. Collecting them
+  # is intrinsic to running an agent: every execution self-collects from this
+  # agent's own middleware, so callback-based middleware (metering, logging,
+  # etc) fires uniformly regardless of entry point — `Agent.execute/3`,
+  # `Sagents.Extract.run/3`, or a server-managed run.
   #
-  #   * Server-managed runs. The server layers (`AgentServer` /
-  #     `SubAgentServer`) own collection. They assemble the full list —
-  #     middleware callbacks together with PubSub broadcasting and any
-  #     *inherited* sub-agent middleware that is invisible from here — and pass
-  #     it via `:callbacks`. That list is authoritative and is used verbatim;
-  #     re-collecting middleware here would fire those handlers a second time.
+  # Caller-supplied `:callbacks` are *merged on top*, not substituted. This
+  # matters for two callers:
   #
-  #   * Direct runs (`Agent.execute/3`, `Sagents.Extract.run/3`). No
-  #     `:callbacks` are supplied, so we self-collect from this agent's own
-  #     middleware. This is what makes callback-based middleware (metering,
-  #     logging, etc) fire uniformly regardless of entry point.
+  #   * Direct callers can pass an ad-hoc handler (e.g. a token logger) without
+  #     silently disabling their agent's middleware callbacks.
   #
-  # So: supplied `:callbacks` take precedence verbatim; their absence means
-  # collect from this agent's middleware.
+  #   * The server layers (`AgentServer` / `SubAgentServer`) pass only their
+  #     PubSub broadcasting callbacks. They no longer collect middleware
+  #     themselves — that would double-fire now that execution self-collects.
+  #
+  # Supplied callbacks come first to preserve the historical ordering of the
+  # server path (PubSub broadcasting, then middleware handlers). Empty maps are
+  # dropped so a `%{}` default never adds a no-op callback to the chain.
   defp resolve_callbacks(%Agent{} = agent, opts) do
-    case Keyword.get(opts, :callbacks) do
-      nil -> Middleware.collect_callbacks(agent.middleware)
-      callbacks -> callbacks
-    end
+    supplied =
+      opts
+      |> Keyword.get(:callbacks, [])
+      |> List.wrap()
+      |> Enum.reject(&(&1 == %{}))
+
+    supplied ++ Middleware.collect_callbacks(agent.middleware)
   end
 
   # Fire a Sagents-specific callback key (e.g., :on_after_middleware) from the

--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -695,7 +695,6 @@ defmodule Sagents.Agent do
   # be fired by LLMChain.run, so we iterate the list and fire matching handlers
   # ourselves. LangChain-native keys are handled separately via maybe_add_callbacks
   # which adds each map to the chain for LLMChain to fire during execution.
-  defp fire_callback(nil, _key, _args), do: :ok
   defp fire_callback([], _key, _args), do: :ok
 
   defp fire_callback(callbacks, key, args) when is_list(callbacks) do

--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -42,6 +42,7 @@ defmodule Sagents.Agent do
   require Logger
 
   alias __MODULE__
+  alias Sagents.AgentUtils
   alias Sagents.Middleware
   alias Sagents.State
   alias LangChain.LangChainError
@@ -502,7 +503,7 @@ defmodule Sagents.Agent do
     # Ensure agent_id is set in state (library handles this automatically)
     state = %{state | agent_id: agent.agent_id}
 
-    callbacks = resolve_callbacks(agent, opts)
+    callbacks = AgentUtils.resolve_callbacks(agent.middleware, opts)
 
     with {:ok, validated_opts} <- validate_until_tool(agent, opts),
          {:ok, prepared_state} <- apply_before_model_hooks(state, agent.middleware) do
@@ -656,38 +657,6 @@ defmodule Sagents.Agent do
           {:halt, {:error, reason}}
       end
     end)
-  end
-
-  # Resolve the callback handler maps to run for this execution.
-  #
-  # Middleware callbacks (e.g. `on_message_processed`, `on_llm_token_usage`)
-  # only fire if their handler maps are added to the LLMChain. Collecting them
-  # is intrinsic to running an agent: every execution self-collects from this
-  # agent's own middleware, so callback-based middleware (metering, logging,
-  # etc) fires uniformly regardless of entry point — `Agent.execute/3`,
-  # `Sagents.Extract.run/3`, or a server-managed run.
-  #
-  # Caller-supplied `:callbacks` are *merged on top*, not substituted. This
-  # matters for two callers:
-  #
-  #   * Direct callers can pass an ad-hoc handler (e.g. a token logger) without
-  #     silently disabling their agent's middleware callbacks.
-  #
-  #   * The server layers (`AgentServer` / `SubAgentServer`) pass only their
-  #     PubSub broadcasting callbacks. They no longer collect middleware
-  #     themselves — that would double-fire now that execution self-collects.
-  #
-  # Supplied callbacks come first to preserve the historical ordering of the
-  # server path (PubSub broadcasting, then middleware handlers). Empty maps are
-  # dropped so a `%{}` default never adds a no-op callback to the chain.
-  defp resolve_callbacks(%Agent{} = agent, opts) do
-    supplied =
-      opts
-      |> Keyword.get(:callbacks, [])
-      |> List.wrap()
-      |> Enum.reject(&(&1 == %{}))
-
-    supplied ++ Middleware.collect_callbacks(agent.middleware)
   end
 
   # Fire a Sagents-specific callback key (e.g., :on_after_middleware) from the

--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -500,7 +500,7 @@ defmodule Sagents.Agent do
     # Ensure agent_id is set in state (library handles this automatically)
     state = %{state | agent_id: agent.agent_id}
 
-    callbacks = Keyword.get(opts, :callbacks)
+    callbacks = resolve_callbacks(agent, opts)
 
     with {:ok, validated_opts} <- validate_until_tool(agent, opts),
          {:ok, prepared_state} <- apply_before_model_hooks(state, agent.middleware) do
@@ -654,6 +654,33 @@ defmodule Sagents.Agent do
           {:halt, {:error, reason}}
       end
     end)
+  end
+
+  # Resolve the callback handler maps to run for this execution.
+  #
+  # Middleware callbacks (e.g. `on_message_processed`, `on_llm_token_usage`)
+  # only fire if their handler maps are added to the LLMChain. There are two
+  # entry paths into an agent, and the `:callbacks` option distinguishes them:
+  #
+  #   * Server-managed runs. The server layers (`AgentServer` /
+  #     `SubAgentServer`) own collection. They assemble the full list —
+  #     middleware callbacks together with PubSub broadcasting and any
+  #     *inherited* sub-agent middleware that is invisible from here — and pass
+  #     it via `:callbacks`. That list is authoritative and is used verbatim;
+  #     re-collecting middleware here would fire those handlers a second time.
+  #
+  #   * Direct runs (`Agent.execute/3`, `Sagents.Extract.run/3`). No
+  #     `:callbacks` are supplied, so we self-collect from this agent's own
+  #     middleware. This is what makes callback-based middleware (metering,
+  #     logging, etc) fire uniformly regardless of entry point.
+  #
+  # So: supplied `:callbacks` take precedence verbatim; their absence means
+  # collect from this agent's middleware.
+  defp resolve_callbacks(%Agent{} = agent, opts) do
+    case Keyword.get(opts, :callbacks) do
+      nil -> Middleware.collect_callbacks(agent.middleware)
+      callbacks -> callbacks
+    end
   end
 
   # Fire a Sagents-specific callback key (e.g., :on_after_middleware) from the

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -2360,12 +2360,10 @@ defmodule Sagents.AgentServer do
   end
 
   defp execute_agent(%ServerState{} = server_state, pubsub_callbacks) do
-    # Collect middleware callbacks in Task process (safe for process-dictionary closures).
-    # Combine into a single list: [pubsub_map, mw_map_1, mw_map_2, ...].
-    # Agent.execute will add each map to the LLMChain (for LangChain keys)
-    # and iterate the list for Sagents-specific keys (on_after_middleware).
-    middleware_callbacks = Middleware.collect_callbacks(server_state.agent.middleware)
-    callbacks = [pubsub_callbacks | middleware_callbacks]
+    # Pass only the PubSub broadcasting callbacks. Agent.execute self-collects
+    # this agent's middleware callbacks and merges them on top, so collecting
+    # them here too would fire each middleware handler twice.
+    callbacks = [pubsub_callbacks]
 
     # Execute agent with callbacks
     case Agent.execute(server_state.agent, server_state.state, callbacks: callbacks) do
@@ -2401,10 +2399,10 @@ defmodule Sagents.AgentServer do
     # they are NOT included here to avoid double-updating.
     maybe_resolve_interrupt_display_on_resume(server_state, resolved_interrupt_data)
 
-    # Same callback assembly as execute_agent/2
+    # Same callback assembly as execute_agent/2: pass only PubSub callbacks;
+    # Agent.resume self-collects middleware callbacks.
     pubsub_callbacks = build_pubsub_callbacks(server_state)
-    middleware_callbacks = Middleware.collect_callbacks(server_state.agent.middleware)
-    callbacks = [pubsub_callbacks | middleware_callbacks]
+    callbacks = [pubsub_callbacks]
 
     case Agent.resume(server_state.agent, server_state.state, resume_data, callbacks: callbacks) do
       {:ok, new_state} ->

--- a/lib/sagents/agent_utils.ex
+++ b/lib/sagents/agent_utils.ex
@@ -13,6 +13,8 @@ defmodule Sagents.AgentUtils do
 
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
+  alias Sagents.Middleware
+  alias Sagents.MiddlewareEntry
 
   @doc """
   Check if a chain has pending tool calls that require human approval.
@@ -143,6 +145,44 @@ defmodule Sagents.AgentUtils do
       _other ->
         []
     end
+  end
+
+  @doc """
+  Resolve the callback handler maps to run for an execution.
+
+  Collecting middleware callbacks is intrinsic to running an agent: this always
+  collects `middleware`'s callbacks (via `Sagents.Middleware.collect_callbacks/1`)
+  and merges any caller-supplied `:callbacks` from `opts` *on top* rather than
+  substituting them. Supplying `:callbacks` therefore never disables an agent's
+  middleware callbacks.
+
+  Supplied callbacks come first to preserve the historical ordering of the server
+  path (PubSub broadcasting, then middleware handlers). Empty `%{}` maps are
+  dropped so a `%{}` default never adds a no-op callback to the chain.
+
+  Both execution engines share this contract: `Sagents.Agent` passes its own
+  `agent.middleware`, while `Sagents.SubAgent` passes the inherited
+  `parent_middleware` carried in its chain's `custom_context`. The server layers
+  pass only their PubSub callbacks via `:callbacks`; collection happens here, so
+  middleware is never collected twice.
+
+  ## Parameters
+  - `middleware`: List of `Sagents.MiddlewareEntry` structs to collect from
+  - `opts`: Keyword list; reads the optional `:callbacks` key (a map or list of
+    maps)
+
+  ## Example
+      callbacks = AgentUtils.resolve_callbacks(agent.middleware, opts)
+  """
+  @spec resolve_callbacks([MiddlewareEntry.t()], keyword()) :: [map()]
+  def resolve_callbacks(middleware, opts) when is_list(middleware) and is_list(opts) do
+    supplied =
+      opts
+      |> Keyword.get(:callbacks, [])
+      |> List.wrap()
+      |> Enum.reject(&(&1 == %{}))
+
+    supplied ++ Middleware.collect_callbacks(middleware)
   end
 
   @doc """

--- a/lib/sagents/extract.ex
+++ b/lib/sagents/extract.ex
@@ -48,6 +48,11 @@ defmodule Sagents.Extract do
     * `:max_runs` (default `5`) — Maximum LLM calls. Enough for a single call
       plus a few retries if the tool body or `parse_args` validation rejects
       malformed args. Increase for complex schemas.
+    * `:callbacks` — A list of callback handler maps forwarded to
+      `Sagents.Agent.execute/3` (e.g. a token-usage logger). These are merged
+      with the agent's middleware callbacks, not substituted, so supplying them
+      never disables middleware-provided callbacks. See `Sagents.Agent.execute/3`
+      for the accepted keys.
 
   ## What `run/3` returns
 
@@ -137,7 +142,8 @@ defmodule Sagents.Extract do
           tool: Function.t(),
           tool_name: String.t(),
           description: String.t(),
-          max_runs: pos_integer()
+          max_runs: pos_integer(),
+          callbacks: [map()]
         ]
 
   @doc """
@@ -153,9 +159,22 @@ defmodule Sagents.Extract do
       augmented_agent = %{agent | tools: agent.tools ++ [submit_tool]}
       max_runs = Keyword.get(opts, :max_runs, @default_max_runs)
 
+      execute_opts =
+        [until_tool: submit_tool.name, max_runs: max_runs]
+        |> maybe_put_callbacks(opts)
+
       augmented_agent
-      |> Agent.execute(state, until_tool: submit_tool.name, max_runs: max_runs)
+      |> Agent.execute(state, execute_opts)
       |> AgentResult.tool_arguments()
+    end
+  end
+
+  # Forward caller-supplied callbacks only when present, so Agent.execute keeps
+  # its no-`:callbacks` default behaviour otherwise.
+  defp maybe_put_callbacks(execute_opts, opts) do
+    case Keyword.get(opts, :callbacks) do
+      nil -> execute_opts
+      callbacks -> Keyword.put(execute_opts, :callbacks, callbacks)
     end
   end
 

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -774,10 +774,6 @@ defmodule Sagents.SubAgent do
     end)
   end
 
-  defp maybe_add_callbacks(chain, callbacks) when is_map(callbacks) do
-    LLMChain.add_callback(chain, callbacks)
-  end
-
   ## Nested Modules (Config and Compiled)
 
   defmodule Config do

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -106,7 +106,6 @@ defmodule Sagents.SubAgent do
 
   alias __MODULE__
   alias Sagents.AgentUtils
-  alias Sagents.Middleware
   alias Sagents.State
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
@@ -384,7 +383,7 @@ defmodule Sagents.SubAgent do
   def execute(subagent, opts \\ [])
 
   def execute(%SubAgent{status: :idle, chain: chain} = subagent, opts) do
-    callbacks = resolve_callbacks(chain, opts)
+    callbacks = AgentUtils.resolve_callbacks(subagent_middleware(chain), opts)
     Logger.debug("SubAgent #{subagent.id} executing")
 
     # Update status to running
@@ -493,7 +492,7 @@ defmodule Sagents.SubAgent do
         decisions,
         opts
       ) do
-    callbacks = resolve_callbacks(chain, opts)
+    callbacks = AgentUtils.resolve_callbacks(subagent_middleware(chain), opts)
     Logger.debug("SubAgent #{subagent.id} resuming with #{length(decisions)} decisions")
 
     # Update status to running
@@ -736,35 +735,17 @@ defmodule Sagents.SubAgent do
     opts
   end
 
-  # Helper to conditionally add callbacks to chain
-  # Resolve the callback handler maps to run for this sub-agent execution.
-  #
-  # Mirrors `Sagents.Agent.resolve_callbacks/2`: middleware callbacks are always
-  # collected and run, so callback-based middleware fires regardless of entry
-  # point. A sub-agent collects from the *inherited* parent middleware stored in
-  # the chain's `custom_context` (the same source `SubAgentServer` used to read).
-  #
-  # Caller-supplied `:callbacks` are merged on top rather than substituted, so
-  # `SubAgentServer` can pass only its PubSub callbacks (it no longer collects
-  # middleware itself — that would double-fire), and direct callers can add an
-  # ad-hoc handler without losing middleware callbacks. Supplied callbacks come
-  # first to preserve the historical ordering (PubSub, then middleware).
-  defp resolve_callbacks(chain, opts) do
-    supplied =
-      opts
-      |> Keyword.get(:callbacks, [])
-      |> List.wrap()
-      |> Enum.reject(&(&1 == %{}))
-
-    supplied ++ Middleware.collect_callbacks(subagent_middleware(chain))
-  end
-
+  # Extract the inherited parent middleware from the sub-agent's chain. This is
+  # the source `AgentUtils.resolve_callbacks/2` collects this sub-agent's
+  # middleware callbacks from (the same source `SubAgentServer` used to read).
   defp subagent_middleware(chain) do
     case chain do
       %{custom_context: %{parent_middleware: mw}} when is_list(mw) -> mw
       _other -> []
     end
   end
+
+  # Helper to conditionally add callbacks to chain
 
   defp maybe_add_callbacks(chain, callbacks) when callbacks in [nil, %{}, []], do: chain
 

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -106,6 +106,7 @@ defmodule Sagents.SubAgent do
 
   alias __MODULE__
   alias Sagents.AgentUtils
+  alias Sagents.Middleware
   alias Sagents.State
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
@@ -383,7 +384,7 @@ defmodule Sagents.SubAgent do
   def execute(subagent, opts \\ [])
 
   def execute(%SubAgent{status: :idle, chain: chain} = subagent, opts) do
-    callbacks = Keyword.get(opts, :callbacks, %{})
+    callbacks = resolve_callbacks(chain, opts)
     Logger.debug("SubAgent #{subagent.id} executing")
 
     # Update status to running
@@ -492,7 +493,7 @@ defmodule Sagents.SubAgent do
         decisions,
         opts
       ) do
-    callbacks = Keyword.get(opts, :callbacks, %{})
+    callbacks = resolve_callbacks(chain, opts)
     Logger.debug("SubAgent #{subagent.id} resuming with #{length(decisions)} decisions")
 
     # Update status to running
@@ -736,6 +737,35 @@ defmodule Sagents.SubAgent do
   end
 
   # Helper to conditionally add callbacks to chain
+  # Resolve the callback handler maps to run for this sub-agent execution.
+  #
+  # Mirrors `Sagents.Agent.resolve_callbacks/2`: middleware callbacks are always
+  # collected and run, so callback-based middleware fires regardless of entry
+  # point. A sub-agent collects from the *inherited* parent middleware stored in
+  # the chain's `custom_context` (the same source `SubAgentServer` used to read).
+  #
+  # Caller-supplied `:callbacks` are merged on top rather than substituted, so
+  # `SubAgentServer` can pass only its PubSub callbacks (it no longer collects
+  # middleware itself — that would double-fire), and direct callers can add an
+  # ad-hoc handler without losing middleware callbacks. Supplied callbacks come
+  # first to preserve the historical ordering (PubSub, then middleware).
+  defp resolve_callbacks(chain, opts) do
+    supplied =
+      opts
+      |> Keyword.get(:callbacks, [])
+      |> List.wrap()
+      |> Enum.reject(&(&1 == %{}))
+
+    supplied ++ Middleware.collect_callbacks(subagent_middleware(chain))
+  end
+
+  defp subagent_middleware(chain) do
+    case chain do
+      %{custom_context: %{parent_middleware: mw}} when is_list(mw) -> mw
+      _other -> []
+    end
+  end
+
   defp maybe_add_callbacks(chain, callbacks) when callbacks in [nil, %{}, []], do: chain
 
   defp maybe_add_callbacks(chain, callbacks) when is_list(callbacks) do

--- a/lib/sagents/sub_agent_server.ex
+++ b/lib/sagents/sub_agent_server.ex
@@ -370,11 +370,11 @@ defmodule Sagents.SubAgentServer do
     # Broadcast status change to running
     broadcast_subagent_event(server_state, {:subagent_status_changed, :running})
 
-    # Build PubSub callbacks and collect middleware callbacks
+    # Pass only the PubSub broadcasting callbacks. SubAgent.execute self-collects
+    # the inherited middleware callbacks and merges them on top, so collecting
+    # them here too would fire each middleware handler twice.
     pubsub_callbacks = build_pubsub_callbacks(server_state)
-    middleware = get_subagent_middleware(server_state)
-    middleware_callbacks = Sagents.Middleware.collect_callbacks(middleware)
-    callbacks = [pubsub_callbacks | middleware_callbacks]
+    callbacks = [pubsub_callbacks]
 
     # Delegate to SubAgent.execute with callbacks
     case SubAgent.execute(subagent, callbacks: callbacks) do
@@ -415,11 +415,11 @@ defmodule Sagents.SubAgentServer do
     # Broadcast status change to running (resuming)
     broadcast_subagent_event(server_state, {:subagent_status_changed, :running})
 
-    # Build PubSub callbacks and collect middleware callbacks
+    # Pass only the PubSub broadcasting callbacks. SubAgent.resume self-collects
+    # the inherited middleware callbacks and merges them on top, so collecting
+    # them here too would fire each middleware handler twice.
     pubsub_callbacks = build_pubsub_callbacks(server_state)
-    middleware = get_subagent_middleware(server_state)
-    middleware_callbacks = Sagents.Middleware.collect_callbacks(middleware)
-    callbacks = [pubsub_callbacks | middleware_callbacks]
+    callbacks = [pubsub_callbacks]
 
     # Delegate to SubAgent.resume with callbacks
     case SubAgent.resume(subagent, decisions, callbacks: callbacks) do
@@ -504,14 +504,6 @@ defmodule Sagents.SubAgentServer do
   end
 
   ## Private Helper Functions
-
-  # Extract middleware from subagent's chain custom_context
-  defp get_subagent_middleware(%ServerState{subagent: subagent}) do
-    case subagent.chain do
-      %{custom_context: %{parent_middleware: mw}} when is_list(mw) -> mw
-      _other -> []
-    end
-  end
 
   # Handle a completed SubAgent, extracting the result and optionally passing through extra data.
   # Used by both execute and resume handlers to avoid duplication.

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -98,6 +98,27 @@ defmodule Sagents.AgentTest do
     end
   end
 
+  # Registers a LangChain callback (`on_message_processed`) via `callbacks/1`.
+  # Such callbacks only fire if their handler map is added to the LLMChain — the
+  # behavior `Agent.execute/3` is responsible for when no callbacks are passed.
+  defmodule CallbackRecordingMiddleware do
+    @behaviour Middleware
+
+    @impl true
+    def init(opts), do: {:ok, %{pid: Keyword.fetch!(opts, :pid)}}
+
+    @impl true
+    def system_prompt(_config), do: ""
+
+    @impl true
+    def tools(_config), do: []
+
+    @impl true
+    def callbacks(config) do
+      %{on_message_processed: fn _chain, _message -> send(config.pid, :mw_callback_fired) end}
+    end
+  end
+
   describe "new/1" do
     test "creates agent with required model" do
       assert {:ok, agent} = Agent.new(%{model: mock_model()})
@@ -639,6 +660,66 @@ defmodule Sagents.AgentTest do
 
       initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
       assert {:ok, _result_state} = Agent.execute(agent, initial_state, callbacks: [])
+    end
+  end
+
+  describe "execute/2 middleware callback collection" do
+    setup do
+      stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Mock response")]}
+      end)
+
+      :ok
+    end
+
+    test "self-collects the agent's middleware callbacks when none are supplied" do
+      # Direct callers (Agent.execute/3, Sagents.Extract.run/3) pass no
+      # :callbacks. The agent's own middleware callbacks must still fire, so
+      # callback-based middleware (e.g. token metering) works outside a server.
+      {:ok, agent} =
+        Agent.new(
+          %{
+            model: mock_model(),
+            middleware: [{CallbackRecordingMiddleware, [pid: self()]}]
+          },
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      assert {:ok, _result_state} = Agent.execute(agent, initial_state)
+      assert_received :mw_callback_fired
+    end
+
+    test "explicit :callbacks take precedence; middleware callbacks are not auto-added" do
+      # The server layers already collect middleware callbacks (with any
+      # inherited middleware) and pass them via :callbacks. When callbacks are
+      # supplied, execute uses them verbatim and does NOT re-collect — that is
+      # what keeps the server path from firing its middleware callbacks twice.
+      {:ok, agent} =
+        Agent.new(
+          %{
+            model: mock_model(),
+            middleware: [{CallbackRecordingMiddleware, [pid: self()]}]
+          },
+          replace_default_middleware: true
+        )
+
+      test_pid = self()
+
+      explicit = %{
+        on_message_processed: fn _chain, _message -> send(test_pid, :explicit_fired) end
+      }
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      assert {:ok, _result_state} =
+               Agent.execute(agent, initial_state, callbacks: [explicit])
+
+      assert_received :explicit_fired
+      # The agent's own middleware callback must NOT auto-fire on top of the
+      # explicitly-supplied list (no double-counting on the server path).
+      refute_received :mw_callback_fired
     end
   end
 

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -691,11 +691,11 @@ defmodule Sagents.AgentTest do
       assert_received :mw_callback_fired
     end
 
-    test "explicit :callbacks take precedence; middleware callbacks are not auto-added" do
-      # The server layers already collect middleware callbacks (with any
-      # inherited middleware) and pass them via :callbacks. When callbacks are
-      # supplied, execute uses them verbatim and does NOT re-collect — that is
-      # what keeps the server path from firing its middleware callbacks twice.
+    test "merges supplied :callbacks with the agent's middleware callbacks" do
+      # Supplying :callbacks adds to the middleware callbacks rather than
+      # replacing them. A direct caller can pass an ad-hoc handler (e.g. a token
+      # logger) without silently disabling middleware callbacks, and the server
+      # layers pass only their PubSub callbacks while middleware still fires.
       {:ok, agent} =
         Agent.new(
           %{
@@ -716,10 +716,9 @@ defmodule Sagents.AgentTest do
       assert {:ok, _result_state} =
                Agent.execute(agent, initial_state, callbacks: [explicit])
 
+      # Both the supplied callback AND the middleware callback fire.
       assert_received :explicit_fired
-      # The agent's own middleware callback must NOT auto-fire on top of the
-      # explicitly-supplied list (no double-counting on the server path).
-      refute_received :mw_callback_fired
+      assert_received :mw_callback_fired
     end
   end
 

--- a/test/sagents/agent_utils_test.exs
+++ b/test/sagents/agent_utils_test.exs
@@ -683,4 +683,67 @@ defmodule Sagents.AgentUtilsTest do
       assert changes.pending_tools == [%{id: 1}, %{id: 2}, %{id: 4}]
     end
   end
+
+  describe "resolve_callbacks/2" do
+    # Middleware whose `callbacks/1` returns a uniquely-identifiable handler map.
+    defmodule MarkerMiddleware do
+      @behaviour Sagents.Middleware
+
+      @impl true
+      def init(opts), do: {:ok, Enum.into(opts, %{})}
+
+      @impl true
+      def system_prompt(_config), do: ""
+
+      @impl true
+      def tools(_config), do: []
+
+      @impl true
+      def callbacks(config), do: %{on_message_processed: config.marker}
+    end
+
+    defp marker_entry(marker) do
+      %Sagents.MiddlewareEntry{
+        id: marker,
+        module: MarkerMiddleware,
+        config: %{marker: marker}
+      }
+    end
+
+    test "collects middleware callbacks when no :callbacks are supplied" do
+      middleware = [marker_entry(:mw_a), marker_entry(:mw_b)]
+
+      assert AgentUtils.resolve_callbacks(middleware, []) ==
+               [%{on_message_processed: :mw_a}, %{on_message_processed: :mw_b}]
+    end
+
+    test "merges supplied :callbacks ahead of middleware callbacks" do
+      middleware = [marker_entry(:mw)]
+      supplied = %{on_message_processed: :supplied}
+
+      assert AgentUtils.resolve_callbacks(middleware, callbacks: [supplied]) ==
+               [%{on_message_processed: :supplied}, %{on_message_processed: :mw}]
+    end
+
+    test "accepts a single supplied callback map (not wrapped in a list)" do
+      supplied = %{on_message_processed: :supplied}
+
+      assert AgentUtils.resolve_callbacks([], callbacks: supplied) ==
+               [%{on_message_processed: :supplied}]
+    end
+
+    test "drops empty supplied callback maps" do
+      middleware = [marker_entry(:mw)]
+
+      assert AgentUtils.resolve_callbacks(middleware, callbacks: [%{}]) ==
+               [%{on_message_processed: :mw}]
+    end
+
+    test "returns only supplied callbacks when middleware is empty" do
+      supplied = %{on_message_processed: :supplied}
+
+      assert AgentUtils.resolve_callbacks([], callbacks: [supplied]) ==
+               [%{on_message_processed: :supplied}]
+    end
+  end
 end

--- a/test/sagents/extract_test.exs
+++ b/test/sagents/extract_test.exs
@@ -10,6 +10,27 @@ defmodule Sagents.ExtractTest do
   alias Sagents.Extract
   alias Sagents.State
 
+  # Middleware that registers an `on_message_processed` LangChain callback.
+  # Used to prove Extract self-collects middleware callbacks and merges any
+  # caller-supplied `:callbacks` rather than replacing them.
+  defmodule CallbackRecordingMiddleware do
+    @behaviour Sagents.Middleware
+
+    @impl true
+    def init(opts), do: {:ok, %{pid: Keyword.fetch!(opts, :pid)}}
+
+    @impl true
+    def system_prompt(_config), do: ""
+
+    @impl true
+    def tools(_config), do: []
+
+    @impl true
+    def callbacks(config) do
+      %{on_message_processed: fn _chain, _message -> send(config.pid, :mw_callback_fired) end}
+    end
+  end
+
   @schema %{
     type: "object",
     properties: %{
@@ -142,6 +163,44 @@ defmodule Sagents.ExtractTest do
       {:ok, _result} = Extract.run(agent, build_state(), schema: @schema)
 
       assert Enum.map(agent.tools, & &1.name) == original_tool_names
+    end
+  end
+
+  describe "run/3 — callbacks" do
+    defp build_agent_with_recorder do
+      Agent.new!(
+        %{
+          model: mock_model(),
+          tools: [],
+          middleware: [{CallbackRecordingMiddleware, [pid: self()]}]
+        },
+        replace_default_middleware: true
+      )
+    end
+
+    test "fires the agent's middleware callbacks even when none are supplied" do
+      agent = build_agent_with_recorder()
+      stub_submit_call("submit_result", %{"title" => "T", "summary" => "S"})
+
+      assert {:ok, %{"title" => "T"}} = Extract.run(agent, build_state(), schema: @schema)
+      assert_received :mw_callback_fired
+    end
+
+    test "merges supplied :callbacks with the agent's middleware callbacks" do
+      agent = build_agent_with_recorder()
+      stub_submit_call("submit_result", %{"title" => "T", "summary" => "S"})
+
+      test_pid = self()
+
+      supplied = %{
+        on_message_processed: fn _chain, _message -> send(test_pid, :supplied_fired) end
+      }
+
+      assert {:ok, %{"title" => "T"}} =
+               Extract.run(agent, build_state(), schema: @schema, callbacks: [supplied])
+
+      assert_received :supplied_fired
+      assert_received :mw_callback_fired
     end
   end
 end

--- a/test/sagents/file_system_server_test.exs
+++ b/test/sagents/file_system_server_test.exs
@@ -791,10 +791,18 @@ defmodule Sagents.FileSystemServerTest do
           end
         end)
 
-      # Synchronize: wait until the server has processed the subscribe call
-      assert Sagents.Publisher.State.count(
-               FileSystemServer.get_state({:agent, agent_id}).publisher
-             ) == 1
+      # Synchronize: wait until the spawned subscriber's subscribe call has been
+      # processed by the server. A single `get_state` call is NOT enough here —
+      # it only orders *this* (test) process against the server, not the
+      # separately-scheduled `sub` process. `spawn/1` gives no happens-before
+      # guarantee that `sub` has run its subscribe call yet, so the bare assert
+      # races the subscribe and intermittently sees a count of 0 on slower CI
+      # runners. Poll until the subscription actually registers.
+      assert wait_until(fn ->
+               Sagents.Publisher.State.count(
+                 FileSystemServer.get_state({:agent, agent_id}).publisher
+               ) == 1
+             end)
 
       # Monitor `sub` from the test so we know when the kill has taken effect.
       # This alone isn't enough — the test's DOWN and the server's DOWN are

--- a/test/sagents/sub_agent_server_test.exs
+++ b/test/sagents/sub_agent_server_test.exs
@@ -6,6 +6,27 @@ defmodule Sagents.SubAgentServerTest do
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
 
+  # Middleware that registers an `on_message_processed` LangChain callback.
+  # Used to prove SubAgent.execute self-collects the inherited middleware
+  # callbacks now that SubAgentServer passes only its PubSub callbacks.
+  defmodule CallbackRecordingMiddleware do
+    @behaviour Sagents.Middleware
+
+    @impl true
+    def init(opts), do: {:ok, %{pid: Keyword.fetch!(opts, :pid)}}
+
+    @impl true
+    def system_prompt(_config), do: ""
+
+    @impl true
+    def tools(_config), do: []
+
+    @impl true
+    def callbacks(config) do
+      %{on_message_processed: fn _chain, _message -> send(config.pid, :mw_callback_fired) end}
+    end
+  end
+
   setup :set_mimic_global
   setup :verify_on_exit!
 
@@ -112,6 +133,42 @@ defmodule Sagents.SubAgentServerTest do
 
       # Verify final status
       assert SubAgentServer.get_status(subagent.id) == :completed
+    end
+  end
+
+  describe "execute/1 - middleware callbacks" do
+    test "attaches the subagent's inherited middleware callbacks to the chain" do
+      test_pid = self()
+      agent = create_test_agent(middleware: [{CallbackRecordingMiddleware, [pid: test_pid]}])
+      subagent = create_subagent(agent: agent)
+
+      {:ok, _pid} = SubAgentServer.start_link(subagent: subagent)
+
+      assistant_message = Message.new_assistant!(%{content: "Done"})
+
+      # SubAgentServer now passes only its PubSub callbacks; SubAgent.execute
+      # self-collects the inherited middleware callbacks and adds them to the
+      # chain. Invoke every on_message_processed handler on the chain to prove
+      # the middleware callback was collected and attached (and fires once).
+      LLMChain
+      |> expect(:run, fn chain, _opts ->
+        for cb <- chain.callbacks, is_function(cb[:on_message_processed]) do
+          cb[:on_message_processed].(chain, assistant_message)
+        end
+
+        updated_chain =
+          chain
+          |> Map.put(:messages, chain.messages ++ [assistant_message])
+          |> Map.put(:last_message, assistant_message)
+          |> Map.put(:needs_response, false)
+
+        {:ok, updated_chain}
+      end)
+
+      assert {:ok, _result} = SubAgentServer.execute(subagent.id)
+      assert_received :mw_callback_fired
+      # Collected from the chain exactly once — not double-added by the server.
+      refute_received :mw_callback_fired
     end
   end
 


### PR DESCRIPTION
## Problem

Middleware callbacks (e.g. `on_message_processed`, `on_llm_token_usage`) only fire if their handler maps are added to the LLMChain. Collection lived in the server layers (`AgentServer` / `SubAgentServer`), so the direct entry points — `Agent.execute/3` and `Sagents.Extract.run/3` — never fired middleware callbacks at all. Callback-based middleware (token metering, logging, tenancy/APM context) silently did nothing when an agent ran outside a server.

A first pass fixed this by self-collecting *only when no `:callbacks` were supplied*. That introduced a subtler trap: because supplied callbacks **replaced** collection, the documented direct-caller pattern — `Agent.execute(agent, state, callbacks: [my_logger])` — would silently disable the agent's middleware callbacks.

## Solution

Make middleware-callback collection **intrinsic to running an agent**, on every entry point, and treat caller-supplied `:callbacks` as **additive**:

- `Agent.execute/3` and `Agent.resume/4` always collect from `agent.middleware` and merge any supplied callbacks on top (supplied first, preserving the historical PubSub-then-middleware ordering; empty `%{}` maps dropped).
- `SubAgent.execute/2` and `SubAgent.resume/3` do the same, collecting from the *inherited* `parent_middleware` carried in the chain's `custom_context` — the exact source `SubAgentServer` previously read.
- The server layers (`AgentServer`, `SubAgentServer`) now pass **only their PubSub broadcasting callbacks**. Since execution self-collects, the servers no longer collect middleware themselves — doing both would fire each middleware handler twice (a real bug for metering).
- `Sagents.Extract.run/3` gains a `:callbacks` option, forwarded to `Agent.execute/3`, for parity with direct execution.

The merge policy lives in a single shared `Sagents.AgentUtils.resolve_callbacks/2`, parameterized on the middleware list, so `Agent` and `SubAgent` cannot drift apart. Each engine just supplies its own middleware source (`agent.middleware` vs the chain's inherited `parent_middleware`).

This removes the trap (supplied callbacks never disable middleware callbacks), guarantees no double-firing on the server path, and makes behavior uniform regardless of entry point.

## Changes

- `lib/sagents/agent_utils.ex` — New public `resolve_callbacks/2`: collects the given middleware's callbacks and merges supplied `:callbacks` on top (supplied-first, empty maps dropped). Single source of truth for the policy.
- `lib/sagents/agent.ex` — `execute/3` calls `AgentUtils.resolve_callbacks(agent.middleware, opts)`; removed the local copy; updated the `:callbacks` `@doc`.
- `lib/sagents/sub_agent.ex` — `execute/2` and `resume/3` call `AgentUtils.resolve_callbacks(subagent_middleware(chain), opts)`; `subagent_middleware/1` extracts the inherited middleware; removed the local copy.
- `lib/sagents/agent_server.ex` — `execute_agent`/`resume_agent` pass only `[pubsub_callbacks]`; dropped middleware collection.
- `lib/sagents/sub_agent_server.ex` — both handlers pass only `[pubsub_callbacks]`; removed the now-unused `get_subagent_middleware/1`.
- `lib/sagents/extract.ex` — added `:callbacks` option (type, docs, `maybe_put_callbacks/2` forwarding).
- `test/sagents/agent_utils_test.exs` — new `resolve_callbacks/2` describe: no-opts collection, supplied-first merge, single-map supplied, empty-map dropping, empty-middleware.
- `test/sagents/agent_test.exs` — flipped the precedence test to assert merge (both supplied and middleware callbacks fire).
- `test/sagents/extract_test.exs` — new `run/3 — callbacks` describe: middleware callbacks fire with no opts, and supplied `:callbacks` merge rather than replace.
- `test/sagents/sub_agent_server_test.exs` — new test asserting the inherited middleware callback is attached to the chain (and fires once) now that the server passes only PubSub.

## Testing

Full suite green: `mix precommit` — 1486 tests, 0 failures, Credo clean, formatted. New unit tests cover the shared `resolve_callbacks/2` policy directly plus its use on each engine (`Agent`, `SubAgent`) and the new `Extract` option. No live API calls (mocked via Mimic).