### PR TITLE
Add :until_tool_success option for validate-and-retry agent runs

### DIFF
--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -47,6 +47,7 @@ defmodule Sagents.Agent do
   alias Sagents.State
   alias LangChain.LangChainError
   alias LangChain.Message
+  alias LangChain.Message.ToolResult
   alias LangChain.Chains.LLMChain
   alias Sagents.Middleware.HumanInTheLoop
 
@@ -85,6 +86,20 @@ defmodule Sagents.Agent do
   end
 
   @type t :: %Agent{}
+
+  @typedoc """
+  Result of `execute/3` (and `resume/4`).
+
+  The `{:ok, state, tool_result}` shape is returned for `:until_tool` /
+  `:until_tool_success` completions; the third element is the matching
+  `LangChain.Message.ToolResult`.
+  """
+  @type execute_result ::
+          {:ok, State.t()}
+          | {:ok, State.t(), ToolResult.t()}
+          | {:interrupt, State.t(), any()}
+          | {:pause, State.t()}
+          | {:error, any()}
 
   @create_fields [
     :agent_id,
@@ -462,9 +477,58 @@ defmodule Sagents.Agent do
     callbacks. When running via `AgentServer`, the only callbacks passed here are
     the PubSub broadcasting callbacks; middleware collection happens internally.
 
+  - `:until_tool` - Tool name (string) or list of tool names. When set, the run
+    completes (returning `{:ok, state, tool_result}`) as soon as the target tool
+    is *called*, regardless of whether it succeeded or returned an error. Errors
+    with `until_tool_not_called` if the LLM stops without calling it.
+
+  - `:until_tool_success` - Tool name (string) or list of tool names. Like
+    `:until_tool`, but the run completes only when the target tool returns a
+    *successful* (non-error) result. An error result keeps the loop running so
+    the LLM can correct its arguments, up to `:max_runs` attempts. Use this
+    *instead of* `:until_tool` when the tool validates its input and you want the
+    model to retry. Passing both `:until_tool` and `:until_tool_success` is an
+    error (they are mutually exclusive).
+
+    On success the run returns `{:ok, state, %LangChain.Message.ToolResult{}}`.
+    The tool can hand a processed result back on that `ToolResult` by returning
+    `{:ok, "text for LLM", processed_term}` — the 3rd element becomes the
+    result's `processed_content` and is **not** sent to the model. Read it with
+    `Sagents.AgentResult.processed_content/1`. This is the building block
+    `Sagents.Extract` is built on.
+
+        # A submit tool that validates + persists, returning the inserted record:
+        submit =
+          LangChain.Function.new!(%{
+            name: "submit",
+            parameters_schema: schema,
+            function: fn args, _ctx ->
+              case MyApp.create_person(args) do
+                {:ok, person} -> {:ok, "Saved \#{person.id}.", person}
+                # an error result loops so the LLM can correct the call:
+                {:error, reason} -> {:error, "Could not save: \#{reason}"}
+              end
+            end
+          })
+
+        {:ok, _state, %LangChain.Message.ToolResult{}} = result =
+          Agent.execute(agent, state, until_tool_success: "submit", max_runs: 5)
+
+        {:ok, %MyApp.Person{} = person} =
+          Sagents.AgentResult.processed_content(result)
+
+    Plain `:until_tool` would instead terminate on the *first* call even when the
+    tool returns `{:error, ...}`, so the validate-and-retry loop above needs
+    `:until_tool_success`. Note `processed_content` is a virtual field. Read it
+    from the `execute/3` return value; it is not persisted across a state
+    serialize/reload.
+
   ## Returns
 
   - `{:ok, state}` - Normal completion
+  - `{:ok, state, tool_result}` - `:until_tool` / `:until_tool_success` completion;
+    the third element is the matching `%LangChain.Message.ToolResult{}` (see those
+    options and `Sagents.AgentResult`)
   - `{:interrupt, state, interrupt_data}` - Execution paused for human approval
   - `{:error, reason}` - Execution failed
 
@@ -499,6 +563,7 @@ defmodule Sagents.Agent do
 
       Agent.execute(agent, state, callbacks: callbacks)
   """
+  @spec execute(t(), State.t(), keyword()) :: execute_result()
   def execute(%Agent{} = agent, %State{} = state, opts \\ []) do
     # Ensure agent_id is set in state (library handles this automatically)
     state = %{state | agent_id: agent.agent_id}
@@ -570,6 +635,7 @@ defmodule Sagents.Agent do
       response = %{type: :answer, selected: ["PostgreSQL"]}
       {:ok, final_state} = Agent.resume(agent, state, response)
   """
+  @spec resume(t(), State.t(), any(), keyword()) :: execute_result()
   def resume(%Agent{} = agent, %State{} = state, resume_data, opts \\ []) do
     # Ensure agent_id is set in state (library handles this automatically)
     state = %{state | agent_id: agent.agent_id}
@@ -835,23 +901,47 @@ defmodule Sagents.Agent do
     opts
   end
 
+  # `:until_tool` and `:until_tool_success` both name the target tool (string or
+  # list of strings). They are mutually exclusive: `:until_tool` stops when the
+  # tool is called (any result); `:until_tool_success` stops only on a successful
+  # (non-error) result, retrying on errors.
   defp validate_until_tool(%Agent{} = agent, opts) do
-    case Keyword.get(opts, :until_tool) do
-      nil ->
+    call = Keyword.get(opts, :until_tool)
+    success = Keyword.get(opts, :until_tool_success)
+
+    cond do
+      not is_nil(call) and not is_nil(success) ->
+        {:error,
+         "Cannot pass both :until_tool and :until_tool_success; they are mutually exclusive. " <>
+           "Use :until_tool to stop when the tool is called, or :until_tool_success to stop " <>
+           "only when it returns a successful result."}
+
+      not is_nil(call) ->
+        validate_until_tool_target(agent, :until_tool, call, opts)
+
+      not is_nil(success) ->
+        validate_until_tool_target(agent, :until_tool_success, success, opts)
+
+      true ->
         {:ok, opts}
-
-      tool when is_binary(tool) ->
-        do_validate_tool_names(agent, [tool], opts)
-
-      tools when is_list(tools) ->
-        do_validate_tool_names(agent, tools, opts)
-
-      other ->
-        {:error, "Invalid :until_tool option: expected string or list, got: #{inspect(other)}"}
     end
   end
 
-  defp do_validate_tool_names(%Agent{tools: tools}, target_names, opts) do
+  defp validate_until_tool_target(agent, key, value, opts) do
+    case value do
+      tool when is_binary(tool) ->
+        do_validate_tool_names(agent, key, [tool], opts)
+
+      tools when is_list(tools) ->
+        do_validate_tool_names(agent, key, tools, opts)
+
+      other ->
+        {:error,
+         "Invalid #{inspect(key)} option: expected string or list, got: #{inspect(other)}"}
+    end
+  end
+
+  defp do_validate_tool_names(%Agent{tools: tools}, key, target_names, opts) do
     available = MapSet.new(tools, & &1.name)
     missing = Enum.reject(target_names, &MapSet.member?(available, &1))
 
@@ -861,7 +951,7 @@ defmodule Sagents.Agent do
 
       names ->
         {:error,
-         "until_tool: tool(s) #{inspect(names)} not found. Available: #{inspect(MapSet.to_list(available))}"}
+         "#{key}: tool(s) #{inspect(names)} not found. Available: #{inspect(MapSet.to_list(available))}"}
     end
   end
 
