### PR TITLE
Add init config to force allow_other / allow_cancel in AskUserQuestion

### DIFF
--- a/lib/sagents/middleware/ask_user_question.ex
+++ b/lib/sagents/middleware/ask_user_question.ex
@@ -14,6 +14,15 @@ defmodule Sagents.Middleware.AskUserQuestion do
       # Restricted to specific types
       {Sagents.Middleware.AskUserQuestion, response_types: [:single_select, :multi_select]}
 
+  ### Forcing allow_other / allow_cancel
+
+  By default the LLM chooses `allow_other` and `allow_cancel` per question. Set
+  either to a fixed boolean in the init config to force it for every question
+  and remove it from the LLM's control. Omit a key to leave it LLM-decided.
+
+      # User must always answer (never cancel); always offer an "Other" input
+      {Sagents.Middleware.AskUserQuestion, allow_cancel: false, allow_other: true}
+
   ## Response Types
 
   - `:single_select` - User picks one option from a list (radio buttons)
@@ -68,19 +77,40 @@ defmodule Sagents.Middleware.AskUserQuestion do
   @impl true
   def init(opts) do
     response_types = Keyword.get(opts, :response_types, @all_response_types)
-
     invalid = response_types -- @all_response_types
 
-    if invalid != [] do
-      {:error, "Invalid response types: #{inspect(invalid)}"}
+    with [] <- invalid,
+         {:ok, forced_allow_other} <- validate_forced_flag(opts, :allow_other),
+         {:ok, forced_allow_cancel} <- validate_forced_flag(opts, :allow_cancel) do
+      {:ok,
+       %{
+         response_types: response_types,
+         forced_allow_other: forced_allow_other,
+         forced_allow_cancel: forced_allow_cancel
+       }}
     else
-      {:ok, %{response_types: response_types}}
+      invalid when is_list(invalid) ->
+        {:error, "Invalid response types: #{inspect(invalid)}"}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  # A forced flag (`allow_other` / `allow_cancel`) fixes the value for every
+  # question and removes it from the LLM's control. Absent -> nil (LLM decides).
+  # Boolean -> forced. Anything else -> error.
+  defp validate_forced_flag(opts, key) do
+    case Keyword.fetch(opts, key) do
+      :error -> {:ok, nil}
+      {:ok, val} when is_boolean(val) -> {:ok, val}
+      {:ok, other} -> {:error, "#{key} must be a boolean when set, got: #{inspect(other)}"}
     end
   end
 
   @impl true
   def system_prompt(config) do
-    build_system_prompt(config.response_types)
+    build_system_prompt(config)
   end
 
   @impl true
@@ -241,62 +271,77 @@ defmodule Sagents.Middleware.AskUserQuestion do
         "Ask the user a structured question when you need their input to make a decision. " <>
           "Use this for significant choices where multiple valid approaches exist.",
       display_text: "Asking a question",
-      parameters_schema: build_parameters_schema(config.response_types),
+      parameters_schema: build_parameters_schema(config),
       function: fn args, _context ->
         execute_ask_user(args, config)
       end
     })
   end
 
