### PR TITLE
Extract the matched tool result on an until_tool termination

### DIFF
--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -968,8 +968,11 @@ defmodule Sagents.Middleware.SubAgent do
         {:ok, final_result}
 
       {:ok, final_result, extra} ->
-        # SubAgent completed with extra data (e.g., until_tool result)
+        # SubAgent completed with extra data (e.g., until_tool result). The run
+        # is over either way, so the process is stopped exactly as it is for a
+        # plain completion.
         Logger.debug("Task #{sub_agent_id} completed with extra data")
+        SubAgentServer.stop(sub_agent_id)
         {:ok, final_result, extra}
 
       {:interrupt, interrupt_data} ->

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -109,6 +109,8 @@ defmodule Sagents.SubAgent do
   alias Sagents.State
   alias LangChain.Chains.LLMChain
   alias LangChain.Message
+  alias LangChain.Message.ContentPart
+  alias LangChain.Message.ToolResult
   alias LangChain.Utils
 
   @primary_key false
@@ -630,6 +632,14 @@ defmodule Sagents.SubAgent do
   This is the default extraction - middleware or custom logic can provide
   different extraction.
 
+  An `until_tool` run terminates the moment the target tool's result lands, so
+  its final message is a *tool* message and the result the caller wants is that
+  tool's content — not assistant prose. Those runs extract the matched tool
+  result directly; every other completion still goes through
+  `LangChain.Utils.ChainResult.to_string/1`. A tool result flagged `is_error`
+  is returned as `{:error, content}` so a failed submission does not read as a
+  successful one.
+
   Returns `{:ok, string}` on success or `{:error, reason}` on failure.
 
   ## Examples