@@ -872,7 +962,7 @@ defmodule Sagents.Agent do
       run_opts
       |> Keyword.put(:mode, agent.mode || Sagents.Modes.AgentExecution)
       |> Keyword.put(:middleware, middleware)
-      |> maybe_put_until_tool(opts)
+      |> put_until_tool_opts(opts)
       |> maybe_put_max_runs(agent, opts)
 
     if is_raw_langchain_mode?(agent.mode) do
@@ -913,10 +1003,22 @@ defmodule Sagents.Agent do
     end
   end
 
-  defp maybe_put_until_tool(mode_opts, opts) do
-    case Keyword.get(opts, :until_tool) do
-      nil -> mode_opts
-      until_tool -> Keyword.put(mode_opts, :until_tool, until_tool)
+  # Collapse the public either-or options into the mode's internal
+  # `:until_tool` + `:require_tool_success` representation (see
+  # `Sagents.Modes.AgentExecution.collapse_until_tool/2`). Mutual exclusivity is
+  # already enforced by `validate_until_tool/2`.
+  defp put_until_tool_opts(mode_opts, opts) do
+    case Sagents.Modes.AgentExecution.collapse_until_tool(
+           Keyword.get(opts, :until_tool),
+           Keyword.get(opts, :until_tool_success)
+         ) do
+      {nil, _require_success} ->
+        mode_opts
+
+      {until_tool, require_success} ->
+        mode_opts
+        |> Keyword.put(:until_tool, until_tool)
+        |> Keyword.put(:require_tool_success, require_success)
     end
   end
 

--- a/lib/sagents/agent_result.ex
+++ b/lib/sagents/agent_result.ex
@@ -131,7 +131,9 @@ defmodule Sagents.AgentResult do
   tool body can attach by returning `{:ok, "string for LLM", native_term}`.
 
   Useful when the tool wants to hand back something richer than a JSON-parseable
-  argument map (a struct, a tuple, etc.).
+  argument map (a struct, a tuple, etc.). Contrast with `tool_arguments/1`, which
+  returns the arguments the *LLM emitted*; `processed_content/1` returns what the
+  *tool body computed* from them.
   """
   @spec processed_content(execute_return()) ::
           {:ok, any()} | {:error, LangChainError.t()} | {:error, any()}

--- a/lib/sagents/extract.ex
+++ b/lib/sagents/extract.ex
@@ -10,9 +10,13 @@ defmodule Sagents.Extract do
 
   The trick is the same one `DataExtractionChain` uses: define a single tool
   whose `parameters_schema` is the desired result shape, run the agent with
-  `until_tool: "<that tool>"`, and read the LLM-supplied arguments back out.
-  The tool's body never has to do real work — it just hands `args` back as
-  `processed_content`.
+  `until_tool_success: "<tool_name>"`, and read the result back out. `run/3`
+  returns the tool's `processed_content` — the value the tool body produces — so
+  the tool can shape the raw LLM arguments into whatever data structure you
+  actually want (a struct, a persisted record, an id). When the tool sets no
+  `processed_content`, `run/3` falls back to the LLM-supplied argument map. The
+  default schema tool simply hands `args` back as `processed_content`, so the
+  no-frills path still returns the LLM arguments. See "Shaping the result".
 
   ## Basic usage
 
@@ -29,7 +33,8 @@ defmodule Sagents.Extract do
 
       {:ok, result} = Sagents.Extract.run(agent, state, schema: schema)
 
-      # result is the LLM-supplied map: %{"title" => "...", "summary" => "..."}
+      # result is the submit tool's processed_content. For the default schema
+      # tool that is the LLM-supplied map: %{"title" => "...", "summary" => "..."}
 
   ## Options
 
@@ -39,7 +44,10 @@ defmodule Sagents.Extract do
     * `:tool` (required, unless `:schema` is given) — A pre-built
       `LangChain.Function`. Use this when you want full control over the
       tool's name, description, `parse_args` callback, etc. When supplied,
-      `:schema`, `:tool_name`, and `:description` are ignored.
+      `:schema`, `:tool_name`, and `:description` are ignored. Return
+      `{:ok, "text for LLM", processed_term}` from the tool body to make
+      `processed_term` the value `run/3` returns; a 2-tuple `{:ok, "text"}`
+      falls back to the LLM arguments. See "Shaping the result".
     * `:tool_name` (default `"submit_result"`) — Name of the submit tool the
       LLM will be required to call. Only meaningful when `:schema` is used.
     * `:description` (default a generic string) — Description sent to the LLM
@@ -56,12 +64,57 @@ defmodule Sagents.Extract do
 
   ## What `run/3` returns
 
-    * `{:ok, map()}` — The arguments the LLM passed to the submit tool, with
-      keys exactly as the provider returned them (or as the `parse_args`
-      callback processes them).
+    * `{:ok, term()}` — The submit tool's `processed_content`: the value the
+      tool body returns as the 3rd element of `{:ok, "text for LLM", term}`.
+      This can be any term — a map, a struct, a persisted record, an id. When
+      the tool sets no `processed_content` (it returned a 2-tuple
+      `{:ok, "text"}`), this falls back to the LLM-supplied argument map, with
+      keys exactly as the provider returned them. The default schema tool hands
+      `args` back as `processed_content`, so the schema path returns the LLM
+      arguments.
     * `{:error, term()}` — A `LangChainError` if the LLM never successfully
       called the submit tool within `max_runs`, if a same-named tool already
       exists on the agent, or anything else that `Sagents.Agent.execute/3` would surface.
+
+  ## Shaping the result
+
+  `run/3` returns whatever the submit tool *produces*, not just what the LLM
+  *emitted*. That lets the tool body turn the raw LLM arguments into the exact
+  data shape you want, in three escalating tiers:
+
+  1. **Raw arguments (default).** With `:schema` and no custom tool, `run/3`
+     returns the LLM-supplied argument map unchanged. Nothing to do.
+
+  2. **Process inside the tool body.** Supply a `:tool` whose body transforms,
+     validates, or persists the args and returns the shaped value as the 3rd
+     element. That value is what `run/3` returns; the LLM only ever sees the
+     2nd element (the string), never the 3rd.
+
+         submit =
+           LangChain.Function.new!(%{
+             name: "submit_result",
+             description: "Submit the structured result.",
+             parameters_schema: schema,
+             function: fn args, _ctx ->
+               # shape the raw LLM args into the data structure you want
+               person = %MyApp.Person{name: args["name"], age: args["age"]}
+               # (or persist here and return the inserted struct / id instead)
+               {:ok, "Saved \#{person.name}.", person}
+             end
+           })
+
+         {:ok, %MyApp.Person{} = person} =
+           Sagents.Extract.run(agent, state, tool: submit)
+
+  3. **`:parse_args` for coercion/validation.** A `LangChain.Function`
+     `:parse_args` callback (Zoi schemas work well) can coerce the args before
+     the body runs; pair it with a body that returns the shaped value as the
+     3rd element. Returning `{:error, "reason"}` from `parse_args` or the body
+     keeps the loop running so the LLM corrects the call — see "Validation and
+     retry".
+
+  Callers who only care about the raw arguments need none of this: a 2-tuple
+  `{:ok, "text"}`, or just using `:schema`, returns the LLM args.
 
   ## Provider-side `tool_choice`
 
@@ -154,7 +207,7 @@ defmodule Sagents.Extract do
   The `state` carries the full conversation (system messages, user prompts,
   any prior turns). See the module doc for option details.
   """
