### PR TITLE
Denormalize tool_call_id onto display_message templates

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -147,6 +147,7 @@ defmodule MyApp.Conversations.DisplayMessage do
 
     field :message_type, :string      # "user", "assistant", "tool", "system"
     field :content, :map              # Flexible JSONB storage
+    field :tool_call_id, :string      # store denormalized link: tool_call <-> tool_result
     field :content_type, :string      # "text", "thinking", "image", "tool_call", etc.
     field :sequence, :integer, default: 0
     field :status, :string, default: "completed"
@@ -158,6 +159,8 @@ end
 ```
 
 DisplayMessages are multi-content-type: one logical assistant turn can produce several rows (thinking + text + tool_call), ordered by `(inserted_at, sequence)`. See the schema's moduledoc for the valid `content_type` values and their expected `content` shapes.
+
+For `tool_call` and `tool_result` rows the call/result id is pulled out of the `content` JSONB into the top-level `tool_call_id` column (populated at insert time). It's the linking key between a tool call and its result, and the tool-call lifecycle queries (`mark_tool_executing/2`, `complete_tool_call/3`, etc.) use a plain indexed equality on it. The id still lives in `content` as well; the column is an additional indexed copy.
 
 ## Context Module
 

--- a/priv/templates/display_message_persistence.ex.eex
+++ b/priv/templates/display_message_persistence.ex.eex
@@ -28,12 +28,22 @@ defmodule <%= module %> do
           "content" => item.content
         }
 
-        # Set status to "pending" for tool calls
+        # Pull the tool-call id out of `content` into the top-level
+        # `tool_call_id` column so the lifecycle queries can use an indexed
+        # equality lookup. Tool calls additionally start in "pending" status.
         attrs =
-          if item.type == :tool_call do
-            Map.put(attrs, "status", "pending")
-          else
-            attrs
+          case item do
+            %{type: :tool_call, content: %{"call_id" => call_id}} ->
+              Map.merge(attrs, %{
+                "tool_call_id" => call_id,
+                "status" => "pending"
+              })
+
+            %{type: :tool_result, content: %{"tool_call_id" => tool_call_id}} ->
+              Map.put(attrs, "tool_call_id", tool_call_id)
+
+            _other ->
+              attrs
           end
 
         case <%= conversations_module %>.append_display_message(scope, context.conversation_id, attrs) do

--- a/priv/templates/sagents.gen.persistence/context.ex.eex
+++ b/priv/templates/sagents.gen.persistence/context.ex.eex
@@ -548,7 +548,7 @@ defmodule <%= @context_module %> do
     from m in DisplayMessage,
       join: c in Conversation,
       on: m.conversation_id == c.id,
-      where: fragment("?->>'call_id' = ?", m.content, ^call_id),
+      where: m.tool_call_id == ^call_id,
       where: m.content_type == "tool_call"
   end
 
@@ -559,7 +559,7 @@ defmodule <%= @context_module %> do
     from m in DisplayMessage,
       join: c in Conversation,
       on: m.conversation_id == c.id,
-      where: fragment("?->>'tool_call_id' = ?", m.content, ^tool_call_id),
+      where: m.tool_call_id == ^tool_call_id,
       where: m.content_type == "tool_result"
   end
 

--- a/priv/templates/sagents.gen.persistence/display_message.ex.eex
+++ b/priv/templates/sagents.gen.persistence/display_message.ex.eex
@@ -33,7 +33,7 @@ defmodule <%= @context_module %>.DisplayMessage do
   - File: `%{"path" => "/path", "name" => "report.pdf"}`
   - Tool call: `%{"call_id" => "call_123", "name" => "search", "arguments" => %{...}}`
   - Tool result: `%{"tool_call_id" => "call_123", "name" => "search", "content" => "...", "is_error" => false}`
-  - Todo snapshot: `%{"todos" => [%{"id" => "1", "content" => "Plan", "status" => "completed"}, ...], "summary" => %{"total" => 3, "pending" => 1, "in_progress" => 1, "completed" => 1, "cancelled" => 0}}`
+  - Todo snapshot: `%{"todos" => [%{"id" => 1, "content" => "Plan", "status" => "completed"}, ...], "summary" => %{"total" => 3, "pending" => 1, "in_progress" => 1, "completed" => 1, "cancelled" => 0}}`
 
   ## Sequence Field (Message-Local Ordering)
 
@@ -103,6 +103,7 @@ defmodule <%= @context_module %>.DisplayMessage do
     field :message_type, :string
     # Flexible JSONB storage
     field :content, :map
+    field :tool_call_id, :string
     # Type of content for rendering
     field :content_type, :string
     # Message-local ordering (0-based, resets per message)
@@ -118,7 +119,15 @@ defmodule <%= @context_module %>.DisplayMessage do
   @doc false
   def create_changeset(conversation_id, attrs) do
     %DisplayMessage{}
-    |> cast(attrs, [:message_type, :content, :content_type, :sequence, :status, :metadata])
+    |> cast(attrs, [
+      :message_type,
+      :content,
+      :tool_call_id,
+      :content_type,
+      :sequence,
+      :status,
+      :metadata
+    ])
     |> put_change(:conversation_id, conversation_id)
     |> common_validations()
   end
@@ -126,7 +135,15 @@ defmodule <%= @context_module %>.DisplayMessage do
   @doc false
   def changeset(%DisplayMessage{} = message, attrs) do
     message
-    |> cast(attrs, [:message_type, :content, :content_type, :sequence, :status, :metadata])
+    |> cast(attrs, [
+      :message_type,
+      :content,
+      :tool_call_id,
+      :content_type,
+      :sequence,
+      :status,
+      :metadata
+    ])
     |> common_validations()
   end
 
@@ -145,10 +162,6 @@ defmodule <%= @context_module %>.DisplayMessage do
     |> validate_number(:sequence, greater_than_or_equal_to: 0)
     |> validate_content_structure()
     |> foreign_key_constraint(:conversation_id)
-    |> unique_constraint(:conversation_id,
-      name: :unique_tool_call_per_conversation,
-      message: "tool call already exists for this conversation"
-    )
   end
 
   # Validate content structure based on content_type.

--- a/priv/templates/sagents.gen.persistence/migration.exs.eex
+++ b/priv/templates/sagents.gen.persistence/migration.exs.eex
@@ -36,6 +36,7 @@ defmodule <%= @repo %>.Migrations.Create<%= Macro.camelize(@table_prefix) %>Pers
       add :message_type, :string, null: false
       # JSONB storage for flexible content
       add :content, :map, null: false
+      add :tool_call_id, :string
       # Content type for rendering
       add :content_type, :string, null: false, default: "text"
       # Tool execution status: "pending", "executing", "completed", "failed"
@@ -52,13 +53,7 @@ defmodule <%= @repo %>.Migrations.Create<%= Macro.camelize(@table_prefix) %>Pers
     create index(:<%= @table_prefix %>display_messages, [:content_type])
     # For filtering by status (e.g., pending tools)
     create index(:<%= @table_prefix %>display_messages, [:status])
-
-    # Unique partial index to prevent duplicate tool call IDs per conversation
-    create unique_index(
-             :<%= @table_prefix %>display_messages,
-             [:conversation_id, "(content->>'call_id')"],
-             name: :unique_tool_call_per_conversation,
-             where: "content_type = 'tool_call'"
-           )
+    # Index for tool-call lifecycle
+    create index(:<%= @table_prefix %>display_messages, [:tool_call_id])
   end
 end


### PR DESCRIPTION
## Problem

The persistence generator templates stored the tool-call/tool-result linking id only inside the `content` JSONB blob. The tool-call lifecycle queries (`mark_tool_executing/2`, `complete_tool_call/3`, and friends) therefore had to match on a JSON path fragment (`content->>'call_id'` / `content->>'tool_call_id'`). Those fragment lookups don't benefit from an ordinary index, so the hottest queries in the tool lifecycle were doing JSONB extraction on every row.

## Solution

Promote the linking id to a top-level `tool_call_id` column on the `display_messages` schema and populate it at insert time. The persistence callback pulls `call_id` out of tool-call content and `tool_call_id` out of tool-result content into the new column, while the value still lives in `content` as before (the column is an additional indexed copy, not a replacement).

The lifecycle queries in the generated context now use a plain indexed equality (`m.tool_call_id == ^call_id`) instead of the JSONB fragment, and the migration backs the column with a standard index.

This also drops the `unique_tool_call_per_conversation` partial unique index (which was enforced on `content->>'call_id'`) along with its corresponding `unique_constraint/3` in the changeset, replacing it with a plain index on `tool_call_id`. Reviewers should note this removes the DB-level uniqueness guarantee for tool-call ids per conversation.

Since these are generator templates, the change affects newly generated persistence layers; existing generated apps would need to add the column, backfill, and swap the index.

## Changes

- `priv/templates/sagents.gen.persistence/migration.exs.eex` — Add `tool_call_id` column; replace the `unique_tool_call_per_conversation` partial unique index with a plain index on `tool_call_id`
- `priv/templates/sagents.gen.persistence/display_message.ex.eex` — Add `tool_call_id` field; include it in both changesets; drop the `unique_constraint` on `unique_tool_call_per_conversation`
- `priv/templates/sagents.gen.persistence/context.ex.eex` — Switch the tool-call and tool-result lifecycle queries from `fragment("?->>'call_id' = ?", ...)` to indexed `m.tool_call_id == ^id` equality
- `priv/templates/display_message_persistence.ex.eex` — Populate `tool_call_id` at insert time via a `case` over `:tool_call` / `:tool_result` content shapes
- `docs/persistence.md` — Document the denormalized `tool_call_id` column, how it is populated, and its role as the call/result linking key
- `display_message.ex.eex` (@moduledoc) — Minor correction to the Todo snapshot example (`"id" => 1` instead of `"id" => "1"`)

## Testing

These are EEx generator templates, so the change is validated by generating a persistence layer and confirming the migration, schema, and context compile and the lifecycle queries resolve against the new column. No automated test changes are included in this branch.