### PR TITLE
Add Horde participation-based membership with partition support

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1,0 +1,191 @@
+# Clustering & distribution (Horde)
+
+Sagents runs single-node by default. To distribute agents (and their
+filesystems) across a cluster, switch the backend to [Horde](https://hexdocs.pm/horde):
+
+```elixir
+config :sagents, :distribution, :horde   # default is :local
+```
+
+This swaps three pieces of infrastructure from their local equivalents to Horde:
+
+| Sagents process | `:local` | `:horde` |
+| --- | --- | --- |
+| `Sagents.Registry` | `Registry` | `Horde.Registry` |
+| `Sagents.AgentsDynamicSupervisor` | `DynamicSupervisor` | `Horde.DynamicSupervisor` |
+| `Sagents.FileSystem.FileSystemSupervisor` | `DynamicSupervisor` | `Horde.DynamicSupervisor` |
+
+You also need the `:horde` dependency:
+
+```elixir
+{:horde, "~> 0.10"}
+```
+
+## The one idea that explains everything: membership
+
+Horde places a process on a **member** node. So "which nodes can host an agent"
+is entirely a question of each Horde instance's **member set**. There is no
+separate "placement policy" — membership *is* the policy.
+
+Two sub-points are worth internalising, because they explain every surprising
+behaviour:
+
+1. **Member set vs. placement eligibility are different gates.** A node can be a
+   *member* without being a valid *placement target*. `Horde.UniformDistribution`
+   only places on members whose status is `:alive`, and a node reports `:alive`
+   only by actually running the Horde supervisor. A member that never starts
+   Horde stays `:uninitialized` and is skipped for placement.
+
+2. **The member set also drives the DeltaCrdt sync fan-out** — and that path does
+   *not* filter by `:alive`. Every member, alive or not, is a CRDT sync
+   neighbour. An over-broad member set therefore bloats sync traffic (and is the
+   root cause of intermittent `:via` registration timeouts on busy clusters),
+   even if placement itself looks correct.
+
+The practical upshot: **scoping the member set is what matters**, not just where
+processes happen to land.
+
+## Choosing a `members` mode
+
+Configure under `:sagents, :horde`:
+
+```elixir
+config :sagents, :horde, members: <mode>
+```
+
+| Mode | Dynamic? | Scope | Use when |
+| --- | --- | --- | --- |
+| `:auto` (default) | yes (`Horde.NodeListener`) | **all** visible BEAM nodes | every node in the Erlang cluster should host agents |
+| `:participation` | yes (`:pg`) | nodes running `Sagents.Supervisor` | the cluster mixes roles; only some nodes should host agents |
+
+These are the only two modes. (Static `:members` forms — a list, `function/0`,
+or `{m, f, a}` — are intentionally not supported; both modes above are dynamic
+and cover the real cases.)
+
+### `:auto` — all visible nodes
+
+`:auto` is passed straight to Horde, which runs a `Horde.NodeListener` and keeps
+membership equal to `Node.list([:visible, :this])`. Correct **only if every
+connected Elixir node should host agents.** If your cluster meshes unrelated
+roles (web, jobs, scans, …) into one Erlang cluster — e.g. a shared libcluster
+selector — `:auto` pulls all of them in. Placement stays correct (non-Horde
+nodes never go `:alive`), but the CRDT fan-out spans every node. Prefer
+`:participation` there.
+
+### `:participation` — scoped to nodes running Sagents (recommended for mixed clusters)
+
+```elixir
+config :sagents, :distribution, :horde
+config :sagents, :horde, members: :participation
+```
+
+Membership becomes exactly the nodes that run `Sagents.Supervisor`. Each such
+node joins an OTP `:pg` group; `Sagents.Horde.MembershipManager` (started
+automatically, with its `:pg` scope) sets Horde's members to that group's nodes
+and updates them on `:nodeup`/`:nodedown`. Dead nodes are pruned for free (`:pg`
+drops them on `:nodedown`).
+
+The key move is that **you control membership simply by controlling where
+`Sagents.Supervisor` starts.** Gate it to your agent-hosting role:
+
+```elixir
+# lib/my_app/application.ex
+def start(_type, _args) do
+  children =
+    [
+      MyApp.Repo,
+      {Phoenix.PubSub, name: MyApp.PubSub},
+      MyAppWeb.Presence
+    ] ++
+      # Only :web nodes host agents; only they join the Horde cluster.
+      if(:web in MyApp.Cluster.roles(), do: [Sagents.Supervisor], else: []) ++
+      [MyAppWeb.Endpoint]
+
+  Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)
+end
+```
+
+That is the entire configuration: gate the supervisor, set
+`members: :participation`. No node-name predicate, no manual
+`Horde.Cluster.set_members/2` wiring.
+
+### Partitioning membership (e.g. by region)
+
+Participation answers *"which nodes host agents"*. An optional `:partition`
+answers *"which of those nodes belong together"* — it isolates participation
+into independent groups, so a node only clusters with other nodes sharing the
+same partition value.
+
+```elixir
+# runtime.exs (runs per node)
+config :sagents, :horde,
+  members: :participation,
+  partition: System.get_env("FLY_REGION")   # e.g. "ord"; nil => single global group
+```
+
+`:partition` is any opaque grouping key you set per node. The motivating case is
+**geographic**: set it to a Fly.io `FLY_REGION` so an agent for an Illinois user
+is placed on — and only visible from — a Chicago node, never one in France. But
+it can be anything that should partition the cluster, such as a dedicated node
+pool for a large tenant:
+
+```elixir
+config :sagents, :horde,
+  members: :participation,
+  partition: System.get_env("TENANT_POOL")   # nodes dedicated to a tenant
+                                             # cluster only among themselves
+```
+
+A good partition value is a **stable identity, fixed for the node's lifetime.**
+It is read once when the node boots and never re-read, so a node cannot move
+between partitions without restarting. Geography (`FLY_REGION`) and dedicated
+pools fit naturally. Avoid values that rotate or get reassigned in place — e.g. a
+blue/green deploy color: "promoting" green to blue doesn't restart the node, so
+its boot-time partition would be stale.
+
+With a partition set, all three Horde instances are scoped to same-partition
+nodes only. Concretely, in one connected BEAM cluster spanning `ord` and `cdg`:
+
+- `ord` nodes see members `= ord nodes`; `cdg` nodes see members `= cdg nodes`.
+- The two partitions' CRDTs never sync (disjoint member sets), so an agent
+  started in `ord` is invisible to `cdg` and vice-versa.
+
+> #### Cross-partition request routing is your responsibility {: .warning}
+>
+> The library guarantees agents stay *within* their partition. It does **not**
+> route a user's request to the right partition. If a request for an `ord` user
+> lands on a `cdg` node, that node won't find the existing `ord` agent and will
+> start a *second* one in `cdg`. Ensure requests reach the right partition at the
+> infra/app layer — on Fly.io, `fly-replay` to the target region (or sticky
+> region routing) is the usual tool.
+
+### Under the hood: three Horde instances
+
+Sagents runs **three** independent Horde instances — each a separately-named
+Horde process over the *same* set of nodes:
+
+- `Sagents.Registry` (a `Horde.Registry`)
+- `Sagents.AgentsDynamicSupervisor` (a `Horde.DynamicSupervisor`)
+- `Sagents.FileSystem.FileSystemSupervisor` (a `Horde.DynamicSupervisor`)
+
+The registry-vs-supervisor split is inherent to Horde (distributed name
+registration and distributed placement are different components); agents and
+filesystems are kept as separate supervisors because they scope differently.
+Each instance has its own member set, keyed by *that instance's* name, so all
+three must be kept membership-consistent — which both `:auto` and
+`:participation` do for you automatically.
+
+## Quick diagnostics
+
+```elixir
+# Nodes Horde currently considers members of each instance (keep these consistent):
+Horde.Cluster.members(Sagents.Registry)
+Horde.Cluster.members(Sagents.AgentsDynamicSupervisor)
+Horde.Cluster.members(Sagents.FileSystem.FileSystemSupervisor)
+
+# Compare member count to live nodes — members > live ⇒ stale/un-pruned members:
+{length([node() | Node.list()]), length(Horde.Cluster.members(Sagents.Registry))}
+
+# Total registered entries cluster-wide:
+Sagents.ProcessRegistry.count()
+```

--- a/lib/sagents/agents_dynamic_supervisor.ex
+++ b/lib/sagents/agents_dynamic_supervisor.ex
@@ -127,9 +127,20 @@ defmodule Sagents.AgentsDynamicSupervisor do
         {:ok, pid, :already_started}
 
       {:error, reason} = error ->
-        Logger.error(
-          "Failed to start AgentSupervisor for agent_id=#{agent_id}: #{inspect(reason)}"
-        )
+        if registration_timeout?(reason) do
+          # Retryable: the :via registration call exceeded Horde's hardcoded 5s
+          # default. Logged at warning since `start_agent_sync/1` retries it; a
+          # genuinely-live prior registration surfaces as {:already_started, _}
+          # above, so we deliberately do NOT trust a possibly-dead remote pid
+          # here (Process.alive?/1 can't check a remote node).
+          Logger.warning(
+            "AgentSupervisor registration for agent_id=#{agent_id} timed out: #{inspect(reason)}"
+          )
+        else
+          Logger.error(
+            "Failed to start AgentSupervisor for agent_id=#{agent_id}: #{inspect(reason)}"
+          )
+        end
 
         error
     end
@@ -146,6 +157,30 @@ defmodule Sagents.AgentsDynamicSupervisor do
 
   Same as `start_agent/1`, plus:
   - `:startup_timeout` - Maximum time to wait for AgentServer to be ready (default: 5000ms)
+  - `:registration_retries` - How many extra times to retry the start if the
+    AgentSupervisor's `:via` registration times out (Horde/distributed only).
+    Defaults to `1`. See "Registration timeouts" below.
+  - `:registration_retry_backoff` - Milliseconds to wait between registration
+    retries (default: 250ms).
+
+  ## Registration timeouts
+
+  Under the `:horde` distribution backend, a newly-spawned `AgentSupervisor`
+  registers its `:via` name in `Horde.Registry` before `init/1` runs, via a
+  `GenServer.call` that uses Horde's hardcoded 5000ms default. On a busy or
+  churning cluster that call can time out, surfacing as
+  `{:timeout, {GenServer, :call, [Sagents.Registry, {:register, ...}, 5000]}}`.
+
+  The `GenServer.call` timeout runs *inside the spawning supervisor* during
+  `:gen.init_it`, so the timeout exit kills that process — after this error the
+  supervisor is gone, not lingering. This function therefore simply **retries**
+  the start with a short backoff (up to `:registration_retries` times).
+
+  It deliberately does not try to "recover" by looking the pid back up: the
+  process is dead, and the placed pid is typically on a remote node where
+  `Process.alive?/1` cannot verify liveness anyway. A genuinely-live prior
+  registration (e.g. a concurrent start that won) still surfaces correctly as
+  `{:ok, pid, :already_started}` from `start_agent/1`.
 
   ## Examples
 
@@ -160,8 +195,13 @@ defmodule Sagents.AgentsDynamicSupervisor do
   @spec start_agent_sync(keyword()) :: {:ok, pid()} | {:error, term()}
   def start_agent_sync(opts) do
     startup_timeout = Keyword.get(opts, :startup_timeout, 5_000)
+    retries = Keyword.get(opts, :registration_retries, 1)
     agent_id = Keyword.fetch!(opts, :agent_id)
 
+    do_start_agent_sync(opts, agent_id, startup_timeout, retries)
+  end
+
+  defp do_start_agent_sync(opts, agent_id, startup_timeout, retries_left) do
     case start_agent(opts) do
       {:ok, _pid} ->
         # Wait for AgentServer to be registered
@@ -171,8 +211,20 @@ defmodule Sagents.AgentsDynamicSupervisor do
         # Already running, verify it's ready
         wait_for_agent_ready(agent_id, startup_timeout)
 
-      {:error, _reason} = error ->
-        error
+      {:error, reason} = error ->
+        if retries_left > 0 and registration_timeout?(reason) do
+          backoff = Keyword.get(opts, :registration_retry_backoff, 250)
+
+          Logger.warning(
+            "Retrying AgentSupervisor start for agent_id=#{agent_id} after registration " <>
+              "timeout (#{retries_left} attempt(s) left, backoff=#{backoff}ms)"
+          )
+
+          Process.sleep(backoff)
+          do_start_agent_sync(opts, agent_id, startup_timeout, retries_left - 1)
+        else
+          error
+        end
     end
   end
 
@@ -265,6 +317,17 @@ defmodule Sagents.AgentsDynamicSupervisor do
   # ============================================================================
   # Private Functions
   # ============================================================================
+
+  # Matches the exact shape of a Horde `:via` registration timeout, e.g.
+  # `{:timeout, {GenServer, :call, [Sagents.Registry, {:register, _, _, _}, 5000]}}`.
+  # Anything else (a real crash, :already_present, etc.) is a genuine failure.
+  defp registration_timeout?(
+         {:timeout, {GenServer, :call, [registry, {:register, _key, _value, _pid} | _rest]}}
+       ) do
+    registry == Sagents.ProcessRegistry.registry_name()
+  end
+
+  defp registration_timeout?(_reason), do: false
 
   defp wait_for_agent_ready(agent_id, timeout) do
     deadline = System.monotonic_time(:millisecond) + timeout

--- a/lib/sagents/file_system/file_system_supervisor.ex
+++ b/lib/sagents/file_system/file_system_supervisor.ex
@@ -320,7 +320,8 @@ defmodule Sagents.FileSystem.FileSystemSupervisor do
       _other ->
         Logger.warning(
           "Registry propagation timeout for #{inspect(registry_key)}, " <>
-            "pid #{inspect(expected_pid)} is alive=#{Process.alive?(expected_pid)}"
+            "expected pid #{inspect(expected_pid)} on node #{inspect(node(expected_pid))} " <>
+            "not visible via lookup"
         )
 
         :ok
@@ -331,24 +332,7 @@ defmodule Sagents.FileSystem.FileSystemSupervisor do
   # Retries with exponential backoff up to the timeout
   # Uses fast-fail strategy: if supervisor not found on first check, only retry briefly
   defp do_wait_for_supervisor_ready(supervisor, deadline, retry_delay_ms) do
-    # Try to check if the supervisor is alive
-    ready =
-      try do
-        case supervisor do
-          pid when is_pid(pid) ->
-            Process.alive?(pid)
-
-          name when is_atom(name) ->
-            case Process.whereis(name) do
-              nil -> false
-              pid -> Process.alive?(pid)
-            end
-        end
-      catch
-        _kind, _reason -> false
-      end
-
-    if ready do
+    if supervisor_ready?(supervisor) do
       :ok
     else
       now = System.monotonic_time(:millisecond)
@@ -379,5 +363,20 @@ defmodule Sagents.FileSystem.FileSystemSupervisor do
         do_wait_for_supervisor_ready(supervisor, adjusted_deadline, next_delay)
       end
     end
+  end
+
+  # Whether the FileSystemSupervisor process is up on this node.
+  #
+  # The supervisor is a per-node process (registered locally via `name:`, even
+  # under Horde), so readiness is always a *local* question. We therefore avoid
+  # Process.alive?/1 on arbitrary pids — a remote supervisor reference is not
+  # supported and cannot be liveness-checked without a cross-node call.
+  defp supervisor_ready?(name) when is_atom(name) do
+    # Process.whereis/1 only returns a live, locally-registered pid (or nil).
+    not is_nil(Process.whereis(name))
+  end
+
+  defp supervisor_ready?(pid) when is_pid(pid) do
+    node(pid) == node() and Process.alive?(pid)
   end
 end

--- a/lib/sagents/horde/cluster_config.ex
+++ b/lib/sagents/horde/cluster_config.ex
@@ -2,85 +2,98 @@ defmodule Sagents.Horde.ClusterConfig do
   @moduledoc """
   Configuration helpers for Horde clustering.
 
-  ## Configuration Examples
+  Two membership modes are supported, both dynamic:
 
-  ### Auto-discovery (all nodes in cluster)
+  ### Auto-discovery (all visible nodes) — default
 
       config :sagents, :horde,
         members: :auto
 
-  ### Static member list
+  This is also the behaviour when no `:members` key is set. The literal atom
+  `:auto` is passed straight through to Horde, which starts a
+  `Horde.NodeListener` and keeps the member set in sync with *all visible* BEAM
+  nodes as they come and go — dead nodes are pruned on `:nodedown`.
+
+  > #### `:auto` includes every visible node {: .warning}
+  >
+  > Horde's `:auto` means *all* connected nodes, regardless of role. If your
+  > Erlang cluster meshes multiple unrelated service roles together (e.g. a
+  > shared libcluster selector), do not use `:auto` — agents will be scattered
+  > across unrelated nodes and the DeltaCrdt fan-out will span all of them. Use
+  > `:participation` instead.
+
+  ### Participation-based (scoped to nodes running Sagents) — recommended for mixed clusters
 
       config :sagents, :horde,
-        members: [
-          {Sagents.Horde.AgentsSupervisorImpl, :node1@host},
-          {Sagents.Horde.AgentsSupervisorImpl, :node2@host}
-        ]
+        members: :participation
 
-  ### Dynamic via MFA tuple
+  Membership is the set of nodes that actually run `Sagents.Supervisor`,
+  discovered via an OTP `:pg` group and kept current on `:nodeup`/`:nodedown` by
+  `Sagents.Horde.MembershipManager`. Use this when your Erlang cluster contains
+  nodes that should *not* host agents (other service roles): gate
+  `Sagents.Supervisor` to the agent-hosting role(s) and membership follows
+  automatically — no node-name predicate, dead nodes pruned for free. Unlike
+  `:auto`, it never pulls non-participating nodes into the Horde cluster.
 
-      config :sagents, :horde,
-        members: {MyApp.HordeConfig, :get_members, []}
-
-  ### Regional clustering (Fly.io example)
-
-      # In config/runtime.exs
-      region = System.get_env("FLY_REGION") || "default"
+  #### Partitioning participation
 
       config :sagents, :horde,
-        members: {Sagents.Horde.ClusterConfig, :regional_members, [region]}
+        members: :participation,
+        partition: System.get_env("FLY_REGION")
+
+  An optional `:partition` further isolates participation into independent
+  groups: a node only clusters with other nodes sharing the same partition
+  value. It is any opaque grouping key, set per node (commonly from an env var).
+  The motivating case is geography — set it to a Fly.io `FLY_REGION` so an agent
+  for an Illinois user is never placed on, or routed through, a node in France —
+  but it can be anything (datacenter, tenant tier, …).
+  `nil`/unset means a single global participation group (the default).
+
+  Only meaningful with `members: :participation`. See `docs/clustering.md`.
   """
 
   @doc """
   Resolve cluster members for a given module name.
 
-  Reads the `:members` config from `:sagents, :horde` and resolves it
-  to a list of `{module, node}` tuples suitable for Horde.
+  Reads the `:members` config from `:sagents, :horde` and returns a value
+  suitable for Horde's `:members` init option:
+
+  - `:auto` (and the default when unset) returns the literal atom `:auto`, so
+    Horde starts a `Horde.NodeListener` and manages membership dynamically.
+  - `:participation` returns a self-only seed `[{module, Node.self()}]`; Horde
+    starts with no `NodeListener`, and `Sagents.Horde.MembershipManager`
+    maintains the real member set from the `:pg` participation group.
   """
   def resolve_members(module_name) do
     case Application.get_env(:sagents, :horde, [])[:members] do
-      :auto -> auto_members(module_name)
-      list when is_list(list) -> list
-      fun when is_function(fun, 0) -> fun.()
-      {mod, fun, args} -> apply(mod, fun, [module_name | args])
-      nil -> auto_members(module_name)
+      :participation -> [{module_name, Node.self()}]
+      nil -> :auto
+      :auto -> :auto
+      other -> raise ArgumentError, invalid_members_message(other)
     end
   end
 
   @doc """
-  Returns members for auto-discovery mode.
+  Whether participation-based membership is enabled.
 
-  Includes all connected nodes plus the current node.
+  True when running under the `:horde` backend with `members: :participation`.
+  `Sagents.Supervisor` uses this to decide whether to start the `:pg` scope and
+  `Sagents.Horde.MembershipManager`.
   """
-  def auto_members(module_name) do
-    [Node.self() | Node.list()]
-    |> Enum.map(&{module_name, &1})
+  def participation_membership? do
+    Application.get_env(:sagents, :distribution, :local) == :horde and
+      Application.get_env(:sagents, :horde, [])[:members] == :participation
   end
 
   @doc """
-  Returns members for regional clustering.
+  The configured participation partition, or `nil` when unset.
 
-  Only includes nodes with matching region metadata.
-  Useful for Fly.io deployments where you want agents to stay
-  within a geographic region.
-
-  ## Examples
-
-      # In config/runtime.exs
-      region = System.get_env("FLY_REGION") || "default"
-
-      config :sagents, :horde,
-        members: {Sagents.Horde.ClusterConfig, :regional_members, [region]}
+  When set (any non-nil term), `Sagents.Horde.MembershipManager` isolates
+  membership so this node only clusters with nodes sharing the same partition.
+  Only meaningful with `members: :participation`.
   """
-  def regional_members(module_name, region) when is_binary(region) do
-    # Store region in persistent_term on startup
-    region_key = {:sagents_region, Node.self()}
-    :persistent_term.put(region_key, region)
-
-    # Get all nodes in same region
-    [Node.self() | Node.list()]
-    |> Enum.filter(&in_region?(&1, region))
-    |> Enum.map(&{module_name, &1})
+  def partition do
+    Application.get_env(:sagents, :horde, [])[:partition]
   end
 
   @doc """
@@ -114,55 +127,34 @@ defmodule Sagents.Horde.ClusterConfig do
   # Private
   # ---------------------------------------------------------------------------
 
-  defp in_region?(node, expected_region) do
-    case :rpc.call(node, :persistent_term, :get, [{:sagents_region, node}, nil]) do
-      ^expected_region -> true
-      _other -> false
-    end
-  end
-
   defp validate_members_config! do
     members = Application.get_env(:sagents, :horde, [])[:members]
 
-    cond do
-      members == :auto ->
-        :ok
-
-      is_list(members) ->
-        unless Enum.all?(members, &valid_member_tuple?/1) do
-          raise """
-          Invalid :members configuration for Horde.
-          Expected list of {module, node} tuples, got: #{inspect(members)}
-          """
-        end
-
-      is_function(members, 0) ->
-        :ok
-
-      is_tuple(members) and tuple_size(members) == 3 ->
-        {mod, fun, args} = members
-
-        unless is_atom(mod) and is_atom(fun) and is_list(args) do
-          raise "Invalid MFA tuple for :members: #{inspect(members)}"
-        end
-
-      members == nil ->
-        :ok
-
-      true ->
-        raise """
-        Invalid :members configuration for Horde.
-        Must be one of:
-          - :auto
-          - [{module, node}, ...]
-          - function/0
-          - {Module, :function, args}
-
-        Got: #{inspect(members)}
-        """
+    unless members in [:auto, :participation, nil] do
+      raise ArgumentError, invalid_members_message(members)
     end
+
+    if partition() != nil and members != :participation do
+      raise ArgumentError, """
+      Invalid Sagents Horde configuration: :partition is set (#{inspect(partition())}) \
+      but :members is #{inspect(members)}.
+
+      :partition only applies to participation-based membership. Set:
+
+          config :sagents, :horde, members: :participation, partition: ...
+      """
+    end
+
+    :ok
   end
 
-  defp valid_member_tuple?({mod, node}) when is_atom(mod) and is_atom(node), do: true
-  defp valid_member_tuple?(_other), do: false
+  defp invalid_members_message(value) do
+    """
+    Invalid :members configuration for Horde: #{inspect(value)}
+
+    Must be one of:
+      - :auto          # all visible nodes (default)
+      - :participation # nodes running Sagents.Supervisor
+    """
+  end
 end

--- a/lib/sagents/horde/membership_manager.ex
+++ b/lib/sagents/horde/membership_manager.ex
@@ -1,0 +1,176 @@
+defmodule Sagents.Horde.MembershipManager do
+  @moduledoc """
+  Keeps Horde cluster membership scoped to the nodes that actually run
+  `Sagents.Supervisor`, and keeps it current as nodes come and go.
+
+  This is the membership mechanism behind:
+
+      config :sagents, :distribution, :horde
+      config :sagents, :horde, members: :participation
+
+  ## Why this exists
+
+  Horde's built-in `members: :auto` derives membership from
+  `Node.list([:visible, :this])` — *every* connected BEAM node, regardless of
+  whether it runs Horde. In a cluster that meshes multiple service roles into
+  one Erlang cluster, that pulls unrelated nodes into the Sagents Horde cluster:
+  it bloats the DeltaCrdt sync fan-out (a cause of registration timeouts) and,
+  for membership added but never reporting `:alive`, leaves dead entries that
+  are never pruned.
+
+  Membership here is instead derived from **participation**: every node that
+  starts `Sagents.Supervisor` joins an OTP `:pg` group, and this process sets
+  Horde's members to exactly the nodes in that group. Because a node runs
+  `Sagents.Supervisor` only where the host application chose to (e.g. gated to a
+  `:web` role), "nodes running Sagents" *is* "agent-hosting nodes" — no
+  node-name predicate required. `:pg` removes a node's entry automatically on
+  `:nodedown`, so dead nodes are pruned without any extra wiring.
+
+  ## What it manages
+
+  On startup and on every `:pg` join/leave it calls `Horde.Cluster.set_members/2`
+  on all three Sagents Horde instances so they stay consistent:
+
+  - `Sagents.Registry`
+  - `Sagents.AgentsDynamicSupervisor`
+  - `Sagents.FileSystem.FileSystemSupervisor`
+
+  It is started automatically by `Sagents.Supervisor` (together with its `:pg`
+  scope) when `members: :participation` is configured; you do not start it
+  yourself.
+
+  ## Partitioning
+
+  When `config :sagents, :horde, partition: <value>` is set, the `:pg` group is
+  keyed by that partition (`{:sagents_members, value}`). A node only joins and
+  monitors its own partition's group, so membership is isolated per partition —
+  e.g. nodes in one Fly.io region never become members of another region's Horde
+  cluster, even when all nodes share one connected BEAM cluster.
+  """
+
+  use GenServer
+  require Logger
+
+  @compile {:no_warn_undefined, Horde.Cluster}
+
+  @scope Sagents.Horde.MembershipScope
+  @base_group :sagents_members
+
+  # The Horde clusters whose membership we keep in sync. Each is a registered
+  # name resolvable on the local node.
+  @hordes [
+    Sagents.Registry,
+    Sagents.AgentsDynamicSupervisor,
+    Sagents.FileSystem.FileSystemSupervisor
+  ]
+
+  @doc "The `:pg` scope used for participation tracking."
+  def scope, do: @scope
+
+  @doc """
+  The `:pg` group joined by each participating node.
+
+  Keyed by the configured partition (`Sagents.Horde.ClusterConfig.partition/0`)
+  so nodes only cluster with same-partition peers. Unpartitioned membership uses
+  the base group atom.
+  """
+  def group, do: group_for(Sagents.Horde.ClusterConfig.partition())
+
+  @doc "The `:pg` group for a given partition (`nil` => unpartitioned base group)."
+  def group_for(nil), do: @base_group
+  def group_for(partition), do: {@base_group, partition}
+
+  @doc "The Horde clusters this manager keeps membership-consistent."
+  def hordes, do: @hordes
+
+  @doc """
+  Child spec for the `:pg` scope this manager relies on.
+
+  `Sagents.Supervisor` starts this *before* the manager so the scope is
+  available when the manager joins and monitors it.
+  """
+  def pg_scope_spec do
+    %{
+      id: @scope,
+      start: {:pg, :start_link, [@scope]}
+    }
+  end
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(_opts) do
+    group = group()
+
+    # Mark this node as a participant in its partition group, then monitor that
+    # group so we react to same-partition nodes joining/leaving on :nodeup/down.
+    :ok = :pg.join(@scope, group, self())
+    {ref, _pids} = :pg.monitor(@scope, group)
+
+    nodes = current_member_nodes(group)
+    apply_members(nodes)
+
+    {:ok, %{ref: ref, group: group, members: nodes}}
+  end
+
+  @impl true
+  def handle_info({ref, action, _group, _pids}, %{ref: ref} = state)
+      when action in [:join, :leave] do
+    nodes = current_member_nodes(state.group)
+
+    state =
+      if nodes == state.members do
+        state
+      else
+        Logger.debug("Sagents Horde membership changed (#{action}): #{inspect(nodes)}")
+
+        apply_members(nodes)
+        %{state | members: nodes}
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ---------------------------------------------------------------------------
+  # Internal
+  # ---------------------------------------------------------------------------
+
+  defp current_member_nodes(group) do
+    :pg.get_members(@scope, group)
+    |> member_nodes()
+  end
+
+  @doc false
+  # Unique sorted list of nodes hosting a participation marker pid. Public for
+  # testing; not part of the supported API.
+  def member_nodes(pids) do
+    pids
+    |> Enum.map(&node/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp apply_members(nodes) do
+    for horde <- @hordes do
+      members = Enum.map(nodes, &{horde, &1})
+
+      try do
+        :ok = Horde.Cluster.set_members(horde, members)
+      catch
+        kind, reason ->
+          # A horde process may be momentarily unavailable (e.g. restarting).
+          # The next :pg event re-applies, so log and move on rather than crash.
+          Logger.warning(
+            "Failed to set Horde members for #{inspect(horde)} " <>
+              "(#{inspect(kind)}: #{inspect(reason)}); will retry on next change"
+          )
+      end
+    end
+
+    :ok
+  end
+end

--- a/lib/sagents/supervisor.ex
+++ b/lib/sagents/supervisor.ex
@@ -60,12 +60,27 @@ defmodule Sagents.Supervisor do
     # Validate Horde configuration early (raises on invalid config)
     Sagents.Horde.ClusterConfig.validate!()
 
-    children = [
-      Sagents.ProcessRegistry.child_spec([]),
-      Sagents.ProcessSupervisor.agents_supervisor_child_spec([]),
-      Sagents.ProcessSupervisor.filesystem_supervisor_child_spec([])
-    ]
+    children =
+      [
+        Sagents.ProcessRegistry.child_spec([]),
+        Sagents.ProcessSupervisor.agents_supervisor_child_spec([]),
+        Sagents.ProcessSupervisor.filesystem_supervisor_child_spec([])
+      ] ++ membership_children()
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  # With `members: :participation`, start the `:pg` scope and the membership
+  # manager *after* the Horde clusters (so set_members/2 has live targets). The
+  # manager keeps Horde membership scoped to nodes running this supervisor.
+  defp membership_children do
+    if Sagents.Horde.ClusterConfig.participation_membership?() do
+      [
+        Sagents.Horde.MembershipManager.pg_scope_spec(),
+        Sagents.Horde.MembershipManager
+      ]
+    else
+      []
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -177,7 +177,8 @@ defmodule Sagents.MixProject do
       "docs/middleware_messaging.md",
       "docs/observability.md",
       "docs/persistence.md",
-      "docs/filesystem_setup.md"
+      "docs/filesystem_setup.md",
+      "docs/clustering.md"
     ]
   end
 

--- a/test/sagents/agents_dynamic_supervisor_test.exs
+++ b/test/sagents/agents_dynamic_supervisor_test.exs
@@ -1,0 +1,96 @@
+defmodule Sagents.AgentsDynamicSupervisorTest do
+  @moduledoc """
+  Unit tests for the registration-timeout resilience added to
+  `Sagents.AgentsDynamicSupervisor`.
+
+  These tests stub `Sagents.ProcessSupervisor.start_child/2` and
+  `Sagents.AgentSupervisor.get_pid/1` with Mimic so the recovery/retry logic can
+  be exercised without a real Horde cluster.
+  """
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Sagents.AgentSupervisor
+  alias Sagents.AgentsDynamicSupervisor
+  alias Sagents.ProcessSupervisor
+
+  # The exact error shape Horde produces when a `:via` registration call exceeds
+  # its hardcoded 5000ms default.
+  defp registration_timeout(agent_id) do
+    key = {:agent_supervisor, agent_id}
+
+    {:timeout,
+     {GenServer, :call,
+      [Sagents.ProcessRegistry.registry_name(), {:register, key, nil, self()}, 5000]}}
+  end
+
+  describe "start_agent/1 registration timeout" do
+    test "returns the error without consulting get_pid (no remote-liveness guess)" do
+      agent_id = "conversation-reg-timeout"
+      reason = registration_timeout(agent_id)
+
+      stub(ProcessSupervisor, :start_child, fn _sup, _spec -> {:error, reason} end)
+
+      # The placed supervisor is dead after its own registration call timed out,
+      # and it may live on a remote node -- so we must never look the pid back up.
+      reject(&AgentSupervisor.get_pid/1)
+
+      assert {:error, ^reason} = AgentsDynamicSupervisor.start_agent(agent_id: agent_id)
+    end
+
+    test "does not treat an unrelated registry timeout as a registration timeout" do
+      agent_id = "conversation-other-error"
+
+      other_reason =
+        {:timeout, {GenServer, :call, [SomeOther.Registry, {:register, :x, nil, self()}, 5000]}}
+
+      stub(ProcessSupervisor, :start_child, fn _sup, _spec -> {:error, other_reason} end)
+
+      reject(&AgentSupervisor.get_pid/1)
+
+      assert {:error, ^other_reason} = AgentsDynamicSupervisor.start_agent(agent_id: agent_id)
+    end
+  end
+
+  describe "start_agent_sync/1 registration retries" do
+    test "retries after a registration timeout and succeeds on the next attempt" do
+      agent_id = "conversation-retry-ok"
+      ready_pid = self()
+
+      # First start_child times out; the retry succeeds.
+      expect(ProcessSupervisor, :start_child, fn _sup, _spec ->
+        {:error, registration_timeout(agent_id)}
+      end)
+
+      expect(ProcessSupervisor, :start_child, fn _sup, _spec -> {:ok, ready_pid} end)
+
+      # get_pid is only consulted by the post-start readiness wait, never on the
+      # timeout path itself.
+      expect(AgentSupervisor, :get_pid, fn ^agent_id -> {:ok, ready_pid} end)
+
+      assert {:ok, ^ready_pid} =
+               AgentsDynamicSupervisor.start_agent_sync(
+                 agent_id: agent_id,
+                 registration_retries: 1,
+                 registration_retry_backoff: 0
+               )
+    end
+
+    test "gives up and returns the error once retries are exhausted" do
+      agent_id = "conversation-retry-exhausted"
+      reason = registration_timeout(agent_id)
+
+      stub(ProcessSupervisor, :start_child, fn _sup, _spec -> {:error, reason} end)
+
+      # Every attempt times out, so no readiness wait runs and get_pid is never used.
+      reject(&AgentSupervisor.get_pid/1)
+
+      assert {:error, ^reason} =
+               AgentsDynamicSupervisor.start_agent_sync(
+                 agent_id: agent_id,
+                 registration_retries: 2,
+                 registration_retry_backoff: 0
+               )
+    end
+  end
+end

--- a/test/sagents/file_system/file_system_supervisor_test.exs
+++ b/test/sagents/file_system/file_system_supervisor_test.exs
@@ -26,6 +26,26 @@ defmodule Sagents.FileSystem.FileSystemSupervisorTest do
     config
   end
 
+  describe "wait_for_supervisor_ready/2" do
+    test "returns :ok when the supervisor is registered by name" do
+      name = :"fs_sup_ready_#{System.unique_integer([:positive])}"
+      start_supervised!(Supervisor.child_spec({FileSystemSupervisor, name: name}, id: name))
+
+      assert :ok = FileSystemSupervisor.wait_for_supervisor_ready(name, 1_000)
+    end
+
+    test "returns :ok for a live local supervisor pid", %{supervisor_pid: pid} do
+      assert :ok = FileSystemSupervisor.wait_for_supervisor_ready(pid, 1_000)
+    end
+
+    test "returns error when the named supervisor is not running" do
+      name = :"fs_sup_missing_#{System.unique_integer([:positive])}"
+
+      assert {:error, :supervisor_not_ready} =
+               FileSystemSupervisor.wait_for_supervisor_ready(name, 200)
+    end
+  end
+
   describe "start_link/1" do
     test "starts supervisor successfully" do
       supervisor_name = :"fs_sup_#{System.unique_integer([:positive])}"

--- a/test/sagents/horde/cluster_config_test.exs
+++ b/test/sagents/horde/cluster_config_test.exs
@@ -57,75 +57,111 @@ defmodule Sagents.Horde.ClusterConfigTest do
       assert :ok = ClusterConfig.validate!()
     end
 
-    test "validates list members config" do
+    test "validates :participation members config" do
       Application.put_env(:sagents, :distribution, :horde)
-      Application.put_env(:sagents, :horde, members: [{SomeModule, :nonode@nohost}])
+      Application.put_env(:sagents, :horde, members: :participation)
 
       assert :ok = ClusterConfig.validate!()
     end
 
-    test "validates MFA members config" do
+    test "validates :participation with a partition" do
       Application.put_env(:sagents, :distribution, :horde)
-      Application.put_env(:sagents, :horde, members: {SomeModule, :some_function, ["region"]})
+      Application.put_env(:sagents, :horde, members: :participation, partition: "ord")
 
       assert :ok = ClusterConfig.validate!()
     end
 
-    test "raises on invalid members config" do
+    test "raises when :partition is set with non-:participation members" do
       Application.put_env(:sagents, :distribution, :horde)
-      Application.put_env(:sagents, :horde, members: "invalid")
+      Application.put_env(:sagents, :horde, members: :auto, partition: "ord")
 
-      assert_raise RuntimeError, ~r/Invalid :members configuration/, fn ->
+      assert_raise ArgumentError, ~r/:partition only applies to participation/, fn ->
         ClusterConfig.validate!()
       end
     end
 
-    test "raises on invalid list members (not {module, node} tuples)" do
+    test "raises on a string members config" do
       Application.put_env(:sagents, :distribution, :horde)
-      Application.put_env(:sagents, :horde, members: ["not_a_tuple"])
+      Application.put_env(:sagents, :horde, members: "invalid")
 
-      assert_raise RuntimeError, ~r/Expected list of \{module, node\} tuples/, fn ->
+      assert_raise ArgumentError, ~r/Invalid :members configuration/, fn ->
+        ClusterConfig.validate!()
+      end
+    end
+
+    test "raises on a now-unsupported static list members config" do
+      Application.put_env(:sagents, :distribution, :horde)
+      Application.put_env(:sagents, :horde, members: [{SomeModule, :nonode@nohost}])
+
+      assert_raise ArgumentError, ~r/Invalid :members configuration/, fn ->
         ClusterConfig.validate!()
       end
     end
   end
 
   describe "resolve_members/1" do
-    test "returns auto members when config is :auto" do
+    test "passes the literal :auto atom through to Horde when config is :auto" do
       Application.put_env(:sagents, :horde, members: :auto)
 
-      result = ClusterConfig.resolve_members(TestModule)
-      assert [{TestModule, node}] = result
-      assert node == Node.self()
+      assert :auto = ClusterConfig.resolve_members(TestModule)
     end
 
-    test "returns auto members when config is nil" do
+    test "passes the literal :auto atom through when no members config is set" do
       Application.delete_env(:sagents, :horde)
 
-      result = ClusterConfig.resolve_members(TestModule)
-      assert [{TestModule, node}] = result
+      assert :auto = ClusterConfig.resolve_members(TestModule)
+    end
+
+    test "returns a self-only seed for :participation" do
+      Application.put_env(:sagents, :horde, members: :participation)
+
+      assert [{TestModule, node}] = ClusterConfig.resolve_members(TestModule)
       assert node == Node.self()
     end
 
-    test "returns static list when provided" do
-      members = [{MyModule, :node1@host}, {MyModule, :node2@host}]
-      Application.put_env(:sagents, :horde, members: members)
+    test "raises for an unsupported members value" do
+      Application.put_env(:sagents, :horde, members: [{MyModule, :node1@host}])
 
-      assert ^members = ClusterConfig.resolve_members(TestModule)
-    end
-
-    test "calls function when provided" do
-      Application.put_env(:sagents, :horde, members: fn -> [{TestModule, :test@host}] end)
-
-      assert [{TestModule, :test@host}] = ClusterConfig.resolve_members(TestModule)
+      assert_raise ArgumentError, ~r/Invalid :members configuration/, fn ->
+        ClusterConfig.resolve_members(TestModule)
+      end
     end
   end
 
-  describe "auto_members/1" do
-    test "includes current node" do
-      result = ClusterConfig.auto_members(TestModule)
-      assert [{TestModule, node}] = result
-      assert node == Node.self()
+  describe "participation_membership?/0" do
+    test "true under :horde with members: :participation" do
+      Application.put_env(:sagents, :distribution, :horde)
+      Application.put_env(:sagents, :horde, members: :participation)
+
+      assert ClusterConfig.participation_membership?()
+    end
+
+    test "false when members is not :participation" do
+      Application.put_env(:sagents, :distribution, :horde)
+      Application.put_env(:sagents, :horde, members: :auto)
+
+      refute ClusterConfig.participation_membership?()
+    end
+
+    test "false under :local even if members: :participation" do
+      Application.put_env(:sagents, :distribution, :local)
+      Application.put_env(:sagents, :horde, members: :participation)
+
+      refute ClusterConfig.participation_membership?()
+    end
+  end
+
+  describe "partition/0" do
+    test "returns the configured partition" do
+      Application.put_env(:sagents, :horde, members: :participation, partition: "ord")
+
+      assert ClusterConfig.partition() == "ord"
+    end
+
+    test "returns nil when unset" do
+      Application.put_env(:sagents, :horde, members: :participation)
+
+      assert ClusterConfig.partition() == nil
     end
   end
 end

--- a/test/sagents/horde/membership_manager_test.exs
+++ b/test/sagents/horde/membership_manager_test.exs
@@ -1,0 +1,111 @@
+defmodule Sagents.Horde.MembershipManagerTest do
+  # async: false + global Mimic because the manager calls Horde.Cluster from its
+  # own GenServer process during init.
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Sagents.Horde.MembershipManager
+
+  setup :set_mimic_global
+
+  describe "member_nodes/1" do
+    test "dedups and sorts the nodes hosting participation markers" do
+      assert MembershipManager.member_nodes([self(), self()]) == [node()]
+    end
+
+    test "returns [] for no markers" do
+      assert MembershipManager.member_nodes([]) == []
+    end
+  end
+
+  describe "group_for/1" do
+    test "uses the base group when unpartitioned" do
+      assert MembershipManager.group_for(nil) == :sagents_members
+    end
+
+    test "keys the group by partition when set" do
+      assert MembershipManager.group_for("ord") == {:sagents_members, "ord"}
+    end
+  end
+
+  describe "partitioned membership" do
+    setup do
+      original = Application.get_env(:sagents, :horde)
+      Application.put_env(:sagents, :horde, members: :participation, partition: "ord")
+
+      on_exit(fn ->
+        if original,
+          do: Application.put_env(:sagents, :horde, original),
+          else: Application.delete_env(:sagents, :horde)
+      end)
+
+      :ok
+    end
+
+    test "joins the partition group and sets members from it" do
+      test_pid = self()
+
+      stub(Horde.Cluster, :set_members, fn horde, members ->
+        send(test_pid, {:set_members, horde, members})
+        :ok
+      end)
+
+      start_supervised!(MembershipManager.pg_scope_spec())
+      start_supervised!(MembershipManager)
+
+      # The manager joined this node into the "ord" group, so membership is the
+      # self-node and a marker pid is present in the partitioned group.
+      for horde <- MembershipManager.hordes() do
+        assert_receive {:set_members, ^horde, members}
+        assert members == [{horde, node()}]
+      end
+
+      assert [_pid] = :pg.get_members(MembershipManager.scope(), {:sagents_members, "ord"})
+      assert :pg.get_members(MembershipManager.scope(), :sagents_members) == []
+    end
+  end
+
+  describe "membership application on startup" do
+    test "sets members on all three Horde clusters scoped to participating nodes" do
+      test_pid = self()
+
+      stub(Horde.Cluster, :set_members, fn horde, members ->
+        send(test_pid, {:set_members, horde, members})
+        :ok
+      end)
+
+      start_supervised!(MembershipManager.pg_scope_spec())
+      start_supervised!(MembershipManager)
+
+      # Only this node participates, so each cluster's members is the self-node.
+      for horde <- MembershipManager.hordes() do
+        assert_receive {:set_members, ^horde, members}
+        assert members == [{horde, node()}]
+      end
+    end
+
+    test "re-applies membership when the participation group changes" do
+      test_pid = self()
+
+      stub(Horde.Cluster, :set_members, fn horde, members ->
+        send(test_pid, {:set_members, horde, members})
+        :ok
+      end)
+
+      start_supervised!(MembershipManager.pg_scope_spec())
+      start_supervised!(MembershipManager)
+
+      # Drain the startup set_members messages.
+      for horde <- MembershipManager.hordes() do
+        assert_receive {:set_members, ^horde, _members}
+      end
+
+      # A second marker pid on this same node must NOT change the node set, so no
+      # further set_members calls should fire (membership is by node, not pid).
+      extra = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = :pg.join(MembershipManager.scope(), MembershipManager.group(), extra)
+
+      refute_receive {:set_members, _horde, _members}, 200
+    end
+  end
+end

--- a/test/sagents/horde/node_transfer_test.exs
+++ b/test/sagents/horde/node_transfer_test.exs
@@ -42,43 +42,24 @@ defmodule Sagents.Horde.NodeTransferTest do
     {:ok, cluster} =
       LocalCluster.start_link(count,
         environment: [
-          sagents: [distribution: :horde]
+          # :participation scopes membership to the nodes that run
+          # Sagents.Supervisor (started below), automatically excluding the
+          # manager/test-runner node — which `:auto` would wrongly pull in.
+          sagents: [distribution: :horde, horde: [members: :participation]]
         ]
       )
 
     {:ok, nodes} = LocalCluster.nodes(cluster)
 
-    # Start Sagents.Supervisor (registry + Horde supervisors) on each node.
-    # Uses ClusterTestHelper to unlink from the RPC caller process, otherwise
-    # the supervisor dies when the temporary RPC process exits.
+    # Start Sagents.Supervisor (registry + Horde supervisors + membership
+    # manager) on each node. ClusterTestHelper unlinks from the RPC caller so
+    # the supervisor survives the temporary RPC process exiting.
     for node <- nodes do
       {:ok, _pid} = :rpc.call(node, Sagents.ClusterTestHelper, :start_supervisor, [])
     end
 
-    # Set explicit Horde members on each node, excluding the test runner (manager) node.
-    # auto_members includes all connected nodes, which includes the test runner that
-    # doesn't run Horde processes - this confuses distribution and redistribution.
-    agent_members = Enum.map(nodes, &{Sagents.AgentsDynamicSupervisor, &1})
-    fs_members = Enum.map(nodes, &{Sagents.FileSystem.FileSystemSupervisor, &1})
-    registry_members = Enum.map(nodes, &{Sagents.Registry, &1})
-
-    for node <- nodes do
-      :ok =
-        :rpc.call(node, Horde.Cluster, :set_members, [
-          Sagents.AgentsDynamicSupervisor,
-          agent_members
-        ])
-
-      :ok =
-        :rpc.call(node, Horde.Cluster, :set_members, [
-          Sagents.FileSystem.FileSystemSupervisor,
-          fs_members
-        ])
-
-      :ok = :rpc.call(node, Horde.Cluster, :set_members, [Sagents.Registry, registry_members])
-    end
-
-    # Wait for Horde CRDTs to sync membership between nodes.
+    # Wait for :pg participation + Horde CRDTs to converge across nodes before
+    # placing agents.
     Process.sleep(2_000)
 
     {cluster, nodes}

--- a/test/sagents/horde/participation_membership_test.exs
+++ b/test/sagents/horde/participation_membership_test.exs
@@ -1,0 +1,180 @@
+defmodule Sagents.Horde.ParticipationMembershipTest do
+  @moduledoc """
+  Multi-node tests that `members: :participation` scopes Horde membership to
+  exactly the nodes running `Sagents.Supervisor` — and keeps it current as those
+  nodes come and go.
+
+  Uses LocalCluster to start real Erlang nodes. Run with:
+
+      mix test --include cluster
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :cluster
+
+  @converge_timeout 10_000
+
+  @hordes [
+    Sagents.Registry,
+    Sagents.AgentsDynamicSupervisor,
+    Sagents.FileSystem.FileSystemSupervisor
+  ]
+
+  setup_all do
+    LocalCluster.start()
+
+    unless Node.alive?() do
+      raise """
+      Distributed Erlang did not start. LocalCluster.start/0 could not make this \
+      node distributed, most likely because EPMD is not running on localhost:4369.
+
+      Start EPMD and retry:
+
+          epmd -daemon
+      """
+    end
+
+    :ok
+  end
+
+  describe "members: :participation" do
+    test "membership is scoped to nodes running Sagents.Supervisor" do
+      {cluster, [web1, web2, other]} = start_participation_cluster(3)
+
+      # Start Sagents.Supervisor on the two "web" nodes only. `other` is connected
+      # but does not participate (mirrors a non-agent service role).
+      start_supervisor_on([web1, web2])
+
+      expected = Enum.sort([web1, web2])
+
+      # Both participating nodes converge to exactly the participating member set.
+      assert wait_until(fn -> members(web1, Sagents.AgentsDynamicSupervisor) == expected end),
+             "web1 members: #{inspect(members(web1, Sagents.AgentsDynamicSupervisor))}"
+
+      assert wait_until(fn -> members(web2, Sagents.AgentsDynamicSupervisor) == expected end)
+
+      # All three Horde clusters are scoped identically, as seen from each node.
+      for node <- [web1, web2], horde <- @hordes do
+        assert members(node, horde) == expected,
+               "#{inspect(horde)} on #{inspect(node)}: #{inspect(members(node, horde))}"
+      end
+
+      # The non-participating node and the test runner are NOT members — the very
+      # thing :auto gets wrong (it would include both).
+      assert other not in members(web1, Sagents.AgentsDynamicSupervisor)
+      assert node() not in members(web1, Sagents.AgentsDynamicSupervisor)
+
+      LocalCluster.stop(cluster)
+    end
+
+    test "a departing participant is pruned from membership" do
+      {cluster, [web1, web2]} = start_participation_cluster(2)
+      start_supervisor_on([web1, web2])
+
+      assert wait_until(fn ->
+               members(web1, Sagents.AgentsDynamicSupervisor) == Enum.sort([web1, web2])
+             end)
+
+      # web2 leaves the cluster; :pg drops it and the manager re-applies.
+      LocalCluster.stop(cluster, web2)
+
+      assert wait_until(fn -> members(web1, Sagents.AgentsDynamicSupervisor) == [web1] end),
+             "web1 members after web2 left: #{inspect(members(web1, Sagents.AgentsDynamicSupervisor))}"
+
+      LocalCluster.stop(cluster)
+    end
+  end
+
+  describe "members: :participation with partition" do
+    test "membership is isolated per partition within one connected cluster" do
+      {cluster, [ord1, ord2, cdg1, cdg2]} = start_participation_cluster(4)
+
+      # All four nodes are one connected BEAM cluster, but split into two
+      # partitions. Set each node's partition before starting its supervisor.
+      set_partition_on([ord1, ord2], "ord")
+      set_partition_on([cdg1, cdg2], "cdg")
+      start_supervisor_on([ord1, ord2, cdg1, cdg2])
+
+      ord = Enum.sort([ord1, ord2])
+      cdg = Enum.sort([cdg1, cdg2])
+
+      # Each partition converges to only its own nodes, for all three instances.
+      for node <- [ord1, ord2], horde <- @hordes do
+        assert wait_until(fn -> members(node, horde) == ord end),
+               "#{inspect(horde)} on ord node #{inspect(node)}: #{inspect(members(node, horde))}"
+      end
+
+      for node <- [cdg1, cdg2], horde <- @hordes do
+        assert wait_until(fn -> members(node, horde) == cdg end),
+               "#{inspect(horde)} on cdg node #{inspect(node)}: #{inspect(members(node, horde))}"
+      end
+
+      # The partitions are disjoint — no cross-partition members.
+      assert ord1 not in members(cdg1, Sagents.AgentsDynamicSupervisor)
+      assert cdg1 not in members(ord1, Sagents.AgentsDynamicSupervisor)
+
+      LocalCluster.stop(cluster)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp start_participation_cluster(count) do
+    {:ok, cluster} =
+      LocalCluster.start_link(count,
+        environment: [
+          sagents: [distribution: :horde, horde: [members: :participation]]
+        ]
+      )
+
+    {:ok, nodes} = LocalCluster.nodes(cluster)
+    {cluster, nodes}
+  end
+
+  defp start_supervisor_on(nodes) do
+    for node <- nodes do
+      {:ok, _pid} = :rpc.call(node, Sagents.ClusterTestHelper, :start_supervisor, [])
+    end
+  end
+
+  # Set each node's partition before its supervisor (and thus its membership
+  # manager) starts, so it joins the right partition's :pg group.
+  defp set_partition_on(nodes, partition) do
+    for node <- nodes do
+      :ok =
+        :rpc.call(node, Application, :put_env, [
+          :sagents,
+          :horde,
+          [members: :participation, partition: partition]
+        ])
+    end
+  end
+
+  # The node()s currently in `horde`'s member set, as observed from `node`.
+  defp members(node, horde) do
+    :rpc.call(node, Horde.Cluster, :members, [horde])
+    |> Enum.map(fn {_name, member_node} -> member_node end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp wait_until(fun, timeout \\ @converge_timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:millisecond) < deadline do
+        Process.sleep(100)
+        do_wait_until(fun, deadline)
+      else
+        false
+      end
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,9 @@ Mimic.copy(LangChain.ChatModels.ChatAnthropic)
 Mimic.copy(LangChain.ChatModels.ChatOpenAI)
 Mimic.copy(Sagents.SubAgentServer)
 Mimic.copy(Sagents.FileSystem.FileSystemSupervisor)
+Mimic.copy(Sagents.ProcessSupervisor)
+Mimic.copy(Sagents.AgentSupervisor)
+Mimic.copy(Horde.Cluster)
 
 # Start a shared PubSub for tests
 {:ok, _pid} = Phoenix.PubSub.Supervisor.start_link(name: :test_pubsub)


### PR DESCRIPTION
## Problem

Under the `:horde` distribution backend, cluster membership was derived either from Horde's `:auto` mode or from hand-maintained static `{module, node}` lists / MFA callbacks. Both were broken in ways that surfaced, intermittently, as agent-start failures like:

```
{:timeout, {GenServer, :call, [Sagents.Registry, {:register, {:agent_supervisor, "..."}, nil, #PID<...>}, 5000]}}
```

Two root causes combined to produce this:

**1. Membership was effectively frozen, and dead nodes were never pruned.** `resolve_members/1` always handed Horde a concrete member *list* and never the literal atom `:auto`, so Horde never started its `Horde.NodeListener`. Member *additions* still converged (Horde's membership is a CRDT union), but *removals* only ever come from `Horde.Cluster.set_members/2` — which nothing called. So after topology churn, the member set retained dead-but-unpruned nodes. An MFA/function `:members` value was no better: `resolve_members/1` is evaluated once at `init`, so it was frozen too. There was no way to get genuinely dynamic membership through Sagents config.

**2. Over-broad membership bloats CRDT sync and causes registration timeouts.** It's worth separating two gates that look the same but aren't: a node can be a *member* without being a valid *placement target* (`UniformDistribution` only places on `:alive` members, and a node is `:alive` only by actually running the Horde supervisor). But the DeltaCrdt sync fan-out path does **not** filter by `:alive` — *every* member is a sync neighbour. So in a cluster that meshes many unrelated service roles into one Erlang cluster, pulling all of them in (which `:auto`, and the old frozen snapshot, both do) bloats the sync fan-out even though placement still looks correct. When a newly-spawned `AgentSupervisor` registers its `:via` name, it does so via a `GenServer.call` with Horde's hardcoded 5000ms default, *before* `init/1` runs. On a busy or churning cluster — or one wasting time syncing CRDT deltas to dead neighbours — that call blows past 5s. Because a merely-slow (not failed) `GenServer.call` produces no crash report, there is no second log line, and the timeout exit kills the spawning supervisor. Critically, the registration handler uses `DeltaCrdt.put(…, :infinity)`, so registration may still complete *after* the caller has already timed out.

## Solution

Replace the static/MFA member modes with two dynamic modes: `:auto` (now passed straight through to Horde so its `NodeListener` actually runs and prunes dead nodes) and a new `:participation` mode that scopes membership to exactly the nodes running `Sagents.Supervisor`.

`Sagents.Horde.MembershipManager` is the mechanism behind `:participation`: every participating node joins an OTP `:pg` group, and the manager calls `Horde.Cluster.set_members/2` on all three Sagents Horde instances (`Registry`, `AgentsDynamicSupervisor`, `FileSystemSupervisor`) whenever the group changes. Because membership follows where the host app starts `Sagents.Supervisor`, "nodes running Sagents" *is* "agent-hosting nodes" — no node-name predicate needed — and `:pg` prunes departed nodes for free on `:nodedown`. This is the piece neither the frozen snapshot nor Horde's `:auto` (which is "all visible nodes", role-blind) could provide: membership that is both dynamic *and* scoped to agent-hosting nodes. An optional `:partition` key (e.g. a region identifier) keys the `:pg` group so nodes only cluster with same-partition peers, isolating membership and CRDT sync per region/tenant within one connected BEAM cluster.

Separately, this hardens the registration-timeout path itself. `AgentsDynamicSupervisor.start_agent_sync/1` now recognises the Horde `:via` registration timeout and retries with backoff instead of failing. It deliberately does **not** try to "recover" by re-checking the placed pid: after the timeout the spawning supervisor is dead, and the placed pid typically lives on a remote node where `Process.alive?/1` cannot verify liveness anyway — a genuinely-live concurrent registration still surfaces correctly as `{:ok, pid, :already_started}`. For the same remote-liveness reason, `FileSystemSupervisor`'s readiness check no longer calls `Process.alive?/1` on potentially-remote pids; readiness is now a strictly local question (named lookup or same-node pid).

## Changes

- `lib/sagents/horde/membership_manager.ex` — New GenServer that maintains Horde membership from a `:pg` participation group across all three Horde instances; supports partition-keyed groups; tolerates a momentarily-unavailable Horde process (logs and re-applies on the next `:pg` event).
- `lib/sagents/horde/cluster_config.ex` — Replace static list / function / MFA member modes with `:auto` + `:participation`; `resolve_members/1` now passes the literal `:auto` through to Horde (so `NodeListener` runs) and seeds `:participation` self-only; add `participation_membership?/0` and `partition/0`; stricter validation (rejects unsupported `:members`, and `:partition` set without `:participation`).
- `lib/sagents/supervisor.ex` — Start the `:pg` scope and `MembershipManager` after the Horde clusters when `members: :participation`.
- `lib/sagents/agents_dynamic_supervisor.ex` — Detect Horde `:via` registration timeouts and retry the start (`:registration_retries`, `:registration_retry_backoff` opts); log retryable timeouts at warning rather than error.
- `lib/sagents/file_system/file_system_supervisor.ex` — Replace remote-unsafe `Process.alive?/1` readiness check with a local `supervisor_ready?/1` (named lookup or same-node pid only).
- `mix.exs` — Add `docs/clustering.md` to the docs extras.
- `docs/clustering.md` — New guide explaining membership-as-placement-policy, the member-set-vs-placement-eligibility distinction, the `:auto` vs `:participation` trade-off, partitioning, the three-Horde-instance model, and quick diagnostics.
- `test/sagents/horde/membership_manager_test.exs`, `test/sagents/horde/cluster_config_test.exs` — Unit tests for the new membership modes, partition keying, and validation.
- `test/sagents/horde/participation_membership_test.exs` — New multi-node (`:cluster`) tests proving membership scopes to participating nodes, prunes departing nodes, and isolates partitions within one connected cluster.
- `test/sagents/agents_dynamic_supervisor_test.exs` — New tests for registration-timeout detection and retry behaviour.
- `test/sagents/file_system/file_system_supervisor_test.exs` — Tests for the new readiness check.
- `test/sagents/horde/node_transfer_test.exs` — Switched to `:participation` (drops the manual `set_members` wiring the new mode makes unnecessary).
- `test/test_helper.exs` — Mimic copies for `ProcessSupervisor`, `AgentSupervisor`, and `Horde.Cluster`.

## Testing

- Unit tests (`async: true`) cover `ClusterConfig` resolution/validation, `MembershipManager` group keying and member application (Mimic-stubbed `Horde.Cluster`), the registration-timeout retry logic, and `FileSystemSupervisor` readiness.
- Multi-node integration tests in `participation_membership_test.exs` and the updated `node_transfer_test.exs` use `LocalCluster` and are tagged `:cluster` (run with `mix test --include cluster`; require EPMD).