-  @spec run(Agent.t(), State.t(), opts()) :: {:ok, map()} | {:error, term()}
+  @spec run(Agent.t(), State.t(), opts()) :: {:ok, any()} | {:error, term()}
   def run(%Agent{} = agent, %State{} = state, opts) when is_list(opts) do
     with {:ok, submit_tool} <- build_submit_tool(opts),
          :ok <- check_tool_name_unique(agent, submit_tool.name) do
@@ -169,7 +222,26 @@ defmodule Sagents.Extract do
 
       augmented_agent
       |> Agent.execute(state, execute_opts)
-      |> AgentResult.tool_arguments()
+      |> extract_result()
+    end
+  end
+
+  # Prefer the submit tool's `processed_content` (position 3 of its 3-tuple
+  # return) so a tool that validates/parses/persists can hand its processed
+  # result back through Extract. Fall back to the LLM-supplied arguments only
+  # when the tool set no `processed_content` (e.g. it returned a 2-tuple) — the
+  # default submit tool passes `args` through, so the schema path is unchanged.
+  # Genuine failures (until_tool_not_called, interrupt, pause) pass through.
+  defp extract_result(execute_return) do
+    case AgentResult.processed_content(execute_return) do
+      {:ok, content} ->
+        {:ok, content}
+
+      {:error, %LangChainError{type: "no_processed_content"}} ->
+        AgentResult.tool_arguments(execute_return)
+
+      {:error, _reason} = err ->
+        err
     end
   end
 

--- a/lib/sagents/extract.ex
+++ b/lib/sagents/extract.ex
@@ -98,8 +98,10 @@ defmodule Sagents.Extract do
        or `:max_runs` is hit. Write error messages that are actionable — the
        LLM is the one reading them.
 
-  Nothing here needs to know about either layer. They fall out of how
-  `until_tool` already loops.
+  Nothing here needs to know about either layer. The retry behavior is driven
+  by `Extract` running with `until_tool_success: <submit tool>`: an error result
+  from the submit tool keeps the loop running (feeding the error back to the
+  LLM) instead of terminating the run with malformed args.
 
   ## Middleware compatibility
 
@@ -159,8 +161,10 @@ defmodule Sagents.Extract do
       augmented_agent = %{agent | tools: agent.tools ++ [submit_tool]}
       max_runs = Keyword.get(opts, :max_runs, @default_max_runs)
 
+      # Use the success variant so a validation error from the submit tool keeps
+      # the loop running (the LLM retries) instead of terminating with bad args.
       execute_opts =
-        [until_tool: submit_tool.name, max_runs: max_runs]
+        [until_tool_success: submit_tool.name, max_runs: max_runs]
         |> maybe_put_callbacks(opts)
 
       augmented_agent

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -167,6 +167,7 @@ defmodule Sagents.Middleware.SubAgent do
                                         "as `task_name` and provide clear `instructions` describing what the " <>
                                         "handler should accomplish. Do not guess at task types on your own."
 
+  alias Sagents.Modes.AgentExecution
   alias Sagents.State
   alias Sagents.SubAgent
   alias Sagents.SubAgentServer
@@ -204,13 +205,19 @@ defmodule Sagents.Middleware.SubAgent do
         # Build descriptions map for tool schema
         descriptions = SubAgent.build_descriptions(subagents)
 
-        # Build until_tool map from subagent configs that have until_tool set
-        until_tool_map =
+        # Collapse each config's mutually-exclusive until_tool / until_tool_success
+        # into the internal {tool_name, require_success} representation, keyed by
+        # task name. Tasks with neither set are omitted.
+        until_tool_targets =
           subagents
-          |> Enum.filter(fn config ->
-            is_struct(config, SubAgent.Config) and config.until_tool != nil
+          |> Enum.filter(&is_struct(&1, SubAgent.Config))
+          |> Enum.flat_map(fn config ->
+            case AgentExecution.collapse_until_tool(config.until_tool, config.until_tool_success) do
+              {nil, _require_success} -> []
+              {name, require_success} -> [{config.name, {name, require_success}}]
+            end
           end)
-          |> Map.new(fn config -> {config.name, config.until_tool} end)
+          |> Map.new()
 
         # Build display_texts map: %{task_name => display_text}.
         # Used by the :on_tool_call_identified callback to re-label the
@@ -250,7 +257,7 @@ defmodule Sagents.Middleware.SubAgent do
           agent_id: agent_id,
           model: model,
           block_middleware: block_middleware,
-          until_tool_map: until_tool_map,
+          until_tool_targets: until_tool_targets,
           display_texts_map: display_texts_map,
           use_instructions_map: use_instructions_map,
           include_task_list: include_task_list
@@ -396,7 +403,7 @@ defmodule Sagents.Middleware.SubAgent do
       subagents: subagents,
       descriptions: config.descriptions,
       block_middleware: config.block_middleware,
-      until_tool_map: config.until_tool_map,
+      until_tool_targets: Map.get(config, :until_tool_targets, %{}),
       has_use_instructions: not Enum.empty?(Map.get(config, :use_instructions_map, %{}))
     }
   end
@@ -674,9 +681,10 @@ defmodule Sagents.Middleware.SubAgent do
         start_dynamic_subagent(instructions, args, context, config, per_call_initial)
 
       {:ok, agent_config} ->
-        # Look up until_tool configuration for this subagent type
-        until_tool_map = Map.get(config, :until_tool_map, %{})
-        until_tool = Map.get(until_tool_map, task_name)
+        # Look up the collapsed until-tool target for this subagent type:
+        # {tool_name, require_success}, or {nil, false} when not configured.
+        until_tool_targets = Map.get(config, :until_tool_targets, %{})
+        {until_tool, require_tool_success} = Map.get(until_tool_targets, task_name, {nil, false})
 
         # Extract parent's tool_context, metadata, runtime, and scope so
         # SubAgent tools see the same context as parent tools. Agent.build_chain
@@ -700,6 +708,7 @@ defmodule Sagents.Middleware.SubAgent do
                 compiled_agent: compiled.agent,
                 initial_messages: final_initial,
                 until_tool: until_tool,