-  defp build_parameters_schema(response_types) do
-    %{
-      type: "object",
-      properties: %{
-        question: %{type: "string", description: "The question to ask the user"},
-        response_type: %{
-          type: "string",
-          enum: Enum.map(response_types, &Atom.to_string/1),
-          description:
-            "The type of response expected: " <>
-              Enum.map_join(response_types, ", ", fn
-                :single_select -> "single_select (pick one)"
-                :multi_select -> "multi_select (pick one or more)"
-                :freeform -> "freeform (open text)"
-              end)
-        },
-        options: %{
-          type: "array",
-          description:
-            "Options for single_select or multi_select. Must have 2-10 items. Not used for freeform.",
-          items: %{
-            type: "object",
-            properties: %{
-              label: %{type: "string", description: "Display label for the option"},
-              value: %{type: "string", description: "Machine-readable value"},
-              description: %{
-                type: "string",
-                description: "Optional description with tradeoffs or details"
-              }
-            },
-            required: ["label", "value"]
-          }
-        },
-        context: %{
-          type: "string",
-          description: "Additional context to help the user understand the decision"
-        },
-        allow_other: %{
-          type: "boolean",
-          description: "Whether to allow a freeform 'other' option alongside selections"
-        },
-        allow_cancel: %{
-          type: "boolean",
-          description: "Whether the user can cancel/dismiss this question"
+  defp build_parameters_schema(config) do
+    response_types = config.response_types
+
+    base_properties = %{
+      question: %{type: "string", description: "The question to ask the user"},
+      response_type: %{
+        type: "string",
+        enum: Enum.map(response_types, &Atom.to_string/1),
+        description:
+          "The type of response expected: " <>
+            Enum.map_join(response_types, ", ", fn
+              :single_select -> "single_select (pick one)"
+              :multi_select -> "multi_select (pick one or more)"
+              :freeform -> "freeform (open text)"
+            end)
+      },
+      options: %{
+        type: "array",
+        description:
+          "Options for single_select or multi_select. Must have 2-10 items. Not used for freeform.",
+        items: %{
+          type: "object",
+          properties: %{
+            label: %{type: "string", description: "Display label for the option"},
+            value: %{type: "string", description: "Machine-readable value"},
+            description: %{
+              type: "string",
+              description: "Optional description with tradeoffs or details"
+            }
+          },
+          required: ["label", "value"]
         }
       },
+      context: %{
+        type: "string",
+        description: "Additional context to help the user understand the decision"
+      }
+    }
+
+    # A forced flag is dropped from the schema so the LLM can't (and isn't asked
+    # to) set it. An unforced flag (nil) is exposed as today.
+    properties =
+      base_properties
+      |> maybe_put_flag_property(:allow_other, config.forced_allow_other, %{
+        type: "boolean",
+        description: "Whether to allow a freeform 'other' option alongside selections"
+      })
+      |> maybe_put_flag_property(:allow_cancel, config.forced_allow_cancel, %{
+        type: "boolean",
+        description: "Whether the user can cancel/dismiss this question"
+      })
+
+    %{
+      type: "object",
+      properties: properties,
       required: ["question", "response_type"]
     }
   end
+
+  defp maybe_put_flag_property(properties, _key, forced, _schema) when is_boolean(forced),
+    do: properties
+
+  defp maybe_put_flag_property(properties, key, nil, schema),
+    do: Map.put(properties, key, schema)
 
   # -- Tool execution (validation + interrupt) --
 
@@ -309,8 +354,8 @@ defmodule Sagents.Middleware.AskUserQuestion do
         question: question,
         response_type: response_type,
         options: options,
-        allow_other: get_boolean_arg(args, "allow_other", false),
-        allow_cancel: get_boolean_arg(args, "allow_cancel", true),
+        allow_other: resolve_flag(config.forced_allow_other, args, "allow_other", false),
+        allow_cancel: resolve_flag(config.forced_allow_cancel, args, "allow_cancel", true),
         context: Map.get(args, "context")
       }
 
@@ -435,6 +480,11 @@ defmodule Sagents.Middleware.AskUserQuestion do
       _other -> default
     end
   end
+
+  # A forced config value wins and the LLM-provided arg is ignored. When not
+  # forced (nil), fall back to the LLM arg with its existing default.
+  defp resolve_flag(forced, _args, _key, _default) when is_boolean(forced), do: forced
+  defp resolve_flag(nil, args, key, default), do: get_boolean_arg(args, key, default)
 
   # -- Response processing --
 
@@ -663,7 +713,9 @@ defmodule Sagents.Middleware.AskUserQuestion do
 
   # -- System prompt --
 
-  defp build_system_prompt(response_types) do
+  defp build_system_prompt(config) do
+    response_types = config.response_types
+
     type_instructions =
       Enum.map_join(response_types, "\n", fn
         :single_select ->
@@ -708,7 +760,22 @@ defmodule Sagents.Middleware.AskUserQuestion do
     - Keep questions concise and focused on the decision at hand
     - Provide 2-5 distinct options with brief descriptions of tradeoffs
     - Include relevant context to help the user make an informed decision
-    - Set allow_cancel to true unless the question blocks critical progress
+    #{flag_guidance(config)}
     """
+  end
+
+  # Only guide the LLM about a flag it actually controls. A forced flag is
+  # absent from the tool schema, so mentioning it here would be misleading.
+  defp flag_guidance(config) do
+    [
+      if(is_nil(config.forced_allow_cancel),
+        do: "- Set allow_cancel to true unless the question blocks critical progress"
+      ),
+      if(is_nil(config.forced_allow_other),
+        do: "- Set allow_other to true only when a custom 'Other' answer would genuinely help"
+      )
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
   end
 end

--- a/test/sagents/middleware/ask_user_question_test.exs
+++ b/test/sagents/middleware/ask_user_question_test.exs
@@ -16,6 +16,20 @@ defmodule Sagents.Middleware.AskUserQuestionTest do
     end)
   end
 
+  defp single_select_args(extra) do
+    Map.merge(
+      %{
+        "question" => "Which database?",
+        "response_type" => "single_select",
+        "options" => [
+          %{"label" => "PostgreSQL", "value" => "postgresql"},
+          %{"label" => "MongoDB", "value" => "mongodb"}
+        ]
+      },
+      extra
+    )
+  end
+
   describe "init/1" do
     test "defaults to all response types" do
       {:ok, config} = AskUserQuestion.init([])
@@ -30,6 +44,34 @@ defmodule Sagents.Middleware.AskUserQuestionTest do
     test "returns error for invalid response types" do
       assert {:error, msg} = AskUserQuestion.init(response_types: [:invalid_type])
       assert msg =~ "Invalid response types"
+    end
+
+    test "forced flags default to nil" do
+      {:ok, config} = AskUserQuestion.init([])
+      assert config.forced_allow_cancel == nil
+      assert config.forced_allow_other == nil
+    end
+
+    test "forces allow_cancel when a boolean is given" do
+      {:ok, config} = AskUserQuestion.init(allow_cancel: false)
+      assert config.forced_allow_cancel == false
+      assert config.forced_allow_other == nil
+    end
+
+    test "forces allow_other when a boolean is given" do
+      {:ok, config} = AskUserQuestion.init(allow_other: true)
+      assert config.forced_allow_other == true
+      assert config.forced_allow_cancel == nil
+    end
+
+    test "returns error when allow_cancel is not a boolean" do
+      assert {:error, msg} = AskUserQuestion.init(allow_cancel: "yes")
+      assert msg =~ "allow_cancel must be a boolean"
+    end
+
+    test "returns error when allow_other is not a boolean" do
+      assert {:error, msg} = AskUserQuestion.init(allow_other: 1)
+      assert msg =~ "allow_other must be a boolean"
     end
   end
 
@@ -51,6 +93,16 @@ defmodule Sagents.Middleware.AskUserQuestionTest do
       assert prompt =~ "multi_select"
       assert prompt =~ "freeform"
     end
+
+    test "includes allow_cancel guidance when not forced" do
+      {:ok, config} = AskUserQuestion.init([])
+      assert AskUserQuestion.system_prompt(config) =~ "Set allow_cancel"
+    end
+
+    test "omits allow_cancel guidance when forced" do
+      {:ok, config} = AskUserQuestion.init(allow_cancel: false)
+      refute AskUserQuestion.system_prompt(config) =~ "Set allow_cancel"
+    end
   end
 
   describe "tools/1" do
@@ -68,6 +120,33 @@ defmodule Sagents.Middleware.AskUserQuestionTest do
 
       enum = tool.parameters_schema.properties.response_type.enum
       assert enum == ["single_select", "freeform"]
+    end
+
+    test "exposes both flags in schema when neither is forced" do
+      {:ok, config} = AskUserQuestion.init([])
+      [tool] = AskUserQuestion.tools(config)
+
+      props = tool.parameters_schema.properties
+      assert Map.has_key?(props, :allow_other)
+      assert Map.has_key?(props, :allow_cancel)
+    end
+
+    test "omits allow_cancel from schema when forced" do
+      {:ok, config} = AskUserQuestion.init(allow_cancel: false)
+      [tool] = AskUserQuestion.tools(config)
+
+      props = tool.parameters_schema.properties
+      refute Map.has_key?(props, :allow_cancel)
+      assert Map.has_key?(props, :allow_other)
+    end
+
+    test "omits allow_other from schema when forced" do
+      {:ok, config} = AskUserQuestion.init(allow_other: true)
+      [tool] = AskUserQuestion.tools(config)
+
+      props = tool.parameters_schema.properties
+      refute Map.has_key?(props, :allow_other)
+      assert Map.has_key?(props, :allow_cancel)
     end
   end
 
@@ -154,6 +233,42 @@ defmodule Sagents.Middleware.AskUserQuestionTest do
       assert {:interrupt, _msg, question_data} = tool.function.(args, %{})
       assert question_data.allow_other == true
       assert question_data.allow_cancel == false
+    end
+  end
+
+  # These tests build config inline (the shared setup uses default config) so
+  # each can force a specific flag.
+  describe "tool execution - forced flags" do
+    test "forced allow_cancel overrides the LLM-provided arg" do
+      {:ok, config} = AskUserQuestion.init(allow_cancel: false)
+      [tool] = AskUserQuestion.tools(config)
+
+      # LLM tries to set true; the forced false must win.
+      args = single_select_args(%{"allow_cancel" => true})
+
+      assert {:interrupt, _msg, question_data} = tool.function.(args, %{})
+      assert question_data.allow_cancel == false
+    end
+
+    test "forced allow_other overrides the LLM-provided arg" do
+      {:ok, config} = AskUserQuestion.init(allow_other: true)
+      [tool] = AskUserQuestion.tools(config)
+
+      args = single_select_args(%{"allow_other" => false})
+
+      assert {:interrupt, _msg, question_data} = tool.function.(args, %{})
+      assert question_data.allow_other == true
+    end
+
+    test "uses LLM-provided flags when neither is forced" do
+      {:ok, config} = AskUserQuestion.init([])
+      [tool] = AskUserQuestion.tools(config)
+
+      args = single_select_args(%{"allow_cancel" => false, "allow_other" => true})
+
+      assert {:interrupt, _msg, question_data} = tool.function.(args, %{})
+      assert question_data.allow_cancel == false
+      assert question_data.allow_other == true
     end
   end
 


### PR DESCRIPTION
## Problem

The `AskUserQuestion` middleware lets an agent ask the user structured questions, and the LLM decides **per call** whether to offer an "Other" freeform input (`allow_other`) and whether the user may cancel without answering (`allow_cancel`). Some products need a guarantee — e.g. "the user must always answer" or "always offer an Other option" — that shouldn't depend on the model choosing correctly each time. Previously the only init-time control was `response_types`.

## Solution

`init/1` now accepts optional `allow_other` and `allow_cancel` keys. A boolean value forces that flag for every question and removes it from the LLM's control; an absent key preserves today's behavior (LLM decides, defaults `allow_other=false` / `allow_cancel=true`). Each flag is independent — force one, both, or neither.

The forcing is wired through three points so the LLM and the runtime stay consistent:

- **Tool schema** — a forced flag is dropped from the `ask_user` parameter schema via `maybe_put_flag_property/4`, so the model never sees (or is asked to set) it.
- **Tool execution** — `resolve_flag/4` makes the forced config value win and defensively ignores any arg the LLM sends anyway.
- **System prompt** — `flag_guidance/1` only emits guidance for flags the LLM actually controls, keeping the prompt aligned with the schema.

This is low-risk because `allow_other`/`allow_cancel` already flow as plain values in the `:ask_user_question` interrupt map. Downstream consumers (the LiveView UI and the `process_response/2` / `user_facing_attrs/2` validators) only read those values, so the change is purely about *who decides them* — no downstream code needed changing.

## Changes

- `lib/sagents/middleware/ask_user_question.ex` — `init/1` parses and validates the optional `allow_other`/`allow_cancel` keys (non-booleans return `{:error, _}`) into `forced_allow_*` config; schema omits forced flags; `execute_ask_user/2` resolves forced-vs-LLM values; system prompt suppresses guidance for forced flags; moduledoc documents the new "Forcing allow_other / allow_cancel" config.
- `test/sagents/middleware/ask_user_question_test.exs` — Added coverage for init validation (success and error per key), schema omission of forced flags, forced values overriding opposing LLM args, the unforced regression path, and prompt-guidance presence/absence.

## Testing

`mix test test/sagents/middleware/ask_user_question_test.exs` passes (78 tests). Full `mix precommit` is green: formatting clean, Credo reports no issues, no vulnerabilities, and the suite passes (1498 passed, 1 skipped, 2 excluded).