@@ -638,16 +648,50 @@ defmodule Sagents.SubAgent do
       {:ok, result} = SubAgent.extract_result(completed_subagent)
       # => {:ok, "Research complete: Solar energy has shown..."}
   """
+  def extract_result(%SubAgent{status: :completed, chain: chain, until_tool: until_tool})
+      when not is_nil(until_tool) do
+    case matched_tool_result(chain, until_tool) do
+      %ToolResult{is_error: true} = result -> {:error, tool_result_to_string(result)}
+      %ToolResult{} = result -> {:ok, tool_result_to_string(result)}
+      # The run ended some other way (e.g. a resume that completed with prose).
+      nil -> chain_result_to_string(chain)
+    end
+  end
+
   def extract_result(%SubAgent{status: :completed, chain: chain}) do
+    chain_result_to_string(chain)
+  end
+
+  def extract_result(%SubAgent{status: status}) do
+    {:error, {:invalid_status, status, :expected_completed}}
+  end
+
+  defp chain_result_to_string(chain) do
     case Utils.ChainResult.to_string(chain) do
       {:ok, result} -> {:ok, result}
       {:error, _chain, reason} -> {:error, reason}
     end
   end
 
-  def extract_result(%SubAgent{status: status}) do
-    {:error, {:invalid_status, status, :expected_completed}}
+  # The tool result that ended the run, mirroring the match the mode's
+  # until-tool step made on the same final message.
+  defp matched_tool_result(
+         %LLMChain{last_message: %Message{role: :tool, tool_results: results}},
+         until_tool
+       )
+       when is_list(results) do
+    names = List.wrap(until_tool)
+    Enum.find(results, &(&1.name in names))
   end
+
+  defp matched_tool_result(_chain, _until_tool), do: nil
+
+  defp tool_result_to_string(%ToolResult{content: content}) when is_binary(content), do: content
+
+  defp tool_result_to_string(%ToolResult{content: content}) when is_list(content),
+    do: ContentPart.parts_to_string(content)
+
+  defp tool_result_to_string(%ToolResult{content: nil}), do: ""
 
   ## Private Helper Functions
 

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -686,12 +686,14 @@ defmodule Sagents.SubAgent do
 
   defp matched_tool_result(_chain, _until_tool), do: nil
 
-  defp tool_result_to_string(%ToolResult{content: content}) when is_binary(content), do: content
-
-  defp tool_result_to_string(%ToolResult{content: content}) when is_list(content),
-    do: ContentPart.parts_to_string(content)
-
-  defp tool_result_to_string(%ToolResult{content: nil}), do: ""
+  # `ToolResult` normalizes content into a list of ContentParts (see
+  # `LangChain.Utils.migrate_to_content_parts/1`), so this reads parts far more
+  # often than a bare string. `content_to_string/1` returns nil for an empty
+  # result or one carrying no text parts (an image-only result, say), and
+  # `extract_result/1` promises a string — so fall back to "".
+  defp tool_result_to_string(%ToolResult{content: content}) do
+    ContentPart.content_to_string(content) || ""
+  end
 
   ## Private Helper Functions
 

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -2266,6 +2266,57 @@ defmodule Sagents.Middleware.SubAgentTest do
       assert result == "Finished!"
       assert extra == extra_data
     end
+
+    test "execute_subagent stops the SubAgentServer after a 3-tuple completion" do
+      agent_id = "parent-3tuple-stop-#{System.unique_integer([:positive])}"
+
+      {:ok, sup} =
+        start_supervised({
+          SubAgentsDynamicSupervisor,
+          agent_id: agent_id
+        })
+
+      config_with_until =
+        SubAgent.Config.new!(%{
+          name: "finisher",
+          description: "Agent with until_tool",
+          system_prompt: "You are an agent",
+          tools: [test_tool("finish_tool")],
+          until_tool: "finish_tool"
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: agent_id,
+          model: test_model(),
+          middleware: [],
+          subagents: [config_with_until]
+        )
+
+      [task_tool] = SubAgentMiddleware.tools(middleware_config)
+
+      assistant_message = Message.new_assistant!(%{content: "Finished!"})
+
+      LLMChain
+      |> stub(:run, fn chain, _opts ->
+        updated_chain =
+          chain
+          |> Map.put(:messages, chain.messages ++ [assistant_message])
+          |> Map.put(:last_message, assistant_message)
+          |> Map.put(:needs_response, false)
+
+        {:ok, updated_chain, %{tool_name: "finish_tool"}}
+      end)
+
+      args = %{"instructions" => "Finish the task", "task_name" => "finisher"}
+      context = %{state: State.new!(%{messages: []})}
+
+      assert {:ok, _result, _extra} = task_tool.function.(args, context)
+
+      # An until_tool run is over when it returns, same as a plain completion,
+      # so its server must not be left behind under the parent's supervisor.
+      assert %{active: 0} = DynamicSupervisor.count_children(sup)
+    end
   end
 
   describe "handle_resume/5" do

--- a/test/sagents/sub_agent_until_tool_result_test.exs
+++ b/test/sagents/sub_agent_until_tool_result_test.exs
@@ -1,0 +1,134 @@
+defmodule Sagents.SubAgentUntilToolResultTest do
+  @moduledoc """
+  End-to-end coverage for result extraction on an `until_tool` termination.
+
+  These tests deliberately drive the real mode pipeline with a scripted model
+  rather than stubbing `LLMChain.run/2`. An `until_tool` run terminates the
+  instant the target tool's result lands, so the chain's `last_message` is a
+  *tool* message — never the assistant message that a stubbed chain returns.
+  """
+
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Sagents.Agent
+  alias Sagents.SubAgent
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.Function
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+
+  setup :verify_on_exit!
+
+  defp test_model do
+    ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"})
+  end
+
+  defp submit_tool(fun) do
+    Function.new!(%{
+      name: "submit_report",
+      description: "Submit the final report",
+      parameters_schema: %{
+        type: "object",
+        properties: %{"summary" => %{type: "string"}}
+      },
+      function: fun
+    })
+  end
+
+  defp build_subagent(tool, until_opts) do
+    agent =
+      Agent.new!(
+        %{
+          model: test_model(),
+          base_system_prompt: "Confined agent",
+          tools: [tool],
+          middleware: []
+        },
+        replace_default_middleware: true
+      )
+
+    SubAgent.new_from_config(
+      [
+        parent_agent_id: "parent-1",
+        instructions: "produce a report",
+        agent_config: agent
+      ] ++ until_opts
+    )
+  end
+
+  # Scripts the model to emit a single call to the until-tool.
+  defp script_submit_call(args) do
+    ChatAnthropic
+    |> expect(:call, fn _model, _messages, _tools ->
+      {:ok,
+       Message.new_assistant!(%{
+         tool_calls: [
+           ToolCall.new!(%{call_id: "call_1", name: "submit_report", arguments: args})
+         ]
+       })}
+    end)
+  end
+
+  describe "extract_result/1 on an until_tool termination" do
+    test "returns the matched tool's result rather than failing on the tool message" do
+      payload = ~s({"summary":"widget X is safe"})
+
+      subagent =
+        build_subagent(submit_tool(fn _args, _ctx -> {:ok, payload} end),
+          until_tool: "submit_report"
+        )
+
+      script_submit_call(%{"summary" => "widget X is safe"})
+
+      assert {:ok, %SubAgent{status: :completed} = completed, _extra} = SubAgent.execute(subagent)
+
+      # The run genuinely ended on the tool message, which is what makes
+      # ChainResult.to_string/1 the wrong extractor here.
+      assert %Message{role: :tool} = completed.chain.last_message
+
+      assert {:ok, ^payload} = SubAgent.extract_result(completed)
+    end
+
+    test "surfaces a failing until-tool result as an error" do
+      subagent =
+        build_subagent(submit_tool(fn _args, _ctx -> {:error, "schema violation"} end),
+          until_tool: "submit_report"
+        )
+
+      script_submit_call(%{"summary" => "bad"})
+
+      assert {:ok, %SubAgent{status: :completed} = completed, _extra} = SubAgent.execute(subagent)
+
+      assert {:error, reason} = SubAgent.extract_result(completed)
+      assert reason =~ "schema violation"
+    end
+
+    test "extracts the result of an until_tool_success termination" do
+      payload = ~s({"summary":"validated"})
+
+      subagent =
+        build_subagent(submit_tool(fn _args, _ctx -> {:ok, payload} end),
+          until_tool: "submit_report",
+          require_tool_success: true
+        )
+
+      script_submit_call(%{"summary" => "validated"})
+
+      assert {:ok, %SubAgent{status: :completed} = completed, _extra} = SubAgent.execute(subagent)
+      assert {:ok, ^payload} = SubAgent.extract_result(completed)
+    end
+
+    test "still reads assistant prose when no until_tool is configured" do
+      subagent = build_subagent(submit_tool(fn _args, _ctx -> {:ok, "unused"} end), [])
+
+      ChatAnthropic
+      |> expect(:call, fn _model, _messages, _tools ->
+        {:ok, Message.new_assistant!(%{content: "all done"})}
+      end)
+
+      assert {:ok, %SubAgent{status: :completed} = completed} = SubAgent.execute(subagent)
+      assert {:ok, "all done"} = SubAgent.extract_result(completed)
+    end
+  end
+end

--- a/test/sagents/sub_agent_until_tool_result_test.exs
+++ b/test/sagents/sub_agent_until_tool_result_test.exs
@@ -16,6 +16,7 @@ defmodule Sagents.SubAgentUntilToolResultTest do
   alias LangChain.ChatModels.ChatAnthropic
   alias LangChain.Function
   alias LangChain.Message
+  alias LangChain.Message.ContentPart
   alias LangChain.Message.ToolCall
 
   setup :verify_on_exit!
@@ -117,6 +118,22 @@ defmodule Sagents.SubAgentUntilToolResultTest do
 
       assert {:ok, %SubAgent{status: :completed} = completed, _extra} = SubAgent.execute(subagent)
       assert {:ok, ^payload} = SubAgent.extract_result(completed)
+    end
+
+    test "returns a string when the terminating result carries no text part" do
+      # `ContentPart.content_to_string/1` yields nil for a result with no text
+      # part. extract_result/1 promises a string, so this must not leak a nil.
+      image = ContentPart.image!("base64data", media: :png)
+
+      subagent =
+        build_subagent(submit_tool(fn _args, _ctx -> {:ok, [image]} end),
+          until_tool: "submit_report"
+        )
+
+      script_submit_call(%{"summary" => "picture"})
+
+      assert {:ok, %SubAgent{status: :completed} = completed, _extra} = SubAgent.execute(subagent)
+      assert {:ok, ""} = SubAgent.extract_result(completed)
     end
 
     test "still reads assistant prose when no until_tool is configured" do


### PR DESCRIPTION
Fixes #141.

## The problem

`SubAgent.extract_result/1` routes every completed subagent through
`LangChain.Utils.ChainResult.to_string/1`, which requires the chain's last
message to be an assistant message. An `until_tool` run always ends on a
tool-result message, so extraction fails on every `until_tool` termination —
success and failure alike — and a parent driving the subagent through the
`task` tool receives a generic error instead of the terminating tool's result.
Full write-up in #141.

## The change

Add an `until_tool`-aware clause to `extract_result/1`. When the completed
subagent has an `until_tool` configured, it reads the **matched terminating
tool's result** from the final message and returns its content directly:

- a successful tool result becomes `{:ok, content}`;
- a tool result flagged `is_error` becomes `{:error, content}`, so a failed
  submission does not read as a success;
- if no matching tool result is found (for example a run that resumed and then
  ended in prose), it falls back to the existing `ChainResult.to_string/1`
  path unchanged.

Runs that end in assistant prose are untouched — they take exactly the path
they took before. The matching reuses the same rule the mode's own until-tool
step applies to the same message (`result.name in names`), rather than
inventing a second one, and keys on the `until_tool` field the `%SubAgent{}`
struct already carries. No new public API.

## Why this shape

The codebase already draws this distinction elsewhere: `Sagents.AgentResult`
exists precisely because an `until_tool` completion carries a `ToolResult`,
not assistant prose. `extract_result/1` predates the `until_tool` option and
was simply never brought in line with it. This change makes it consistent with
the reading layer already in the tree.

## Tests

New `test/sagents/sub_agent_until_tool_result_test.exs`: success extraction,
error propagation, the `until_tool_success` path, and a control asserting
non-`until_tool` prose extraction is unchanged. Three of the four fail without
the change; the control passes both ways. These tests drive the real mode
pipeline with a scripted model rather than stubbing `LLMChain.run/2` — worth
noting, because the existing `until_tool` tests stub a chain whose last message
is an assistant message, a shape the real pipeline cannot produce for this
mode, which is why the defect went unnoticed.

Full suite: 1549 tests, 0 failures (from a 1545/0 baseline).
`mix format --check-formatted` clean; no new credo issues.

## Open to discussion

The one judgment call worth flagging: mapping an `is_error` tool result to
`{:error, content}` changes what a failing `until_tool` termination reports to
the parent — previously a uniform extraction error, now the tool's real
message. I believe that is the correct behavior and it matches the issue's
stated expectation, but I am happy to adjust if you would prefer a different
shape.
