### PR TITLE
prep for v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## v0.9.0
+
+Reworks the optional `:horde` distribution backend so cluster membership is
+correct, dynamic, and scopable. Full write-up in
+[#134](https://github.com/sagents-ai/sagents/pull/134).
+
+### `members: :participation` — dynamic, role-scoped membership
+
+    config :sagents, :distribution, :horde
+    config :sagents, :horde, members: :participation
+
+Membership becomes exactly the nodes that run `Sagents.Supervisor`, discovered
+via an OTP `:pg` group and kept current on `:nodeup`/`:nodedown` by the new
+`Sagents.Horde.MembershipManager`. Gate `Sagents.Supervisor` to your
+agent-hosting role(s) and membership follows automatically — no node-name
+predicate, and dead nodes are pruned for free. Prefer this over `:auto` whenever
+the Erlang cluster also contains nodes that should not host agents.
+
+### `:partition` — isolate participation into independent groups
+
+    config :sagents, :horde,
+      members: :participation,
+      partition: System.get_env("FLY_REGION")
+
+An optional per-node `:partition` (any stable, opaque grouping key) scopes
+membership further so a node only clusters with same-partition nodes. The
+motivating case is geographic — set it to a Fly.io `FLY_REGION` so an agent for
+an Illinois user is never placed on, or routed through, a node in France — but it
+works for any per-node grouping. Cross-partition request routing remains an
+infra/app concern (e.g. Fly `fly-replay`). See
+[`docs/clustering.md`](https://github.com/sagents-ai/sagents/blob/main/docs/clustering.md).
+
+### Also in this release
+
+See [#134](https://github.com/sagents-ai/sagents/pull/134) for details on each:
+
+- **`members: :auto` is now real** — potential behaviour change. It previously
+  froze to a one-time node snapshot; it now drives Horde's `NodeListener` for
+  genuine dynamic membership with dead-node pruning. The undocumented static
+  `:members` forms (list / `function/0` / `{m, f, a}`) are removed; the only
+  values are `:auto` (default) and `:participation`.
+- **Registration-timeout resilience** — `AgentsDynamicSupervisor.start_agent_sync/1`
+  retries on Horde's hardcoded-5s `:via` registration timeout, via new
+  `:registration_retries` / `:registration_retry_backoff` options.
+- **FileSystem distribution-safety** — dropped `Process.alive?/1` checks on
+  potentially-remote pids that could raise.
+
 ## v0.8.0
 
 A large release that reworks the runtime foundations of the library: a new direct point-to-point event transport (replacing `Phoenix.PubSub`), session/factory lifecycle ownership moved into the library, interrupts that survive a process restart, a richer interrupt model (`:halt`, configurable `ask_user`), structured data extraction through the full middleware stack, cross-process caller-context propagation, and new tool-driven stop conditions.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A sage is a person who has attained wisdom and is often characterized by sound j
 - **Phoenix.Presence Integration** - Smart resource management that knows when to shut down idle agents
 - **PubSub Real-Time Events** - Stream agent state, messages, and events to multiple LiveView subscribers
 - **Middleware System** - Extensible plugin architecture for adding capabilities to agents, including composable observability callbacks for OpenTelemetry, metrics, or custom logging
-- **Cluster-Aware Distribution** - Optional Horde-based distribution for running agents across a cluster of nodes with automatic state migration, or run locally on a single node (the default)
+- **Cluster-Aware Distribution** - Optional Horde-based distribution for running agents across a cluster of nodes, with automatic state migration and configurable membership (role-scoped, or partitioned by region/grouping), or run locally on a single node (the default)
 - **State Persistence** - Save and restore agent conversations via optional behaviour modules for agent state and display messages
 - **Virtual Filesystem** - Isolated, in-memory file operations with optional persistence
 
@@ -45,7 +45,7 @@ Add `sagents` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:sagents, "~> 0.8.0"}
+    {:sagents, "~> 0.9.0"}
   ]
 end
 ```
@@ -679,10 +679,26 @@ When Horde is enabled, `Sagents.ProcessRegistry` and `Sagents.ProcessSupervisor`
 
 - **Automatic agent redistribution** across cluster nodes
 - **State migration** when nodes join or leave the cluster
-- **Regional clustering** for Fly.io deployments via `Sagents.Horde.ClusterConfig`
 - **Node transfer events** broadcast during redistribution so your UI can react
 
 Agents broadcast `{:agent, {:node_transferring, data}}` and `{:agent, {:node_transferred, data}}` events during Horde redistribution, allowing connected clients to follow their agent to a new node.
+
+#### Controlling membership
+
+Choose which nodes form the Horde cluster with `config :sagents, :horde, members:`:
+
+- `:auto` (default) — every visible BEAM node hosts agents.
+- `:participation` — only the nodes that run `Sagents.Supervisor`. Gate it to your agent-hosting role(s) and the other service roles stay out of the cluster. Membership is tracked via an OTP `:pg` group, and dead nodes are pruned automatically.
+
+An optional per-node `:partition` isolates participation further, so nodes only cluster with same-partition peers:
+
+```elixir
+config :sagents, :horde,
+  members: :participation,
+  partition: System.get_env("FLY_REGION")   # keep a region's agents on that region's nodes
+```
+
+`:partition` is any stable per-node grouping key — geography (a Fly.io `FLY_REGION`) is the motivating case, but a datacenter or dedicated node pool works too. See [Clustering & Distribution](docs/clustering.md) for the full model.
 
 No code changes are needed beyond the config — the `ProcessRegistry` and `ProcessSupervisor` abstractions handle backend switching transparently.
 
@@ -814,6 +830,7 @@ See [Conversations Architecture](docs/conversations_architecture.md) for the com
 
 - [Conversations Architecture](docs/conversations_architecture.md) - How the dual-view pattern works with agent state and display messages
 - [Lifecycle Management](docs/lifecycle.md) - Process supervision, timeouts, and shutdown
+- [Clustering & Distribution](docs/clustering.md) - Horde membership modes, participation, and region/partition scoping
 - [Subscriptions & Presence](docs/subscriptions_and_presence.md) - Real-time events, agent-discovery presence, and viewer-presence shutdown
 - [Middleware Development](docs/middleware.md) - Building custom middleware
 - [Observability](docs/observability.md) - Middleware-based callbacks for OpenTelemetry, metrics, and logging

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Sagents.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/sagents-ai/sagents"
-  @version "0.8.0"
+  @version "0.9.0"
 
   def project do
     [


### PR DESCRIPTION
Bump to 0.9.0, trim the CHANGELOG entry to lead with the participation and partition membership features (linking #134 for the rest), and describe the new Horde membership controls in the README.