### PR TITLE
Recover an errored AgentServer without discarding the conversation

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -1006,6 +1006,55 @@ defmodule Sagents.AgentServer do
   end
 
   @doc """
+  Recover an errored server to `:idle`, keeping the conversation.
+
+  A run that fails partway through leaves the server in `:error`, and
+  `execute/1` refuses from there, so a transient provider fault — a rate
+  limit, a timeout, a transport error — ends the conversation permanently.
+  `reset/1` is the only other way out and it clears the whole message log,
+  which is a different thing from recovering: it discards the conversation to
+  save the process.
+
+  Recovery keeps the messages and drops only what the aborted turn left
+  behind. The state is trimmed by `Sagents.State.trim_unfinished_turn/1` to
+  the longest well-formed prefix, because the tail an aborted run leaves is
+  frequently an assistant message announcing tool calls whose results never
+  arrived — a log every provider rejects. Without the trim the next execution
+  fails on the shape of the history rather than on anything the caller did.
+
+  Returns `{:ok, info}` where `info` carries:
+
+  - `:reason` — the error the run failed with, preserved so the host can show
+    a person why the turn stopped. The server clears its own `:error` field,
+    so this reply is the only place the reason survives.
+  - `:dropped` — how many messages the trim removed. `0` means the failure
+    landed on a well-formed boundary and no work was discarded.
+
+  Broadcasts `{:status_changed, :idle, nil}` like every other transition to
+  idle, so a subscriber watching the status stream learns the server is usable
+  again without polling.
+
+  Returns `{:error, reason}` when the server is not in `:error` — recovery is
+  for a failed run, and a running, interrupted, or already-idle server is
+  asked to `cancel/1`, `resume/2`, or nothing at all.
+
+  ## Examples
+
+      # a turn failed on a provider rate limit
+      :error = AgentServer.get_status("my-agent-1")
+
+      {:ok, %{reason: reason, dropped: 1}} = AgentServer.recover("my-agent-1")
+
+      # the conversation continues from the last well-formed boundary
+      :ok = AgentServer.add_message("my-agent-1", Message.new_user!("Try again"))
+  """
+  @spec recover(String.t()) ::
+          {:ok, %{reason: term(), dropped: non_neg_integer()}} | {:error, term()}
+  def recover(agent_id) do
+    safe_call(agent_id, :recover)
+  end
+
+  @doc """
   Get the current inactivity status of an agent.
 
   Returns a map with:
@@ -1782,6 +1831,43 @@ defmodule Sagents.AgentServer do
     updated_server_state = reset_inactivity_timer(updated_server_state)
 
     {:reply, :ok, updated_server_state}
+  end
+
+  @impl true
+  def handle_call(:recover, _from, %ServerState{status: :error} = server_state) do
+    reason = server_state.error
+    {recovered_state, dropped} = State.trim_unfinished_turn(server_state.state)
+
+    # `execution_seq` is bumped for the same reason `dismiss_interrupt` bumps
+    # it: a late cast from the run that failed must not be applied to the state
+    # the recovery just established.
+    updated_server_state = %{
+      server_state
+      | state: recovered_state,
+        status: :idle,
+        error: nil,
+        interrupt_data: nil,
+        execution_seq: server_state.execution_seq + 1
+    }
+
+    # The trimmed log has to survive a restart. Without this, a cold load
+    # restores the malformed messages the failure left and the recovery is
+    # undone by the next process death.
+    updated_server_state = maybe_persist_state(updated_server_state, :on_completion)
+
+    broadcast_event(updated_server_state, {:status_changed, :idle, nil})
+    update_presence_status(updated_server_state, :idle)
+    broadcast_state_changes(updated_server_state, recovered_state)
+
+    updated_server_state = reset_inactivity_timer(updated_server_state)
+
+    {:reply, {:ok, %{reason: reason, dropped: dropped}}, updated_server_state}
+  end
+
+  @impl true
+  def handle_call(:recover, _from, server_state) do
+    {:reply, {:error, "Cannot recover, server is not in error (status: #{server_state.status})"},
+     server_state}
   end
 
   @impl true

--- a/lib/sagents/state.ex
+++ b/lib/sagents/state.ex
@@ -680,4 +680,94 @@ defmodule Sagents.State do
   end
 
   defp demote_for_cancel(other), do: other
+
+  @doc """
+  Drop the trailing messages an aborted turn left behind, so the log is a
+  shape a provider accepts again.
+
+  A run that fails partway through — a rate limit, a timeout, a transport
+  error, a crashed execution task — stops wherever it was. The messages
+  already appended stay in the state, and the tail is frequently malformed:
+  an assistant message announcing tool calls whose results never landed. Every
+  provider rejects that log, so the next execution fails for the shape of the
+  history rather than for anything the caller did, and the conversation is
+  stuck.
+
+  The boundary this trims back to is the longest prefix of the log in which
+  every assistant tool call has its matching tool result and every tool result
+  has its matching call. Messages after that boundary are dropped. Nothing
+  before it is edited: an earlier turn's messages, its tool results, and any
+  completed work are exactly as they were.
+
+  Returns `{state, dropped}` where `dropped` is the number of messages
+  removed. Idempotent: a log that is already well formed is unchanged and
+  answers `0`.
+
+  ## Examples
+
+      # the model asked for a tool and the run died before the result
+      state = State.new!(%{messages: [user, assistant_with_tool_calls]})
+      {trimmed, 1} = State.trim_unfinished_turn(state)
+      # trimmed.messages == [user]
+  """
+  @spec trim_unfinished_turn(t()) :: {t(), non_neg_integer()}
+  def trim_unfinished_turn(%State{} = state) do
+    kept = drop_unmatched_tail(Enum.reverse(state.messages), [])
+    dropped = length(state.messages) - length(kept)
+
+    {%{state | messages: kept}, dropped}
+  end
+
+  # Walks the log from its end. `older` is what has not been examined yet,
+  # newest first; `tail` is the suffix kept so far, oldest first. A message
+  # joins the tail only once the rest of the log can answer it, and a message
+  # that cannot be answered discards the whole tail behind it — which is what
+  # makes the result the longest well-formed prefix rather than merely a log
+  # without a trailing tool call.
+  defp drop_unmatched_tail([], tail), do: tail
+
+  defp drop_unmatched_tail([message | older], tail) do
+    if matched?(message, older, tail) do
+      drop_unmatched_tail(older, [message | tail])
+    else
+      drop_unmatched_tail(older, [])
+    end
+  end
+
+  # An assistant message is matched when every tool call it made has a result
+  # later in the log. A tool message is matched when every result it carries
+  # answers a call earlier in the log. Any other message stands on its own.
+  defp matched?(%LangChain.Message{role: :assistant, tool_calls: calls}, _older, tail)
+       when is_list(calls) and calls != [] do
+    answered = result_ids(tail)
+
+    Enum.all?(calls, &MapSet.member?(answered, &1.call_id))
+  end
+
+  defp matched?(%LangChain.Message{role: :tool, tool_results: results}, older, _tail)
+       when is_list(results) and results != [] do
+    called = call_ids(older)
+
+    Enum.all?(results, &MapSet.member?(called, &1.tool_call_id))
+  end
+
+  defp matched?(_message, _older, _tail), do: true
+
+  defp result_ids(messages) do
+    for %LangChain.Message{role: :tool, tool_results: results} <- messages,
+        is_list(results),
+        result <- results,
+        into: MapSet.new() do
+      result.tool_call_id
+    end
+  end
+
+  defp call_ids(messages) do
+    for %LangChain.Message{role: :assistant, tool_calls: calls} <- messages,
+        is_list(calls),
+        call <- calls,
+        into: MapSet.new() do
+      call.call_id
+    end
+  end
 end

--- a/test/sagents/agent_server_recover_test.exs
+++ b/test/sagents/agent_server_recover_test.exs
@@ -1,0 +1,259 @@
+defmodule Sagents.AgentServerRecoverTest do
+  @moduledoc """
+  Recovering an errored AgentServer without discarding the conversation.
+
+  A run that fails partway through leaves the server in `:error`, where
+  `execute/1` refuses. Before `recover/1` the only way out was `reset/1`,
+  which clears the whole message log — so a transient provider fault cost the
+  conversation. These tests drive a real failing execution and assert what the
+  recovery leaves behind.
+  """
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.{Agent, AgentServer, State}
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+  alias LangChain.Message.ToolResult
+
+  setup :set_mimic_global
+  setup :verify_on_exit!
+
+  setup_all do
+    Mimic.copy(Agent)
+    :ok
+  end
+
+  setup do
+    agent = create_test_agent()
+    {:ok, agent: agent, agent_id: agent.agent_id}
+  end
+
+  defp start_server(agent, messages) do
+    {:ok, _pid} =
+      AgentServer.start_link(
+        agent: agent,
+        initial_state: State.new!(%{messages: messages}),
+        name: AgentServer.get_name(agent.agent_id),
+        pubsub: nil
+      )
+
+    :ok
+  end
+
+  # Fails the run the way a provider fault does: the model's tool-call message
+  # has already been appended to the live state through the turn-update cast,
+  # and then the execution answers an error.
+  defp fail_mid_turn(agent, unanswered_call) do
+    Agent
+    |> expect(:execute, fn ^agent, _state, _opts ->
+      server = AgentServer.get_name(agent.agent_id)
+      seq = :sys.get_state(GenServer.whereis(server)).execution_seq
+
+      GenServer.cast(server, {:turn_state_update, seq, unanswered_call})
+
+      # The cast lands in the server's mailbox before the task's result does,
+      # so the message is in the live state by the time the failure is handled.
+      {:error, "rate_limit_error: 429"}
+    end)
+  end
+
+  defp assistant_calling(name) do
+    Message.new_assistant!(%{
+      content: nil,
+      tool_calls: [
+        ToolCall.new!(%{type: :function, call_id: "call-#{name}", name: name, arguments: "{}"})
+      ]
+    })
+  end
+
+  defp tool_answering(name) do
+    Message.new_tool_result!(%{
+      tool_results: [
+        ToolResult.new!(%{
+          type: :function,
+          tool_call_id: "call-#{name}",
+          name: name,
+          content: "ok"
+        })
+      ]
+    })
+  end
+
+  describe "recover/1 from an errored run" do
+    test "returns the server to idle and preserves the failure reason", %{
+      agent: agent,
+      agent_id: agent_id
+    } do
+      start_server(agent, [Message.new_user!("Read the ledger")])
+      fail_mid_turn(agent, assistant_calling("read_ledger"))
+
+      assert :ok = AgentServer.execute(agent_id)
+      Process.sleep(50)
+      assert AgentServer.get_status(agent_id) == :error
+
+      assert {:ok, %{reason: "rate_limit_error: 429", dropped: 1}} =
+               AgentServer.recover(agent_id)
+
+      assert AgentServer.get_status(agent_id) == :idle
+      assert AgentServer.get_info(agent_id).error == nil
+    end
+
+    test "trims the unanswered tool call and keeps everything before it", %{
+      agent: agent,
+      agent_id: agent_id
+    } do
+      history = [
+        Message.new_user!("Read the ledger"),
+        assistant_calling("read_ledger"),
+        tool_answering("read_ledger"),
+        Message.new_assistant!("41 rows."),
+        Message.new_user!("Export it")
+      ]
+
+      start_server(agent, history)
+      fail_mid_turn(agent, assistant_calling("export"))
+
+      assert :ok = AgentServer.execute(agent_id)
+      Process.sleep(50)
+
+      assert {:ok, %{dropped: 1}} = AgentServer.recover(agent_id)
+
+      assert AgentServer.get_state(agent_id).messages == history
+    end
+
+    test "keeps the log untouched when the failure landed on a well-formed boundary", %{
+      agent: agent,
+      agent_id: agent_id
+    } do
+      history = [Message.new_user!("Read the ledger")]
+      start_server(agent, history)
+
+      Agent
+      |> expect(:execute, fn ^agent, _state, _opts -> {:error, "connection refused"} end)
+
+      assert :ok = AgentServer.execute(agent_id)
+      Process.sleep(50)
+
+      assert {:ok, %{reason: "connection refused", dropped: 0}} = AgentServer.recover(agent_id)
+      assert AgentServer.get_state(agent_id).messages == history
+    end
+
+    test "the next execution runs, which is the whole point", %{agent: agent, agent_id: agent_id} do
+      start_server(agent, [Message.new_user!("Read the ledger")])
+      fail_mid_turn(agent, assistant_calling("read_ledger"))
+
+      assert :ok = AgentServer.execute(agent_id)
+      Process.sleep(50)
+      assert {:error, _refused} = AgentServer.execute(agent_id)
+
+      assert {:ok, _info} = AgentServer.recover(agent_id)
+
+      Agent
+      |> expect(:execute, fn ^agent, state, _opts ->
+        {:ok, State.add_message(state, Message.new_assistant!("41 rows."))}
+      end)
+
+      assert :ok = AgentServer.execute(agent_id)
+      Process.sleep(50)
+
+      assert AgentServer.get_status(agent_id) == :idle
+
+      assert %Message{role: :assistant, content: [%{content: "41 rows."}]} =
+               List.last(AgentServer.get_state(agent_id).messages)
+    end
+
+    test "broadcasts the transition to idle", %{agent: agent, agent_id: agent_id} do
+      start_server(agent, [Message.new_user!("Read the ledger")])
+      {:ok, _pid, _ref} = AgentServer.subscribe(agent_id)
+
+      fail_mid_turn(agent, assistant_calling("read_ledger"))
+
+      assert :ok = AgentServer.execute(agent_id)
+      assert_receive {:agent, {:status_changed, :error, "rate_limit_error: 429"}}, 500
+
+      assert {:ok, _info} = AgentServer.recover(agent_id)
+      assert_receive {:agent, {:status_changed, :idle, nil}}, 500
+    end
+
+    test "is refused when the server is not in error", %{agent: agent, agent_id: agent_id} do
+      start_server(agent, [])
+
+      assert {:error, message} = AgentServer.recover(agent_id)
+      assert message =~ "status: idle"
+    end
+  end
+
+  describe "State.trim_unfinished_turn/1" do
+    test "drops an assistant message whose tool calls were never answered" do
+      state = State.new!(%{messages: [Message.new_user!("Go"), assistant_calling("read")]})
+
+      assert {trimmed, 1} = State.trim_unfinished_turn(state)
+      assert Enum.map(trimmed.messages, & &1.role) == [:user]
+    end
+
+    test "drops a partially answered batch whole" do
+      calls =
+        Message.new_assistant!(%{
+          content: nil,
+          tool_calls: [
+            ToolCall.new!(%{type: :function, call_id: "call-a", name: "a", arguments: "{}"}),
+            ToolCall.new!(%{type: :function, call_id: "call-b", name: "b", arguments: "{}"})
+          ]
+        })
+
+      answer_a =
+        Message.new_tool_result!(%{
+          tool_results: [
+            ToolResult.new!(%{type: :function, tool_call_id: "call-a", name: "a", content: "ok"})
+          ]
+        })
+
+      state = State.new!(%{messages: [Message.new_user!("Go"), calls, answer_a]})
+
+      # `call-b` has no result, so the assistant message is unmatched and the
+      # result that did land goes with it — a lone tool result answering a call
+      # that is no longer in the log is exactly the shape being removed.
+      assert {trimmed, 2} = State.trim_unfinished_turn(state)
+      assert Enum.map(trimmed.messages, & &1.role) == [:user]
+    end
+
+    test "leaves a well-formed log alone" do
+      messages = [
+        Message.new_user!("Go"),
+        assistant_calling("read"),
+        tool_answering("read"),
+        Message.new_assistant!("Done.")
+      ]
+
+      state = State.new!(%{messages: messages})
+
+      assert {trimmed, 0} = State.trim_unfinished_turn(state)
+      assert trimmed.messages == messages
+    end
+
+    test "is idempotent" do
+      state = State.new!(%{messages: [Message.new_user!("Go"), assistant_calling("read")]})
+
+      {once, 1} = State.trim_unfinished_turn(state)
+      assert {^once, 0} = State.trim_unfinished_turn(once)
+    end
+
+    test "keeps a trailing user message, which a provider accepts" do
+      messages = [
+        Message.new_user!("Go"),
+        Message.new_assistant!("Sure."),
+        Message.new_user!("More")
+      ]
+
+      state = State.new!(%{messages: messages})
+
+      assert {trimmed, 0} = State.trim_unfinished_turn(state)
+      assert trimmed.messages == messages
+    end
+
+    test "answers an empty log unchanged" do
+      assert {%State{messages: []}, 0} = State.trim_unfinished_turn(State.new!(%{}))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #145.

A run that fails partway through — a rate limit, a timeout, a transport
error, a crashed execution task — leaves the server in `:error`, and
`execute/1` refuses from there. `reset/1` is the only exit, and it clears
the whole message log, so the only way past a transient provider fault is
to throw the conversation away. Every host that runs a chat against an
AgentServer hits this, and the recovery each of them would write is the
same one.

`AgentServer.recover/1` is that recovery. From `:error` it returns the
server to `:idle`, keeps the messages, and answers
`{:ok, %{reason: reason, dropped: n}}` — the failure reason preserved for
the host to show a person, and the count of messages the trim removed. It
broadcasts `{:status_changed, :idle, nil}` like every other transition to
idle, so a subscriber already watching the status stream needs no new
event shape. From any other status it returns a named error, because
recovery is for a failed run and a running or interrupted server is asked
to `cancel/1` or `resume/2` instead.

The trim is why this belongs in the library rather than in each host.
`{:turn_state_update, ...}` appends each completed message to the live
state as the turn runs, so a run that dies after the model announced tool
calls leaves an assistant message whose results never arrived. Every
provider rejects that log, so the next execution fails on the shape of the
history rather than on anything the caller did.
`State.trim_unfinished_turn/1` drops back to the longest prefix in which
every tool call has its result and every result has its call, and edits
nothing before that boundary. It is the sibling of
`cancel_pending_interrupts/1`, which already keeps the log well formed for
a different cause.

Two details the state machinery owns. `execution_seq` is bumped, so a late
cast from the run that failed cannot be applied to the state the recovery
just established — the same reason `dismiss_interrupt` bumps it. The
trimmed state is persisted, because without that a cold load restores the
malformed messages and the next process death undoes the recovery.

Tests: `test/sagents/agent_server_recover_test.exs`, 12 cases covering the
recovery from a real failing execution and the trim rule directly.

Note on the branch: this contains only this fix, rebased on current main
— independent of #143 and #144, mergeable in any order.
