### PR TITLE
Add transform_display_message middleware hook for shaping display messages

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -3092,6 +3092,13 @@ defmodule Sagents.AgentServer do
 
   # Save message via DisplayMessagePersistence behaviour and broadcast display messages
   defp maybe_save_and_broadcast_message(server_state, message) do
+    # Give middleware a chance to shape the message into its display
+    # representation (annotate metadata for the UI, or rewrite content) before it
+    # is persisted or broadcast. The message in agent state is untouched; this
+    # only affects the display/transcript. See
+    # Sagents.Middleware.transform_display_message/2.
+    message = apply_display_transforms(server_state, message)
+
     if server_state.display_message_persistence && server_state.conversation_id do
       module = server_state.display_message_persistence
       scope = current_scope(server_state)
@@ -3117,6 +3124,26 @@ defmodule Sagents.AgentServer do
       # No persistence configured — just broadcast the message event
       broadcast_event(server_state, {:llm_message, message})
     end
+  end
+
+  # Fold an outbound message through each middleware's transform_display_message
+  # hook, in order. Middleware that doesn't implement it passes the message
+  # through unchanged. An {:error, _} from a middleware is logged and the
+  # untransformed message continues down the chain.
+  defp apply_display_transforms(server_state, message) do
+    Enum.reduce(server_state.agent.middleware, message, fn entry, msg ->
+      case Middleware.apply_transform_display_message(msg, entry) do
+        {:ok, transformed} ->
+          transformed
+
+        {:error, reason} ->
+          Logger.error(
+            "transform_display_message failed in #{inspect(entry.module)}: #{inspect(reason)}"
+          )
+
+          msg
+      end
+    end)
   end
 
   # Persist a middleware-originated synthetic display message via the configured

