### PR TITLE
Fix Elixir 1.20 type-system warnings and dead code

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -2180,8 +2180,6 @@ defmodule Sagents.AgentServer do
     end
   end
 
-  defp wait_for_task_completion(nil, _max_wait_ms), do: :ok
-
   ## Private Functions
 
   # A halt interrupt is dismissable via dismiss_interrupt/1. Other interrupt

--- a/lib/sagents/horde/cluster_config.ex
+++ b/lib/sagents/horde/cluster_config.ex
@@ -31,8 +31,6 @@ defmodule Sagents.Horde.ClusterConfig do
         members: {Sagents.Horde.ClusterConfig, :regional_members, [region]}
   """
 
-  require Logger
-
   @doc """
   Resolve cluster members for a given module name.
 

--- a/lib/sagents/middleware/ask_user_question.ex
+++ b/lib/sagents/middleware/ask_user_question.ex
@@ -476,15 +476,21 @@ defmodule Sagents.Middleware.AskUserQuestion do
   end
 
   defp validate_single_select(response, question_data) do
-    selected = Map.get(response, :selected, [])
-    valid_values = Enum.map(question_data.options, & &1.value)
+    case Map.get(response, :selected, []) do
+      [value] ->
+        valid_values = Enum.map(question_data.options, & &1.value)
+        validate_single_value(value, response, question_data, valid_values)
+
+      _multiples ->
+        {:error, "single_select requires exactly one selection"}
+    end
+  end
+
+  defp validate_single_value(value, response, question_data, valid_values) do
     # "other" is only the special allow_other value when it's NOT a regular option
-    special_other? = hd(selected) == "other" and "other" not in valid_values
+    special_other? = value == "other" and "other" not in valid_values
 
     cond do
-      not is_list(selected) or length(selected) != 1 ->
-        {:error, "single_select requires exactly one selection"}
-
       special_other? and not question_data.allow_other ->
         {:error, "'other' is not allowed for this question"}
 
@@ -492,12 +498,12 @@ defmodule Sagents.Middleware.AskUserQuestion do
         other_text = Map.get(response, :other_text, "")
         {:ok, "User selected: other\nAdditional input: \"#{other_text}\""}
 
-      hd(selected) not in valid_values ->
+      value not in valid_values ->
         {:error,
-         "Selected value '#{hd(selected)}' is not a valid option. Valid: #{inspect(valid_values)}"}
+         "Selected value '#{value}' is not a valid option. Valid: #{inspect(valid_values)}"}
 
       true ->
-        text = "User selected: #{hd(selected)}"
+        text = "User selected: #{value}"
 
         case Map.get(response, :other_text) do
           nil -> {:ok, text}

--- a/lib/sagents/middleware/file_system.ex
+++ b/lib/sagents/middleware/file_system.ex
@@ -100,7 +100,6 @@ defmodule Sagents.Middleware.FileSystem do
 
   @behaviour Sagents.Middleware
 
-  require Logger
   alias LangChain.Function
   alias Sagents.FileSystem.FileEntry
   alias Sagents.FileSystemServer

