### PR TITLE
Preserve whitespace-only content when creating a file

### DIFF
--- a/lib/sagents/file_system/file_entry.ex
+++ b/lib/sagents/file_system/file_entry.ex
@@ -51,15 +51,28 @@ defmodule Sagents.FileSystem.FileEntry do
   This is the full internal changeset used by `new_file/3` and friends.
   It casts all schema fields including `:path`, `:content`, and
   `:dirty_content`.
+
+  `empty_values: []` opts out of Ecto's default empty-value coercion. By
+  default Ecto treats any string that trims to `""` as absent and replaces
+  it with the field's default — so `""`, `"\\n"`, and `"   "` would all be
+  stored as `nil`. A filesystem must store bytes verbatim: a file holding a
+  single newline is a real file with real content, not a missing value.
+  Without this, whitespace-only writes report success while silently
+  discarding the content.
   """
   def internal_changeset(entry \\ %FileEntry{}, attrs) do
     entry
-    |> cast(attrs, [
-      :path,
-      :content,
-      :loaded,
-      :dirty_content
-    ])
+    |> cast(
+      attrs,
+      [
+        :path,
+        :content,
+        :loaded,
+        :dirty_content
+      ],
+      # NOTE: Passing an empty list means NO values are treated as empty.
+      empty_values: []
+    )
     |> cast_embed(:metadata, with: &FileMetadata.changeset/2)
     |> validate_path()
     |> validate_required([:loaded, :dirty_content])

--- a/test/sagents/file_system/file_entry_test.exs
+++ b/test/sagents/file_system/file_entry_test.exs
@@ -62,6 +62,27 @@ defmodule Sagents.FileSystem.FileEntryTest do
       assert {:error, error} = FileEntry.new_file("/path//file.txt", "data")
       assert error =~ "invalid segment"
     end
+
+    # A filesystem stores bytes verbatim. Whitespace-only content is a real
+    # file, not an absent value, so it must survive the write unchanged —
+    # Ecto's default empty-value coercion would turn every one of these into
+    # nil while still reporting success.
+    for {label, content} <- [
+          {"empty string", ""},
+          {"single newline", "\n"},
+          {"two newlines", "\n\n"},
+          {"spaces", "   "},
+          {"tab", "\t"},
+          {"mixed whitespace", " \n \t\n"}
+        ] do
+      test "preserves whitespace-only content: #{label}" do
+        content = unquote(content)
+
+        assert {:ok, entry} = FileEntry.new_file("/tmp/spacer.md", content)
+        assert entry.content == content
+        assert entry.metadata.size == byte_size(content)
+      end
+    end
   end
 
   describe "new_indexed_file/1" do

--- a/test/sagents/file_system_server_test.exs
+++ b/test/sagents/file_system_server_test.exs
@@ -128,6 +128,39 @@ defmodule Sagents.FileSystemServerTest do
       assert entry.dirty_content == false
     end
 
+    # Whitespace-only payloads are legitimate file contents (a spacer file
+    # holding one newline, for example). They must round-trip byte-for-byte
+    # rather than being coerced to nil on the way in.
+    for {label, content} <- [
+          {"empty string", ""},
+          {"single newline", "\n"},
+          {"two newlines", "\n\n"},
+          {"spaces", "   "},
+          {"mixed whitespace", " \n \t\n"}
+        ] do
+      test "round-trips whitespace-only content: #{label}", %{agent_id: agent_id} do
+        {:ok, _pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
+        content = unquote(content)
+        path = "/scratch/spacer.md"
+
+        assert {:ok, _entry} = FileSystemServer.write_file({:agent, agent_id}, path, content)
+        assert {:ok, entry} = FileSystemServer.read_file({:agent, agent_id}, path)
+        assert entry.content == content
+        assert entry.metadata.size == byte_size(content)
+      end
+
+      test "overwrite with whitespace-only content: #{label}", %{agent_id: agent_id} do
+        {:ok, _pid} = FileSystemServer.start_link(scope_key: {:agent, agent_id})
+        content = unquote(content)
+        path = "/scratch/spacer.md"
+
+        {:ok, _entry} = FileSystemServer.write_file({:agent, agent_id}, path, "original")
+        assert {:ok, _entry} = FileSystemServer.write_file({:agent, agent_id}, path, content)
+        assert {:ok, entry} = FileSystemServer.read_file({:agent, agent_id}, path)
+        assert entry.content == content
+      end
+    end
+
     test "writes to unconfigured directory as memory-only", %{
       agent_id: agent_id
     } do


### PR DESCRIPTION
## Problem

Creating a file with empty or whitespace-only content silently discarded that content. `FileEntry.new_file/3` builds its entry through an Ecto changeset, and Ecto's default `:empty_values` is `[""]`, tested against the value after `Ecto.Type.trim/2`. That meant `""`, `"\n"`, `"   "`, and `"\t"` were all flagged as *absent* and replaced by the field's default (`nil`), while the changeset stayed valid and the write reported success.

A filesystem has to store bytes verbatim. A spacer file holding a single newline is real content, not a missing value.

The bug was easy to miss because everything around it looked healthy. Metadata is computed from the raw `content` argument *before* the changeset runs, so `size: 0` and the checksum of `""` were both correct, and `:content` is not covered by `validate_required/2`. The result was an entry with `loaded: true` and `content: nil`, which is exactly the shape a not-yet-loaded lazy file is supposed to have.

There was also an asymmetry that hid it further: `update_content/3` builds the struct directly without a changeset, so *overwriting* an existing file with whitespace always worked. Only the **first** write to a path lost its content.

## Solution

Pass `empty_values: []` to `cast/4` in `internal_changeset/2`. Ecto's emptiness check is a membership test (`trimmed_value in empty_values`), so an empty list makes it always false: nothing is ever treated as absent, and the value reaches the field byte for byte.

This does not change handling of non-empty content. The trim only ever fed the membership test and was never applied to the stored value, so content like `"  hi  "` was already stored unmodified.

Scope of the behavior change is narrow. `internal_changeset/2` has exactly two callers, `new_file/3` and `new_indexed_file/2`, and the latter always passes `content: nil`, which was never affected by the default (`nil` is not in `[""]`). So `new_file/3` is the only path that behaves differently.

## Changes

- `lib/sagents/file_system/file_entry.ex` — Pass `empty_values: []` to `cast/4` in `internal_changeset/2` so file content is stored verbatim
- `lib/sagents/file_system/file_entry.ex` (`@doc` on `internal_changeset/2`) — Documented what Ecto's default coercion does and why a filesystem must opt out, so the option is not mistaken for noise and removed later
- `test/sagents/file_system/file_entry_test.exs` — Unit coverage at the changeset boundary: six generated cases (`""`, `"\n"`, `"\n\n"`, `"   "`, `"\t"`, `" \n \t\n"`) asserting both `entry.content` and `entry.metadata.size`
- `test/sagents/file_system_server_test.exs` — End-to-end coverage through `FileSystemServer`: five generated cases run twice each, once as a fresh write plus read round-trip, and once overwriting existing content

## Testing

`mix test test/sagents/file_system/file_entry_test.exs test/sagents/file_system_server_test.exs` passes, 87 tests.

The new tests were confirmed to be load-bearing rather than vacuous: with `empty_values: []` removed from `internal_changeset/2`, the six `file_entry_test.exs` cases fail with `left: nil`, one per whitespace variant. Restoring the option returns the file to green.

The server-level tests deliberately cover both the create path and the overwrite path. The overwrite cases passed before this change (they go through `update_content/3`, which bypasses the changeset) and are included to pin down that asymmetry so a future refactor routing both paths through the changeset cannot silently reintroduce the bug.

No new external calls, so no live-API tagged tests were needed.