--- a/lib/sagents/middleware.ex
+++ b/lib/sagents/middleware.ex
@@ -249,6 +249,63 @@ defmodule Sagents.Middleware do
   @callback after_model(State.t(), middleware_config) :: middleware_result()
 
   @doc """
+  Transform an outbound message into its display representation before it is
+  persisted or broadcast.
+
+  This is the outbound mirror of `Sagents.MessagePreprocessor`. Where a
+  preprocessor turns user input (a display chip, a mention) into something for
+  the model, this callback turns a model-produced message into something for the
+  UI. The most common use is **metadata annotation**: a middleware inspects the
+  message and sets `metadata` on it so the UI renders it accordingly. It could
+  also rewrite content (for example, an XML tag with a JSON body becoming a
+  renderable structure).
+
+  ## When it runs
+
+  Runs per message at display-commit time, inside `AgentServer`, just before the
+  message is handed to `DisplayMessagePersistence.save_message/3` and broadcast.
+  It receives the message that is about to become a display message and returns
+  the version to persist and broadcast. The message in agent state (what the LLM
+  sees next turn) is left untouched.
+
+  ## Metadata vs the LLM
+
+  `LangChain.Message.metadata` is a local field and is not sent to the LLM, so
+  annotating a message with metadata is safe: it never changes what the model
+  sees. Note that for annotated metadata to reach the persisted display record,
+  the `DisplayMessagePersistence` implementation must carry `message.metadata`
+  onto the record it stores; live subscribers receive it via the broadcast
+  message regardless.
+
+  ## Streaming caveat
+
+  Because this fires when a message is complete, a middleware that **rewrites
+  content** while the integrator streams responses will cause the streamed text
+  to be replaced once complete. Metadata annotation does not have this problem.
+
+  Because divergence between what the user sees and what the model sees is
+  possible when content is rewritten, keeping it intentional is the developer's
+  responsibility.
+
+  All of an agent's middleware run in order, each receiving the previous one's
+  output, so transforms compose.
+
+  ## Parameters
+
+  - `message` - The `LangChain.Message` about to become a display message.
+  - `config` - This middleware's configuration.
+
+  ## Returns
+
+  - `{:ok, message}` - The (possibly transformed) message to persist/broadcast.
+  - `{:error, reason}` - Failure; the untransformed message is used and the error logged.
+
+  Defaults to returning the message unchanged if not implemented.
+  """
+  @callback transform_display_message(LangChain.Message.t(), middleware_config) ::
+              {:ok, LangChain.Message.t()} | {:error, term()}
+
+  @doc """
   Handle messages sent to this middleware.
 
   Messages are routed to a specific middleware by ID through the AgentServer's
@@ -481,6 +538,7 @@ defmodule Sagents.Middleware do
     tools: 1,
     before_model: 2,
     after_model: 2,
+    transform_display_message: 2,
     handle_message: 3,
     state_schema: 0,
     on_server_start: 2,
@@ -655,6 +713,37 @@ defmodule Sagents.Middleware do
       module.after_model(state, config)
     rescue
       UndefinedFunctionError -> {:ok, state}
+    end
+  end
+
+  @doc """
+  Apply the transform_display_message callback from middleware.
+
+  Returns the (possibly transformed) message. Middleware that doesn't implement
+  the callback, returns an unexpected shape, or raises `UndefinedFunctionError`
+  passes the message through unchanged.
+
+  ## Parameters
+
+  - `message` - The `LangChain.Message` about to become a display message
+  - `entry` - MiddlewareEntry struct with module and config
+
+  ## Returns
+
+  - `{:ok, message}` - The message to persist/broadcast
+  - `{:error, reason}` - Middleware returned an error (caller decides handling)
+  """
+  @spec apply_transform_display_message(LangChain.Message.t(), Sagents.MiddlewareEntry.t()) ::
+          {:ok, LangChain.Message.t()} | {:error, term()}
+  def apply_transform_display_message(message, %MiddlewareEntry{module: module, config: config}) do
+    try do
+      case module.transform_display_message(message, config) do
+        {:ok, %LangChain.Message{} = transformed} -> {:ok, transformed}
+        {:error, reason} -> {:error, reason}
+        _other -> {:ok, message}
+      end
+    rescue
+      UndefinedFunctionError -> {:ok, message}
     end
   end
 

--- a/test/sagents/agent_server_display_transform_test.exs
+++ b/test/sagents/agent_server_display_transform_test.exs
@@ -1,0 +1,150 @@
+defmodule Sagents.AgentServerDisplayTransformTest do
+  @moduledoc """
+  Tests for the `transform_display_message/2` middleware hook.
+
+  As each message is about to become a display message, middleware can shape it
+  (annotate metadata for the UI, or rewrite content) before it is persisted and
+  broadcast. The message in agent state — what the LLM sees next turn — is left
+  untouched. Persistence stays eager (per message), so the tool-execution
+  lifecycle is unaffected.
+  """
+
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.Agent
+  alias Sagents.AgentServer
+  alias Sagents.AgentSupervisor
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.Message
+  alias LangChain.Message.ContentPart
+  alias Sagents.TestingHelpers
+
+  # Use case: annotate metadata based on the message so the
+  # UI can render it accordingly. Content is unchanged.
+  defmodule MetadataAnnotateMiddleware do
+    @behaviour Sagents.Middleware
+
+    @impl true
+    def init(opts), do: {:ok, Map.new(opts)}
+
+    @impl true
+    def transform_display_message(%Message{role: :assistant} = message, _config) do
+      annotated = Map.put(message.metadata || %{}, :ui_component, "special_card")
+      {:ok, %{message | metadata: annotated}}
+    end
+
+    def transform_display_message(message, _config), do: {:ok, message}
+  end
+
+  # Content rewrite variant: shape the display content (e.g. model emits a tag we
+  # turn into something renderable). Canonical state content is left untouched.
+  defmodule ContentRewriteMiddleware do
+    @behaviour Sagents.Middleware
+
+    @impl true
+    def init(opts), do: {:ok, Map.new(opts)}
+
+    @impl true
+    def transform_display_message(%Message{role: :assistant} = message, _config) do
+      original = ContentPart.parts_to_string(message.content)
+      {:ok, %{message | content: [ContentPart.text!("DISPLAY[" <> original <> "]")]}}
+    end
+
+    def transform_display_message(message, _config), do: {:ok, message}
+  end
+
+  setup :set_mimic_global
+
+  setup do
+    stub(ChatAnthropic, :call, fn _model, _messages, _callbacks ->
+      {:ok, [Message.new_assistant!("original content")]}
+    end)
+
+    :ok
+  end
+
+  defp start_agent(agent_id, middleware) do
+    model = ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"})
+
+    agent =
+      Agent.new!(%{
+        agent_id: agent_id,
+        model: model,
+        base_system_prompt: "Test agent",
+        replace_default_middleware: true,
+        middleware: middleware
+      })
+
+    supervisor_config = [
+      name: AgentSupervisor.get_name(agent_id),
+      agent: agent,
+      pubsub: {Phoenix.PubSub, :test_pubsub},
+      conversation_id: "conv-#{agent_id}",
+      display_message_persistence: Sagents.TestDisplayMessagePersistenceForwarding
+    ]
+
+    {:ok, _sup} = AgentSupervisor.start_link_sync(supervisor_config)
+    AgentServer.subscribe(agent_id)
+    agent_id
+  end
+
+  test "middleware can annotate display-message metadata without touching agent state" do
+    Sagents.TestDisplayMessagePersistenceForwarding.register_test_process(self())
+    agent_id = start_agent(TestingHelpers.generate_test_agent_id(), [MetadataAnnotateMiddleware])
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+    # User message passes through the transform unchanged (middleware only
+    # annotates assistant messages).
+    assert_receive {:saved_message, %Message{role: :user} = user_saved, _}, 500
+    refute user_saved.metadata[:ui_component]
+
+    # The persisted assistant display message carries the annotated metadata.
+    assert_receive {:saved_message, %Message{role: :assistant} = saved, _}, 500
+    assert saved.metadata[:ui_component] == "special_card"
+
+    # But the canonical message in agent state (what the LLM sees) is untouched.
+    state = AgentServer.get_state(agent_id)
+    last = List.last(state.messages)
+    assert last.role == :assistant
+    assert last.metadata[:ui_component] == nil
+
+    AgentServer.stop(agent_id)
+  end
+
+  test "middleware can rewrite display content without touching agent state" do
+    Sagents.TestDisplayMessagePersistenceForwarding.register_test_process(self())
+    agent_id = start_agent(TestingHelpers.generate_test_agent_id(), [ContentRewriteMiddleware])
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+    assert_receive {:saved_message, %Message{role: :user}, _}, 500
+
+    # The persisted display message is the transformed representation.
+    assert_receive {:saved_message, %Message{role: :assistant} = saved, _}, 500
+    assert ContentPart.parts_to_string(saved.content) == "DISPLAY[original content]"
+
+    # The canonical state message is the original.
+    state = AgentServer.get_state(agent_id)
+    last = state.messages |> List.last() |> Map.get(:content) |> ContentPart.parts_to_string()
+    assert last == "original content"
+
+    AgentServer.stop(agent_id)
+  end
+
+  test "no transform middleware leaves the message unchanged" do
+    Sagents.TestDisplayMessagePersistenceForwarding.register_test_process(self())
+    agent_id = start_agent(TestingHelpers.generate_test_agent_id(), [])
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+    assert_receive {:saved_message, %Message{role: :user}, _}, 500
+
+    assert_receive {:saved_message, %Message{role: :assistant} = saved, _}, 500
+    assert ContentPart.parts_to_string(saved.content) == "original content"
+    refute saved.metadata[:ui_component]
+
+    AgentServer.stop(agent_id)
+  end
+end


### PR DESCRIPTION
Closes #133

## Problem

When `AgentServer` persists display messages, middleware had no clean place to shape what the user ultimately sees. As reported in #133, edits made in `after_model` did not reach the saved transcript or connected clients. Clarifying with the reporter, the real need was lighter than content rewriting: a middleware wants to attach **metadata** to a message so the UI can render it accordingly.

## Solution

Adds a new optional `Sagents.Middleware` callback, `transform_display_message/2` — the outbound mirror of `MessagePreprocessor`. As each message is about to become a display message, every middleware gets a chance to shape it (annotate `metadata` for the UI, or rewrite content) before it is persisted and broadcast. The message in agent state (what the LLM sees next turn) is left untouched.

- Applied at the single **eager** persist/broadcast choke point (`maybe_save_and_broadcast_message`), so persistence timing is unchanged and the tool-execution lifecycle is unaffected.
- `Message.metadata` is a local field and is not sent to the LLM, so annotation never changes what the model sees. For annotated metadata to land on the stored display record, the `DisplayMessagePersistence` implementation reads `message.metadata` in its `save_message/3`; live subscribers receive it via the broadcast message.
- Composes across middleware (each receives the previous one's output). Passthrough default, so middleware that don't implement it are unaffected.

## Why not defer persistence until after `after_model`

An earlier approach deferred display persistence to the end of the turn so `after_model` edits could flow through. But `after_model` fires once at the conclusion of the entire multi-loop turn (after every tool round-trip), so deferring would leave mid-loop `update_tool_status` with nothing to update and regress live tool progress. Keeping persistence eager and shaping the display per message avoids that regression.

## Streaming caveat

Because the hook fires when a message is complete, a middleware that **rewrites content** while the integrator streams responses will cause the streamed text to be replaced once complete. Metadata annotation (the primary use case) does not have this issue.

## Tests

`test/sagents/agent_server_display_transform_test.exs`:
- metadata annotation reaches the persisted display message while agent state is untouched
- content rewrite likewise
- no-middleware passthrough

Full suite green; no changes to persistence timing or the message loop.