+                require_tool_success: require_tool_success,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
                 parent_runtime: parent_runtime,
@@ -714,6 +723,7 @@ defmodule Sagents.Middleware.SubAgent do
                 agent_config: agent,
                 initial_messages: per_call_initial,
                 until_tool: until_tool,
+                require_tool_success: require_tool_success,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
                 parent_runtime: parent_runtime,

--- a/lib/sagents/mode/steps.ex
+++ b/lib/sagents/mode/steps.ex
@@ -71,6 +71,35 @@ defmodule Sagents.Mode.Steps do
 
   def propagate_state(terminal, _opts), do: terminal
 
+  @doc """
+  Until-tool termination that fires only on a *successful* matching result.
+
+  Like LangChain's `check_until_tool/2`, but ignores tool results with
+  `is_error: true`. When the target tool is called but returns an error, the
+  pipeline continues (`{:continue, chain}`) so the loop re-runs and the LLM
+  sees the error result and can correct the call. This is the default behavior
+  for `until_tool`; pass `until_tool_success: false` to use name-only matching.
+
+  Reads `:tool_names` from opts (a list of tool-name strings, populated by
+  `Sagents.Modes.AgentExecution`).
+  """
+  def check_until_tool_success({:continue, chain}, opts) do
+    names = Keyword.get(opts, :tool_names, [])
+
+    case chain.last_message do
+      %{role: :tool, tool_results: results} when is_list(results) ->
+        case Enum.find(results, &(&1.name in names and not &1.is_error)) do
+          nil -> {:continue, chain}
+          result -> {:ok, chain, result}
+        end
+
+      _other ->
+        {:continue, chain}
+    end
+  end
+
+  def check_until_tool_success(terminal, _opts), do: terminal
+
   # ── Loop Boundary (with until_tool enforcement) ────────────────
 
   @doc """

--- a/lib/sagents/modes/agent_execution.ex
+++ b/lib/sagents/modes/agent_execution.ex
@@ -20,8 +20,17 @@ defmodule Sagents.Modes.AgentExecution do
   - `:should_pause?` — Zero-arity function for infrastructure pause
   - `:max_runs` — Maximum LLM calls (default: 50)
   - `:until_tool` — Tool name (string) or list of tool names. When set, the
-    mode will return `{:ok, chain, tool_result}` when the target tool is called,
+    mode returns `{:ok, chain, tool_result}` once the target tool is *called*,
     or `{:error, chain, %LangChainError{}}` if the LLM stops without calling it.
+  - `:require_tool_success` — Boolean (default `false`). When `true`, the mode
+    terminates only when the target tool returns a *successful* (non-error)
+    result; an error result keeps the loop running so the LLM can correct the
+    call, bounded by `:max_runs`.
+
+  These two are the mode's internal representation. Callers using
+  `Sagents.Agent.execute/3` pass the friendlier mutually-exclusive
+  `:until_tool` / `:until_tool_success` (each naming the target tool), which are
+  collapsed into the pair above via `collapse_until_tool/2`.
   """
 
   @behaviour LangChain.Chains.LLMChain.Mode
@@ -53,32 +62,59 @@ defmodule Sagents.Modes.AgentExecution do
 
   # ── Private Helpers ──────────────────────────────────────────────
 
+  # `:until_tool` names the target tool (string or list); `:require_tool_success`
+  # (boolean) says whether it must return a non-error result. Populates the
+  # internal `:tool_names` and `:until_tool_active` keys read downstream;
+  # `:require_tool_success` is already a boolean in opts (default false).
   defp normalize_until_tool_opts(opts) do
-    case Keyword.get(opts, :until_tool) do
+    case normalize_tool_names(Keyword.get(opts, :until_tool)) do
       nil ->
         opts
 
-      # Empty list means no until_tool behavior
-      [] ->
+      names ->
         opts
-
-      tool_name when is_binary(tool_name) ->
-        opts
-        |> Keyword.put(:tool_names, [tool_name])
-        |> Keyword.put(:until_tool_active, true)
-
-      tool_names when is_list(tool_names) ->
-        opts
-        |> Keyword.put(:tool_names, tool_names)
+        |> Keyword.put(:tool_names, names)
         |> Keyword.put(:until_tool_active, true)
     end
   end
+
+  defp normalize_tool_names(nil), do: nil
+  defp normalize_tool_names([]), do: nil
+  defp normalize_tool_names(name) when is_binary(name), do: [name]
+  defp normalize_tool_names(names) when is_list(names), do: names
 
   defp maybe_check_until_tool(pipeline_result, opts) do
-    if Keyword.get(opts, :until_tool_active, false) do
-      check_until_tool(pipeline_result, opts)
-    else
-      pipeline_result
+    cond do
+      not Keyword.get(opts, :until_tool_active, false) ->
+        pipeline_result
+
+      # require success — terminate only on a successful matching result.
+      Keyword.get(opts, :require_tool_success, false) ->
+        check_until_tool_success(pipeline_result, opts)
+
+      # any call to the target tool ends the run.
+      true ->
+        check_until_tool(pipeline_result, opts)
     end
   end
+
+  @doc """
+  Collapse the public `:until_tool` / `:until_tool_success` either-or spelling
+  into the internal `{tool_name | nil, require_success_boolean}` representation.
+
+  The friendly either-or options are mutually exclusive (validated at the public
+  boundary in `Sagents.Agent` / `Sagents.SubAgent.Config`). If both are non-nil
+  when this is called, the success variant wins.
+
+  Used at the two collapse points — `Sagents.Agent.execute/3` (opts → mode opts)
+  and `Sagents.Middleware.SubAgent` (config → sub-agent construction) — so the
+  rest of the system carries only `:until_tool` + `:require_tool_success`.
+  """
+  @spec collapse_until_tool(term(), term()) :: {term() | nil, boolean()}
+  def collapse_until_tool(_until_tool, until_tool_success) when not is_nil(until_tool_success),
+    do: {until_tool_success, true}
+
+  def collapse_until_tool(until_tool, nil) when not is_nil(until_tool), do: {until_tool, false}
+
+  def collapse_until_tool(_until_tool, _until_tool_success), do: {nil, false}
 end

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -131,8 +131,13 @@ defmodule Sagents.SubAgent do
     # Error information (when status = :error)
     field :error, :any, virtual: true
 
-    # Until-tool termination: tool name (string) or list of tool names
+    # Until-tool termination: tool name (string) or list of tool names.
     field :until_tool, :any, virtual: true
+
+    # When true, :until_tool stops only on a successful (non-error) result; an
+    # error result keeps the loop running so the LLM can retry. Defaults to
+    # false (any call to :until_tool ends the run).
+    field :require_tool_success, :boolean, default: false, virtual: true
 
     # Maximum number of LLM calls per execution. Overrides the mode's default
     # (50 for AgentExecution). See Agent :max_runs for details.