--- a/lib/sagents/persistence/state_serializer.ex
+++ b/lib/sagents/persistence/state_serializer.ex
@@ -45,7 +45,6 @@ defmodule Sagents.Persistence.StateSerializer do
   with the current tool schema. Affects calls named `"task"` or
   `"get_task_instructions"`.
   """
-  require Logger
 
   alias Sagents.{State, Agent, Todo}
   alias LangChain.Message

--- a/test/sagents/agent_supervisor_test.exs
+++ b/test/sagents/agent_supervisor_test.exs
@@ -367,16 +367,10 @@ defmodule Sagents.AgentSupervisorTest do
           name: AgentSupervisor.get_name(agent_id)
         )
 
-      # Should handle already_started gracefully
-      case result do
-        {:ok, sup_pid2} ->
-          # Some supervisors return the existing pid
-          assert sup_pid1 == sup_pid2 or Process.alive?(sup_pid2)
-
-        {:error, {:already_started, sup_pid2}} ->
-          # Also acceptable - supervisor already running
-          assert sup_pid1 == sup_pid2
-      end
+      # start_link_sync/1 collapses an already-started supervisor into
+      # {:ok, sup_pid}, returning the existing pid.
+      assert {:ok, sup_pid2} = result
+      assert sup_pid1 == sup_pid2 or Process.alive?(sup_pid2)
 
       # AgentServer should still be accessible
       assert AgentServer.get_pid(agent_id) != nil

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -3,7 +3,6 @@ defmodule Sagents.AgentTest do
   use Mimic
 
   import ExUnit.CaptureLog
-  require Logger
 
   alias Sagents.{Agent, Middleware, State}
   alias LangChain.ChatModels.ChatAnthropic

--- a/test/sagents/middleware/conversation_title_test.exs
+++ b/test/sagents/middleware/conversation_title_test.exs
@@ -16,7 +16,7 @@ defmodule Sagents.Middleware.ConversationTitleTest do
   describe "init/1" do
     test "initializes with required chat_model" do
       assert {:ok, config} = ConversationTitle.init(chat_model: mock_model())
-      assert config.chat_model != nil
+      assert %ChatAnthropic{} = config.chat_model
       assert config.fallbacks == []
       assert config.examples != nil
     end
@@ -144,7 +144,7 @@ defmodule Sagents.Middleware.ConversationTitleTest do
           id: "test_id"
         )
 
-      assert config.chat_model != nil
+      assert %ChatAnthropic{} = config.chat_model
       assert config.fallbacks == [fallback]
       assert config.prompt_template == prompt
       assert config.examples == examples

--- a/test/support/testing_helpers.ex
+++ b/test/support/testing_helpers.ex
@@ -236,13 +236,6 @@ defmodule Sagents.TestingHelpers do
         _result = AgentServer.subscribe(agent_id, :debug)
         {:ok, %{agent_id: agent_id, pid: pid}}
 
-      {:error, {:already_started, _supervisor_pid}} ->
-        # Already started - return existing pid
-        pid = AgentServer.get_pid(agent_id)
-        _result = AgentServer.subscribe(agent_id)
-        _result = AgentServer.subscribe(agent_id, :debug)
-        {:ok, %{agent_id: agent_id, pid: pid}}
-
       {:error, reason} ->
         {:error, reason}
     end


### PR DESCRIPTION
## Problem

Upgrading to Elixir 1.20-rc.6 brought an improved set-theoretic type system that performs flow-sensitive analysis at compile time. This surfaced several warnings that were previously invisible: unused `require` directives, unreachable function clauses, and conditional branches the analyzer can now prove will never succeed. One of these warnings pointed at an actual latent crash, not just cosmetic noise.

## Solution

Cleaned up every warning the new compiler raised across both the library and the test suite. The most significant fix was in `validate_single_select/2`, where `hd(selected)` was called eagerly before the list was validated. With the default `Map.get(response, :selected, [])` returning `[]`, that path would raise `ArgumentError` on `hd([])` instead of returning the intended validation error. Because `hd/1` ran first, the type system also narrowed `selected` to a non-empty list, making the downstream `not is_list(selected)` guard provably dead. The function now uses a `[value]` pattern match that handles the arity check, type check, and extraction in a single, total `case`.

The remaining changes remove genuinely dead code: a `require Logger` in three modules with no `Logger.` calls, an unreachable `nil` clause in `wait_for_task_completion/2` (its only caller is already guarded by `task != nil`), and dead `{:error, {:already_started, _}}` branches in test helpers (since `AgentSupervisor.start_link_sync/1` collapses that case into `{:ok, sup_pid}` internally).

## Changes

- `lib/sagents/middleware/ask_user_question.ex` - Rewrote `validate_single_select/2` to pattern match `[value]`, fixing a latent `hd([])` crash and removing the dead guard; extracted `validate_single_value/4` helper
- `lib/sagents/agent_server.ex` - Removed unreachable `wait_for_task_completion(nil, _)` clause
- `lib/sagents/horde/cluster_config.ex`, `lib/sagents/middleware/file_system.ex`, `lib/sagents/persistence/state_serializer.ex` - Removed unused `require Logger`
- `test/support/testing_helpers.ex` - Removed dead `{:already_started, _}` clause (start_link_sync never returns it)
- `test/sagents/agent_supervisor_test.exs` - Simplified the already-started test to assert the actual `{:ok, sup_pid}` contract
- `test/sagents/agent_test.exs` - Removed unused `require Logger`
- `test/sagents/middleware/conversation_title_test.exs` - Replaced tautological `chat_model != nil` assertions with `%ChatAnthropic{}` struct matches

## Testing

Full suite passes clean with no warnings: `mix compile --force` produces no output, and `mix test` reports 1480 passed, 1 skipped, 7 excluded. The `ask_user_question` change is covered by its existing 65-test file, all green. No new tests were added since this is a warning and dead-code cleanup; the behavior change in `validate_single_select/2` (returning a validation error instead of crashing on empty input) is exercised by the existing single_select test cases.