@@ -151,6 +156,7 @@ defmodule Sagents.SubAgent do
           interrupt_data: map() | nil,
           error: term() | nil,
           until_tool: String.t() | [String.t()] | nil,
+          require_tool_success: boolean(),
           id: String.t() | nil,
           parent_agent_id: String.t() | nil,
           created_at: DateTime.t() | nil
@@ -291,6 +297,7 @@ defmodule Sagents.SubAgent do
     # `:scope` field if the caller didn't pass one (e.g., direct new_from_compiled).
     scope = Keyword.get(opts, :scope, agent.scope)
     until_tool = Keyword.get(opts, :until_tool)
+    require_tool_success = Keyword.get(opts, :require_tool_success, false)
     max_runs = Keyword.get(opts, :max_runs)
 
     sub_agent_id = "#{parent_agent_id}-sub-#{:erlang.unique_integer([:positive])}"
@@ -337,6 +344,7 @@ defmodule Sagents.SubAgent do
       chain: chain,
       interrupt_on: interrupt_on,
       until_tool: until_tool,
+      require_tool_success: require_tool_success,
       max_runs: max_runs,
       status: :idle,
       created_at: DateTime.utc_now()
@@ -697,6 +705,7 @@ defmodule Sagents.SubAgent do
   def build_mode_opts(%SubAgent{
         interrupt_on: interrupt_on,
         until_tool: until_tool,
+        require_tool_success: require_tool_success,
         max_runs: max_runs
       }) do
     opts = [mode: Sagents.Modes.AgentExecution]
@@ -722,8 +731,13 @@ defmodule Sagents.SubAgent do
 
     opts =
       case until_tool do
-        nil -> opts
-        ut -> Keyword.put(opts, :until_tool, ut)
+        nil ->
+          opts
+
+        ut ->
+          opts
+          |> Keyword.put(:until_tool, ut)
+          |> Keyword.put(:require_tool_success, require_tool_success)
       end
 
     opts =
@@ -782,6 +796,9 @@ defmodule Sagents.SubAgent do
       field :middleware, {:array, :any}, default: [], virtual: true
       field :interrupt_on, :map
       field :until_tool, :any, virtual: true
+      # See SubAgent.until_tool_success. Tool name (string) or list; mutually
+      # exclusive with :until_tool. Stops only on a successful result.
+      field :until_tool_success, :any, virtual: true
       field :max_runs, :integer, virtual: true
     end
 
@@ -798,6 +815,7 @@ defmodule Sagents.SubAgent do
             middleware: list(),
             interrupt_on: map() | nil,
             until_tool: String.t() | [String.t()] | nil,
+            until_tool_success: String.t() | [String.t()] | nil,
             max_runs: integer() | nil
           }
 
@@ -816,6 +834,7 @@ defmodule Sagents.SubAgent do
         :middleware,
         :interrupt_on,
         :until_tool,
+        :until_tool_success,
         :max_runs
       ])
       |> validate_required([:name, :description, :tools])
@@ -857,25 +876,43 @@ defmodule Sagents.SubAgent do
     end
 
     defp validate_until_tool(changeset) do
-      until_tool = get_field(changeset, :until_tool)
+      call = get_field(changeset, :until_tool)
+      success = get_field(changeset, :until_tool_success)
       tools = get_field(changeset, :tools)
 
-      case until_tool do
-        nil ->
+      cond do
+        not is_nil(call) and not is_nil(success) ->
+          add_error(
+            changeset,
+            :until_tool_success,
+            "cannot be set together with :until_tool (they are mutually exclusive)"
+          )
+
+        not is_nil(call) ->
+          validate_until_tool_value(changeset, :until_tool, call, tools)
+
+        not is_nil(success) ->
+          validate_until_tool_value(changeset, :until_tool_success, success, tools)
+
+        true ->
           changeset
-
-        name when is_binary(name) ->
-          validate_tool_names_exist(changeset, [name], tools)
-
-        names when is_list(names) ->
-          validate_tool_names_exist(changeset, names, tools)
-
-        _other ->
-          add_error(changeset, :until_tool, "must be a string or list of strings")
       end
     end
 
-    defp validate_tool_names_exist(changeset, names, tools) when is_list(tools) do
+    defp validate_until_tool_value(changeset, key, value, tools) do
+      case value do
+        name when is_binary(name) ->
+          validate_tool_names_exist(changeset, key, [name], tools)
+
+        names when is_list(names) ->
+          validate_tool_names_exist(changeset, key, names, tools)
+
+        _other ->
+          add_error(changeset, key, "must be a string or list of strings")
+      end
+    end
+
+    defp validate_tool_names_exist(changeset, key, names, tools) when is_list(tools) do
       tool_names =
         tools
         |> Enum.filter(&is_struct(&1, LangChain.Function))
@@ -889,13 +926,13 @@ defmodule Sagents.SubAgent do
       else
         add_error(
           changeset,
-          :until_tool,
+          key,
           "references tools that are not in the tools list: #{Enum.join(missing, ", ")}"
         )
       end
     end
 
-    defp validate_tool_names_exist(changeset, _names, _tools), do: changeset
+    defp validate_tool_names_exist(changeset, _key, _names, _tools), do: changeset
 
     # At least one of system_prompt, instructions, or system_prompt_override
     # must be present so the sub-agent has *some* task framing beyond the

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -1012,6 +1012,47 @@ defmodule Sagents.AgentTest do
       assert msg =~ "not found"
     end
 
+    test "until_tool_success validation: invalid tool name returns error" do
+      {:ok, agent} =
+        Agent.new(
+          %{model: mock_model(), tools: [], middleware: []},
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      assert {:error, msg} =
+               Agent.execute(agent, initial_state, until_tool_success: "nonexistent")
+
+      assert msg =~ "until_tool_success"
+      assert msg =~ "not found"
+    end
+
+    test "until_tool and until_tool_success are mutually exclusive" do
+      search_tool =
+        LangChain.Function.new!(%{
+          name: "search",
+          description: "Search",
+          function: fn _args, _params -> {:ok, "result"} end
+        })
+
+      {:ok, agent} =
+        Agent.new(
+          %{model: mock_model(), tools: [search_tool], middleware: []},
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      assert {:error, msg} =
+               Agent.execute(agent, initial_state,
+                 until_tool: "search",
+                 until_tool_success: "search"
+               )
+
+      assert msg =~ "mutually exclusive"
+    end
+
     test "until_tool validation: multiple tools, one invalid" do
       search_tool =
         LangChain.Function.new!(%{

--- a/test/sagents/extract_test.exs
+++ b/test/sagents/extract_test.exs
@@ -203,4 +203,70 @@ defmodule Sagents.ExtractTest do
       assert_received :mw_callback_fired
     end
   end
+
+  describe "run/3 — validation and retry" do
+    # Submit tool that enforces a business rule the JSON schema can't: only a
+    # "good" title is accepted. Anything else returns an error result.
+    defp validating_tool do
+      LangChain.Function.new!(%{
+        name: "submit_result",
+        description: "Submit the result",
+        parameters_schema: @schema,
+        function: fn
+          %{"title" => "good"} = args, _ctx -> {:ok, Jason.encode!(args), args}
+          _args, _ctx -> {:error, "title must be 'good'"}
+        end
+      })
+    end
+
+    test "retries past a validation error and returns the corrected arguments" do
+      agent = build_agent()
+
+      # First call: rejected by the tool body -> error result -> loop continues.
+      ChatAnthropic
+      |> expect(:call, fn _model, _messages, _tools ->
+        call =
+          ToolCall.new!(%{
+            call_id: "c1",
+            name: "submit_result",
+            arguments: %{"title" => "bad", "summary" => "S"}
+          })
+
+        {:ok, [Message.new_assistant!(%{tool_calls: [call]})]}
+      end)
+      # Second call: corrected args -> success -> run completes.
+      |> expect(:call, fn _model, _messages, _tools ->
+        call =
+          ToolCall.new!(%{
+            call_id: "c2",
+            name: "submit_result",
+            arguments: %{"title" => "good", "summary" => "S"}
+          })
+
+        {:ok, [Message.new_assistant!(%{tool_calls: [call]})]}
+      end)
+
+      assert {:ok, %{"title" => "good", "summary" => "S"}} =
+               Extract.run(agent, build_state(), tool: validating_tool())
+    end
+
+    test "returns an error rather than malformed args when validation never passes" do
+      agent = build_agent()
+
+      # The model always submits bad args, so the tool always errors.
+      stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        call =
+          ToolCall.new!(%{
+            call_id: "c#{System.unique_integer([:positive])}",
+            name: "submit_result",
+            arguments: %{"title" => "bad", "summary" => "S"}
+          })
+
+        {:ok, [Message.new_assistant!(%{tool_calls: [call]})]}
+      end)
+
+      assert {:error, %LangChainError{}} =
+               Extract.run(agent, build_state(), tool: validating_tool(), max_runs: 2)
+    end
+  end
 end

--- a/test/sagents/extract_test.exs
+++ b/test/sagents/extract_test.exs
@@ -111,6 +111,43 @@ defmodule Sagents.ExtractTest do
     end
   end
 
+  describe "run/3 — processed_content" do
+    test "returns the tool's processed_content, not the raw LLM args" do
+      # Tool shapes the raw args into a different structure and hands it back as
+      # the 3rd element. run/3 should return that, not the LLM-supplied map.
+      tool =
+        LangChain.Function.new!(%{
+          name: "submit_result",
+          description: "Submit",
+          parameters_schema: @schema,
+          function: fn args, _ctx ->
+            {:ok, "saved", %{id: 42, title: args["title"]}}
+          end
+        })
+
+      agent = build_agent()
+      stub_submit_call("submit_result", %{"title" => "T", "summary" => "S"})
+
+      assert {:ok, %{id: 42, title: "T"}} = Extract.run(agent, build_state(), tool: tool)
+    end
+
+    test "falls back to LLM args when the tool returns a 2-tuple (no processed_content)" do
+      tool =
+        LangChain.Function.new!(%{
+          name: "submit_result",
+          description: "Submit",
+          parameters_schema: @schema,
+          function: fn args, _ctx -> {:ok, Jason.encode!(args)} end
+        })
+
+      agent = build_agent()
+      stub_submit_call("submit_result", %{"title" => "T", "summary" => "S"})
+
+      assert {:ok, %{"title" => "T", "summary" => "S"}} =
+               Extract.run(agent, build_state(), tool: tool)
+    end
+  end
+
   describe "run/3 — error paths" do
     test "errors when neither :schema nor :tool is supplied" do
       agent = build_agent()

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -169,7 +169,7 @@ defmodule Sagents.Middleware.SubAgentTest do
       assert summary.descriptions["agent1"] == "First agent"
       assert summary.descriptions["agent2"] == "Second agent"
       assert is_list(summary.block_middleware)
-      assert is_map(summary.until_tool_map)
+      assert is_map(summary.until_tool_targets)
       assert summary.has_use_instructions == false
     end
 
@@ -2104,7 +2104,7 @@ defmodule Sagents.Middleware.SubAgentTest do
   end
 
   describe "until_tool configuration" do
-    test "init stores until_tool_map from subagent configs with until_tool" do
+    test "init stores until_tool_targets from configs with until_tool / until_tool_success" do
       config_with_until =
         SubAgent.Config.new!(%{
           name: "finisher",
@@ -2114,22 +2114,34 @@ defmodule Sagents.Middleware.SubAgentTest do
           until_tool: "finish_tool"
         })
 
+      config_with_success =
+        SubAgent.Config.new!(%{
+          name: "validator",
+          description: "Agent with until_tool_success",
+          system_prompt: "You are an agent that uses submit_tool",
+          tools: [test_tool("submit_tool")],
+          until_tool_success: "submit_tool"
+        })
+
       config_without_until = build_subagent_config("plain", "Plain agent")
 
       opts = [
         agent_id: "parent",
         model: test_model(),
         middleware: [],
-        subagents: [config_with_until, config_without_until]
+        subagents: [config_with_until, config_with_success, config_without_until]
       ]
 
       assert {:ok, middleware_config} = SubAgentMiddleware.init(opts)
-      assert is_map(middleware_config.until_tool_map)
-      assert middleware_config.until_tool_map["finisher"] == "finish_tool"
-      refute Map.has_key?(middleware_config.until_tool_map, "plain")
+      assert is_map(middleware_config.until_tool_targets)
+      # until_tool collapses to require_success: false
+      assert middleware_config.until_tool_targets["finisher"] == {"finish_tool", false}
+      # until_tool_success collapses to require_success: true
+      assert middleware_config.until_tool_targets["validator"] == {"submit_tool", true}
+      refute Map.has_key?(middleware_config.until_tool_targets, "plain")
     end
 
-    test "init stores empty until_tool_map when no configs have until_tool" do
+    test "init stores empty until_tool_targets when no configs have until-tool set" do
       config = build_subagent_config("plain", "Plain agent")
 
       opts = [
@@ -2140,7 +2152,7 @@ defmodule Sagents.Middleware.SubAgentTest do
       ]
 
       assert {:ok, middleware_config} = SubAgentMiddleware.init(opts)
-      assert middleware_config.until_tool_map == %{}
+      assert middleware_config.until_tool_targets == %{}
     end
 
     test "SubAgent created with until_tool from config" do

--- a/test/sagents/mode/steps_test.exs
+++ b/test/sagents/mode/steps_test.exs
@@ -381,4 +381,72 @@ defmodule Sagents.Mode.StepsTest do
       assert {:pause, ^chain} = result
     end
   end
+
+  describe "check_until_tool_success/2" do
+    defp tool_result(name, opts \\ []) do
+      ToolResult.new!(%{
+        tool_call_id: Keyword.get(opts, :call_id, "call_1"),
+        name: name,
+        content: Keyword.get(opts, :content, "ok"),
+        is_error: Keyword.get(opts, :is_error, false)
+      })
+    end
+
+    defp chain_with_last_tool_message(results) do
+      message = Message.new_tool_result!(%{tool_results: results})
+      %LLMChain{last_message: message}
+    end
+
+    test "terminates on a successful matching result" do
+      chain = chain_with_last_tool_message([tool_result("submit")])
+      opts = [tool_names: ["submit"]]
+
+      assert {:ok, ^chain, result} = Steps.check_until_tool_success({:continue, chain}, opts)
+      assert result.name == "submit"
+      refute result.is_error
+    end
+
+    test "continues when the matching result is an error" do
+      chain = chain_with_last_tool_message([tool_result("submit", is_error: true)])
+      opts = [tool_names: ["submit"]]
+
+      assert {:continue, ^chain} = Steps.check_until_tool_success({:continue, chain}, opts)
+    end
+
+    test "continues when there is no matching result" do
+      chain = chain_with_last_tool_message([tool_result("other_tool")])
+      opts = [tool_names: ["submit"]]
+
+      assert {:continue, ^chain} = Steps.check_until_tool_success({:continue, chain}, opts)
+    end
+
+    test "continues when last message is not a tool message" do
+      chain = %LLMChain{last_message: Message.new_assistant!(%{content: "hi"})}
+      opts = [tool_names: ["submit"]]
+
+      assert {:continue, ^chain} = Steps.check_until_tool_success({:continue, chain}, opts)
+    end
+
+    test "fires on the success when an error and a success are both present" do
+      results = [
+        tool_result("submit", call_id: "c1", is_error: true),
+        tool_result("submit", call_id: "c2", content: "good")
+      ]
+
+      chain = chain_with_last_tool_message(results)
+      opts = [tool_names: ["submit"]]
+
+      assert {:ok, ^chain, result} = Steps.check_until_tool_success({:continue, chain}, opts)
+      assert result.tool_call_id == "c2"
+      refute result.is_error
+    end
+
+    test "terminal tuples pass through unchanged" do
+      chain = %LLMChain{}
+
+      assert {:ok, ^chain} = Steps.check_until_tool_success({:ok, chain}, [])
+      assert {:ok, ^chain, :x} = Steps.check_until_tool_success({:ok, chain, :x}, [])
+      assert {:error, ^chain, :y} = Steps.check_until_tool_success({:error, chain, :y}, [])
+    end
+  end
 end

--- a/test/sagents/modes/agent_execution_test.exs
+++ b/test/sagents/modes/agent_execution_test.exs
@@ -9,7 +9,7 @@ defmodule Sagents.Modes.AgentExecutionTest do
   alias LangChain.Message.ToolCall
   alias LangChain.Message.ToolResult
   alias LangChain.LangChainError
-  alias LangChain.Function, as: LFunction
+  alias LangChain.Function
   alias Sagents.MiddlewareEntry
   alias Sagents.Middleware.HumanInTheLoop
 
@@ -37,7 +37,7 @@ defmodule Sagents.Modes.AgentExecutionTest do
   end
 
   defp submit_tool do
-    LFunction.new!(%{
+    Function.new!(%{
       name: "submit_report",
       description: "Submit a report",
       parameters_schema: %{
@@ -49,7 +49,7 @@ defmodule Sagents.Modes.AgentExecutionTest do
   end
 
   defp other_tool do
-    LFunction.new!(%{
+    Function.new!(%{
       name: "search",
       description: "Search for information",
       parameters_schema: %{
@@ -61,7 +61,7 @@ defmodule Sagents.Modes.AgentExecutionTest do
   end
 
   defp finalize_tool do
-    LFunction.new!(%{
+    Function.new!(%{
       name: "finalize",
       description: "Finalize the work",
       parameters_schema: %{
@@ -69,6 +69,23 @@ defmodule Sagents.Modes.AgentExecutionTest do
         properties: %{"status" => %{type: "string"}}
       },
       function: fn args, _ctx -> {:ok, Jason.encode!(args)} end
+    })
+  end
+
+  # Submit tool whose body validates business rules: only "good" titles
+  # succeed; anything else returns {:error, ...} (an error ToolResult).
+  defp validating_submit_tool do
+    Function.new!(%{
+      name: "submit_report",
+      description: "Submit a report",
+      parameters_schema: %{
+        type: "object",
+        properties: %{"title" => %{type: "string"}}
+      },
+      function: fn
+        %{"title" => "good"} = args, _ctx -> {:ok, Jason.encode!(args)}
+        _args, _ctx -> {:error, "title must be 'good'"}
+      end
     })
   end
 
@@ -260,6 +277,64 @@ defmodule Sagents.Modes.AgentExecutionTest do
 
       assert {:error, %LLMChain{}, %LangChainError{type: "exceeded_max_runs"} = error} = result
       assert error.message =~ "Exceeded maximum number of runs (3/3)"
+    end
+  end
+
+  describe "require_tool_success: true (retry on error)" do
+    test "retries on an error result and terminates on the later success" do
+      tools = [validating_submit_tool()]
+      chain = build_chain(tools, [Message.new_user!("Write a report")])
+
+      # Iteration 1: bad args -> tool returns {:error, ...} -> loop continues
+      ChatAnthropic
+      |> expect(:call, fn _model, _messages, _tools ->
+        {:ok, [assistant_with_tool_call("submit_report", %{"title" => "bad"}, "call_1")]}
+      end)
+      # Iteration 2: corrected args -> success -> terminate
+      |> expect(:call, fn _model, _messages, _tools ->
+        {:ok, [assistant_with_tool_call("submit_report", %{"title" => "good"}, "call_2")]}
+      end)
+
+      result =
+        AgentExecution.run(chain, until_tool: "submit_report", require_tool_success: true)
+
+      assert {:ok, %LLMChain{}, %ToolResult{name: "submit_report", is_error: false}} = result
+    end
+
+    test "exhausts max_runs when the target tool always errors" do
+      tools = [validating_submit_tool()]
+      chain = build_chain(tools, [Message.new_user!("Write a report")])
+
+      # LLM always submits bad args -> always an error result -> never terminates
+      stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:ok, [assistant_with_tool_call("submit_report", %{"title" => "bad"}, "call_x")]}
+      end)
+
+      result =
+        AgentExecution.run(chain,
+          until_tool: "submit_report",
+          require_tool_success: true,
+          max_runs: 3
+        )
+
+      assert {:error, %LLMChain{}, %LangChainError{type: "exceeded_max_runs"}} = result
+    end
+  end
+
+  describe "until_tool: target name (stop on call)" do
+    test "terminates on the first call even when the result is an error" do
+      tools = [validating_submit_tool()]
+      chain = build_chain(tools, [Message.new_user!("Write a report")])
+
+      # A single bad call. Call-based until_tool terminates on the error result.
+      ChatAnthropic
+      |> expect(:call, fn _model, _messages, _tools ->
+        {:ok, [assistant_with_tool_call("submit_report", %{"title" => "bad"}, "call_1")]}
+      end)
+
+      result = AgentExecution.run(chain, until_tool: "submit_report")
+
+      assert {:ok, %LLMChain{}, %ToolResult{name: "submit_report", is_error: true}} = result
     end
   end
 

--- a/test/sagents/sub_agent_test.exs
+++ b/test/sagents/sub_agent_test.exs
@@ -230,6 +230,58 @@ defmodule Sagents.SubAgentTest do
       assert {:ok, config} = SubAgentConfig.new(attrs)
       assert length(config.tools) == 3
     end
+
+    test "defaults until_tool_success to nil" do
+      attrs = %{
+        name: "test",
+        description: "Test",
+        system_prompt: "Test",
+        tools: [test_tool("submit")]
+      }
+
+      assert {:ok, config} = SubAgentConfig.new(attrs)
+      assert config.until_tool_success == nil
+    end
+
+    test "casts until_tool_success name" do
+      attrs = %{
+        name: "test",
+        description: "Test",
+        system_prompt: "Test",
+        tools: [test_tool("submit")],
+        until_tool_success: "submit"
+      }
+
+      assert {:ok, config} = SubAgentConfig.new(attrs)
+      assert config.until_tool_success == "submit"
+    end
+
+    test "rejects until_tool_success referencing an unknown tool" do
+      attrs = %{
+        name: "test",
+        description: "Test",
+        system_prompt: "Test",
+        tools: [test_tool("submit")],
+        until_tool_success: "missing"
+      }
+
+      assert {:error, changeset} = SubAgentConfig.new(attrs)
+      assert %{until_tool_success: [_msg]} = errors_on(changeset)
+    end
+
+    test "rejects setting both until_tool and until_tool_success" do
+      attrs = %{
+        name: "test",
+        description: "Test",
+        system_prompt: "Test",
+        tools: [test_tool("submit")],
+        until_tool: "submit",
+        until_tool_success: "submit"
+      }
+
+      assert {:error, changeset} = SubAgentConfig.new(attrs)
+      assert %{until_tool_success: [_msg]} = errors_on(changeset)
+    end
   end
 
   describe "SubAgentConfig.new!/1" do
@@ -1630,6 +1682,54 @@ defmodule Sagents.SubAgentTest do
       assert Keyword.get(opts, :mode) == Sagents.Modes.AgentExecution
       assert [%MiddlewareEntry{}] = Keyword.get(opts, :middleware)
       assert Keyword.get(opts, :until_tool) == ["submit", "finalize"]
+    end
+
+    test "threads require_tool_success: true alongside until_tool when set" do
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "test-parent",
+          instructions: "Do something",
+          agent_config: test_agent(),
+          parent_state: %{messages: []},
+          until_tool: "submit",
+          require_tool_success: true
+        )
+
+      opts = SubAgent.build_mode_opts(subagent)
+
+      assert Keyword.get(opts, :until_tool) == "submit"
+      assert Keyword.get(opts, :require_tool_success) == true
+    end
+
+    test "threads require_tool_success: false by default with until_tool" do
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "test-parent",
+          instructions: "Do something",
+          agent_config: test_agent(),
+          parent_state: %{messages: []},
+          until_tool: "submit"
+        )
+
+      opts = SubAgent.build_mode_opts(subagent)
+
+      assert Keyword.get(opts, :until_tool) == "submit"
+      assert Keyword.get(opts, :require_tool_success) == false
+    end
+
+    test "omits until-tool keys entirely when no until_tool is set" do
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "test-parent",
+          instructions: "Do something",
+          agent_config: test_agent(),
+          parent_state: %{messages: []}
+        )
+
+      opts = SubAgent.build_mode_opts(subagent)
+
+      refute Keyword.has_key?(opts, :until_tool)
+      refute Keyword.has_key?(opts, :require_tool_success)
     end
 
     test "does not include middleware when interrupt_on is empty map" do


### PR DESCRIPTION
## Problem

`:until_tool` terminates an agent run as soon as the target tool is *called*, regardless of whether the call would have succeeded. That is wrong for the validate-and-retry pattern: when a submit tool rejects bad arguments with an error result, the run ends carrying malformed data instead of letting the model correct itself. `Sagents.Extract` is built directly on this loop, so its retry story was broken by the same limitation — and it always returned the raw LLM arguments, giving the tool no way to reject the input back to the LLM or hand back a shaped result.

## Solution

Adds a sibling completion option, `:until_tool_success`, that stops only when the target tool returns a *successful* (non-error) result. An error result keeps the loop running so the LLM sees the error and can retry, bounded by `:max_runs`.

The two public options are mutually exclusive and validated at every entry boundary (`Agent.execute/3`, `Agent.resume/4`, and `SubAgent.Config`). Internally they collapse — via the new `Sagents.Modes.AgentExecution.collapse_until_tool/2` — into a single `{tool_name, require_success}` representation, so the rest of the pipeline carries only `:until_tool` + `:require_tool_success`. Termination is decided by the new `Sagents.Mode.Steps.check_until_tool_success/2`, which mirrors LangChain's `check_until_tool/2` but skips results with `is_error: true`.

`Sagents.Extract` now runs with `until_tool_success` so a validation error from its submit tool retries instead of terminating with bad arguments. `Extract.run/3` also now returns the submit tool's `processed_content` (the 3rd element of a `{:ok, "text for LLM", term}` tool return), so a tool can shape the raw LLM args into a struct, persisted record, or id and have that be the return value. When the tool returns a 2-tuple it falls back to the LLM argument map, so the default `:schema` path is unchanged.

## Changes

- `lib/sagents/modes/agent_execution.ex` — Added `collapse_until_tool/2` and the `:require_tool_success` mode option; routes to success-only termination when set
- `lib/sagents/mode/steps.ex` — Added `check_until_tool_success/2`, which ignores error results so the loop continues on failure
- `lib/sagents/agent.ex` — New `:until_tool_success` option with mutual-exclusivity validation; added `execute_result` typespec and `@spec`s for `execute/3` and `resume/4`; expanded `@doc` with a validate-and-retry example
- `lib/sagents/sub_agent.ex` — `SubAgent` and `SubAgent.Config` carry `require_tool_success` / `until_tool_success`, with changeset validation for the new field
- `lib/sagents/middleware/sub_agent.ex` — Renamed `until_tool_map` to `until_tool_targets` holding the collapsed `{name, require_success}` pairs; threads `require_tool_success` into sub-agent construction
- `lib/sagents/extract.ex` — Switched to `until_tool_success` so submit-tool validation errors retry; `run/3` now returns the tool's `processed_content` with a fallback to LLM args; expanded `@moduledoc` with a "Shaping the result" section
- `lib/sagents/agent_result.ex` — Clarified `processed_content/1` docs vs `tool_arguments/1`
- Tests — Added coverage across `agent_test.exs`, `extract_test.exs`, `mode/steps_test.exs`, `modes/agent_execution_test.exs`, `middleware/sub_agent_test.exs`, and `sub_agent_test.exs` for retry-on-error, max_runs exhaustion, mutual exclusivity, validation, the public→internal collapse, and processed_content/fallback behavior