### PR TITLE
Propagate a sub-agent :halt to the parent as a halt

### DIFF
--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -144,6 +144,26 @@ defmodule Sagents.Middleware.SubAgent do
       7. Parent agent resumes
       8. Task tool calls SubAgentServer.resume(decisions)
       9. SubAgent continues and completes
+
+  ## Halts are propagated, not wrapped
+
+  The flow above applies to interrupts that can be *resolved*: a HITL
+  approval, a question. A `:halt` is different. It declares the workflow
+  over, so there is nothing to approve and nothing to resume.
+
+  When a sub-agent tool emits `%{type: :halt}` (or a `:multiple_interrupts`
+  batch containing one, since "halt wins"), the halt is propagated to the parent
+  **as a halt** rather than wrapped in `:subagent_hitl`, and the sub-agent
+  process is stopped. This is what lets the parent's existing halt machinery
+  apply: the loop terminates without another LLM call,
+  `Sagents.Middleware.Haltable` claims the interrupt for cold-start restore,
+  and `Sagents.AgentUtils.interrupt_session_changes/1` surfaces the halt's
+  author-facing `:message`.
+
+  The propagated halt keeps the emitting tool's `:source_tool` and gains a
+  `:source_task` naming the sub-agent that ran it. It deliberately carries no
+  `:sub_agent_id`, because a restorable interrupt must be pure data and the
+  sub-agent process does not survive a reboot.
   """
 
   @behaviour Sagents.Middleware
@@ -973,17 +993,23 @@ defmodule Sagents.Middleware.SubAgent do
         {:ok, final_result, extra}
 
       {:interrupt, interrupt_data} ->
-        Logger.info("Task '#{task_name}' interrupted for HITL")
+        case find_halt(interrupt_data) do
+          nil ->
+            Logger.info("Task '#{task_name}' interrupted for HITL")
 
-        # Return 3-tuple that LangChain.execute_tool_call recognizes
-        # Keep alive — needs resume later
-        {:interrupt, "'#{task_name}' requires human approval.",
-         %{
-           type: :subagent_hitl,
-           sub_agent_id: sub_agent_id,
-           task_name: task_name,
-           interrupt_data: interrupt_data
-         }}
+            # Return 3-tuple that LangChain.execute_tool_call recognizes
+            # Keep alive — needs resume later
+            {:interrupt, "'#{task_name}' requires human approval.",
+             %{
+               type: :subagent_hitl,
+               sub_agent_id: sub_agent_id,
+               task_name: task_name,
+               interrupt_data: interrupt_data
+             }}
+
+          halt ->
+            propagate_halt(halt, sub_agent_id, task_name)
+        end
 
       {:error, reason} ->
         Logger.error("Task #{sub_agent_id} failed: #{inspect(reason)}")
@@ -994,6 +1020,47 @@ defmodule Sagents.Middleware.SubAgent do
         SubAgentServer.stop(sub_agent_id)
         {:error, format_subagent_error(reason, task_name)}
     end
+  end
+
+  # Locate a `:halt` in sub-agent interrupt data.
+  #
+  # "Halt wins": inside a `:multiple_interrupts` batch a single halt terminates
+  # the workflow, so sibling questions/approvals are moot. This mirrors the
+  # policy already implemented in `Haltable.restorable_interrupt?/1` and
+  # `AgentUtils.interrupt_session_changes/1`.
+  defp find_halt(%{type: :halt} = halt), do: halt
+
+  defp find_halt(%{type: :multiple_interrupts, interrupts: subs}) when is_list(subs) do
+    Enum.find(subs, &match?(%{type: :halt}, &1))
+  end
+
+  defp find_halt(_other), do: nil
+
+  # A `:halt` raised inside a sub-agent is terminal: there is nothing to approve
+  # and nothing to resume. Propagate it to the parent *as a halt* rather than
+  # wrapping it in `:subagent_hitl`, so the parent's existing halt machinery
+  # applies: the loop stops without another LLM call, `Middleware.Haltable`
+  # claims it for cold-start restore, and `AgentUtils.interrupt_session_changes/1`
+  # surfaces the author-facing `:message` instead of an empty approval prompt.
+  #
+  # The sub-agent process is stopped, unlike the HITL pause above: there is no
+  # resume leg to keep it alive for. Dropping the sub-agent's `:tool_call_id` is
+  # what makes the propagated halt pure data and therefore restorable. It must
+  # not reference a process that will not survive a reboot. LangChain refills
+  # `:tool_call_id` with the parent's `task` call when it normalizes this return.
+  defp propagate_halt(halt, sub_agent_id, task_name) do
+    Logger.info("Task '#{task_name}' halted by a sub-agent tool")
+    SubAgentServer.stop(sub_agent_id)
+
+    message = Map.get(halt, :message, "Sub-agent task '#{task_name}' halted.")
+
+    propagated =
+      halt
+      |> Map.drop([:tool_call_id])
+      |> Map.put(:type, :halt)
+      |> Map.put(:source_task, task_name)
+
+    {:interrupt, "Task '#{task_name}' halted: #{message}", propagated}
   end
 
   # Preserve structure for LangChainError (e.g., length-stopped) so the caller
@@ -1091,17 +1158,23 @@ defmodule Sagents.Middleware.SubAgent do
         {:ok, final_result, extra}
 
       {:interrupt, interrupt_data} ->
-        Logger.info("SubAgent '#{task_name}' interrupted again")
+        case find_halt(interrupt_data) do
+          nil ->
+            Logger.info("SubAgent '#{task_name}' interrupted again")
 
-        # Return 3-tuple that LangChain.execute_tool_call recognizes
-        # Keep alive — needs resume later
-        {:interrupt, "'#{task_name}' requires human approval.",
-         %{
-           type: :subagent_hitl,
-           sub_agent_id: sub_agent_id,
-           task_name: task_name,
-           interrupt_data: interrupt_data
-         }}
+            # Return 3-tuple that LangChain.execute_tool_call recognizes
+            # Keep alive — needs resume later
+            {:interrupt, "'#{task_name}' requires human approval.",
+             %{
+               type: :subagent_hitl,
+               sub_agent_id: sub_agent_id,
+               task_name: task_name,
+               interrupt_data: interrupt_data
+             }}
+
+          halt ->
+            propagate_halt(halt, sub_agent_id, task_name)
+        end
 
       {:error, reason} ->
         Logger.error("SubAgent #{sub_agent_id} resume failed: #{inspect(reason)}")

--- a/test/sagents/subagent_halt_propagation_test.exs
+++ b/test/sagents/subagent_halt_propagation_test.exs
@@ -1,0 +1,275 @@
+defmodule Sagents.SubAgentHaltPropagationTest do
+  @moduledoc """
+  A `:halt` raised by a tool *inside a sub-agent* must reach the parent as a
+  halt.
+
+  `Sagents.Middleware.Haltable` defines a halt as terminal: the framework does
+  not invoke the LLM again, the author-facing `:message` is surfaced, and the
+  interrupt survives cold start so a UI can re-render it. Halt was originally
+  designed for a tool called directly by a top-level agent; these tests cover
+  the sub-agent case.
+
+  Previously `Middleware.SubAgent` wrapped *every* sub-agent interrupt as
+  `%{type: :subagent_hitl}` with the message "requires human approval". The
+  halt survived nested under `:interrupt_data`, but everything that enforces
+  halt semantics dispatches on the *outer* type, so all three guarantees were
+  lost: the loop kept running, `Haltable` refused to claim it, and the UI
+  rendered an empty approval prompt instead of the halt message.
+  """
+
+  use ExUnit.Case, async: false
+  use Mimic
+
+  import Sagents.TestingHelpers, only: [wait_until: 1]
+
+  alias Sagents.{Agent, AgentUtils, State, SubAgent, SubAgentServer}
+  alias Sagents.Middleware.Haltable
+  alias Sagents.SubAgentsDynamicSupervisor
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.Function
+  alias LangChain.Message
+  alias LangChain.Message.ToolCall
+
+  setup :set_mimic_global
+  setup :verify_on_exit!
+
+  setup_all do
+    unless Process.whereis(Sagents.Registry) do
+      {:ok, _pid} = Registry.start_link(keys: :unique, name: Sagents.Registry)
+    end
+
+    Mimic.copy(ChatAnthropic)
+
+    :ok
+  end
+
+  @halt_message "The outline is missing required sections. Fix and retry."
+
+  defp test_model do
+    ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"})
+  end
+
+  # Halts from inside its body, exactly as the Haltable moduledoc documents.
+  defp halting_tool do
+    Function.new!(%{
+      name: "gate_check",
+      description: "Checks a policy gate",
+      function: fn _args, _context ->
+        {:interrupt, "Workflow halted: policy gate failed",
+         %{type: :halt, source_tool: "gate_check", message: @halt_message}}
+      end
+    })
+  end
+
+  # Emits a non-halt tool interrupt, to prove the HITL path is untouched.
+  defp escalating_tool do
+    Function.new!(%{
+      name: "escalate",
+      description: "Escalates for approval",
+      function: fn _args, _context ->
+        {:interrupt, "Escalation required", %{type: :escalation, capability: "finance_export"}}
+      end
+    })
+  end
+
+  defp make_parent_agent(subagent_configs) do
+    agent =
+      Agent.new!(
+        %{
+          agent_id: "parent-#{System.unique_integer([:positive])}",
+          model: test_model(),
+          system_prompt: "You delegate tasks to sub-agents."
+        },
+        subagent_opts: [subagents: subagent_configs]
+      )
+
+    {:ok, _pid} = SubAgentsDynamicSupervisor.start_link(agent_id: agent.agent_id)
+
+    agent
+  end
+
+  defp subagent_config(tool) do
+    SubAgent.Config.new!(%{
+      name: "scout",
+      description: "Scouts an outline",
+      system_prompt: "You scout outlines.",
+      tools: [tool]
+    })
+  end
+
+  # Parent calls `task`; the sub-agent calls `tool_name`, which interrupts.
+  # Any further LLM call means the interrupt failed to stop the loop, so the
+  # stub raises rather than quietly letting the run continue.
+  defp stub_llm(tool_name) do
+    call_count = :counters.new(1, [:atomics])
+
+    ChatAnthropic
+    |> stub(:call, fn _model, _messages, _tools ->
+      count = :counters.get(call_count, 1)
+      :counters.add(call_count, 1, 1)
+
+      case count do
+        0 ->
+          {:ok,
+           [
+             Message.new_assistant!(%{
+               tool_calls: [
+                 ToolCall.new!(%{
+                   call_id: "parent_tc_1",
+                   name: "task",
+                   arguments: %{"instructions" => "Scout the outline", "task_name" => "scout"}
+                 })
+               ]
+             })
+           ]}
+
+        1 ->
+          {:ok,
+           [
+             Message.new_assistant!(%{
+               tool_calls: [
+                 ToolCall.new!(%{call_id: "sub_tc_1", name: tool_name, arguments: %{}})
+               ]
+             })
+           ]}
+
+        n ->
+          raise "LLM called again (##{n}) after the sub-agent interrupted"
+      end
+    end)
+
+    call_count
+  end
+
+  defp run_until_interrupt(tool) do
+    agent = make_parent_agent([subagent_config(tool)])
+    call_count = stub_llm(tool.name)
+    initial_state = State.new!(%{messages: [Message.new_user!("Scout the outline")]})
+
+    {Agent.execute(agent, initial_state), call_count}
+  end
+
+  describe "a :halt raised inside a sub-agent" do
+    test "reaches the parent as a :halt, preserving the author-facing message" do
+      {result, _count} = run_until_interrupt(halting_tool())
+
+      assert {:interrupt, _state, interrupt_data} = result
+
+      assert interrupt_data.type == :halt
+      assert interrupt_data.message == @halt_message
+
+      # Provenance is preserved: which tool halted, and which task it ran under.
+      assert interrupt_data.source_tool == "gate_check"
+      assert interrupt_data.source_task == "scout"
+    end
+
+    test "stops the loop without another LLM call" do
+      # The central Haltable guarantee: "the framework does NOT invoke the LLM
+      # again". Two calls total: the parent's `task` and the sub-agent's
+      # `gate_check`. A third would mean the halt was demoted to a tool result.
+      {result, call_count} = run_until_interrupt(halting_tool())
+
+      assert {:interrupt, _state, _data} = result
+      assert :counters.get(call_count, 1) == 2
+    end
+
+    test "is claimed by Haltable, so it survives cold start" do
+      {result, _count} = run_until_interrupt(halting_tool())
+
+      assert {:interrupt, _state, interrupt_data} = result
+      assert Haltable.restorable_interrupt?(interrupt_data)
+    end
+
+    test "surfaces the halt message to the UI instead of an empty approval prompt" do
+      {result, _count} = run_until_interrupt(halting_tool())
+
+      assert {:interrupt, _state, interrupt_data} = result
+
+      changes = AgentUtils.interrupt_session_changes(interrupt_data)
+
+      assert %{pending_halt: %{message: @halt_message}} = changes
+      assert Map.get(changes, :pending_tools, []) == []
+    end
+
+    test "carries no reference to the sub-agent process, so it is pure data" do
+      # A restorable interrupt must not point at a process that will not
+      # survive a reboot. This is why the halt is propagated rather than
+      # wrapped: the `:subagent_hitl` wrapper carries :sub_agent_id.
+      {result, _count} = run_until_interrupt(halting_tool())
+
+      assert {:interrupt, _state, interrupt_data} = result
+
+      refute Map.has_key?(interrupt_data, :sub_agent_id)
+
+      # LangChain refills :tool_call_id with the *parent's* task call, not the
+      # sub-agent's inner call.
+      assert interrupt_data.tool_call_id == "parent_tc_1"
+    end
+
+    test "stops the sub-agent process, since there is nothing to resume" do
+      agent = make_parent_agent([subagent_config(halting_tool())])
+      stub_llm("gate_check")
+      initial_state = State.new!(%{messages: [Message.new_user!("Scout the outline")]})
+
+      assert {:interrupt, _state, _data} = Agent.execute(agent, initial_state)
+
+      # No sub-agent processes should be left running under this parent. The
+      # propagated halt carries no :sub_agent_id to look up, so check the
+      # parent's sub-agent supervisor directly.
+      supervisor = SubAgentsDynamicSupervisor.whereis(agent.agent_id)
+
+      assert wait_until(fn ->
+               DynamicSupervisor.count_children(supervisor).active == 0
+             end)
+    end
+  end
+
+  describe "halt wins inside :multiple_interrupts" do
+    test "a halt sibling propagates as a halt" do
+      batch = %{
+        type: :multiple_interrupts,
+        interrupts: [
+          %{type: :ask_user_question, question: "Which one?", tool_call_id: "a"},
+          %{type: :halt, source_tool: "gate_check", message: @halt_message, tool_call_id: "b"}
+        ]
+      }
+
+      assert %{type: :halt, message: @halt_message} = find_halt_via_public_behaviour(batch)
+    end
+
+    test "a batch with no halt is left to the HITL path" do
+      batch = %{
+        type: :multiple_interrupts,
+        interrupts: [%{type: :ask_user_question, question: "Which one?", tool_call_id: "a"}]
+      }
+
+      assert find_halt_via_public_behaviour(batch) == nil
+    end
+  end
+
+  describe "non-halt sub-agent interrupts" do
+    test "still propagate as :subagent_hitl and keep the sub-agent alive" do
+      # Regression guard: the halt branch must not swallow ordinary tool-raised
+      # interrupts, which still need the approval round-trip.
+      {result, _count} = run_until_interrupt(escalating_tool())
+
+      assert {:interrupt, _state, interrupt_data} = result
+
+      assert interrupt_data.type == :subagent_hitl
+      assert interrupt_data.task_name == "scout"
+      assert %{type: :escalation} = interrupt_data.interrupt_data
+
+      # Kept alive for the resume leg.
+      assert SubAgentServer.whereis(interrupt_data.sub_agent_id) != nil
+    end
+  end
+
+  # `find_halt/1` is private. Exercise the same policy through the behaviour it
+  # drives: Haltable claims exactly the batches that contain a halt, which is
+  # the rule `find_halt/1` implements.
+  defp find_halt_via_public_behaviour(%{type: :multiple_interrupts, interrupts: subs} = batch) do
+    if Haltable.restorable_interrupt?(batch) do
+      Enum.find(subs, &match?(%{type: :halt}, &1))
+    end
+  end
+end


### PR DESCRIPTION
## The problem

`Sagents.Middleware.Haltable` defines a halt as terminal: the framework does not
invoke the LLM again, the author-facing `:message` is surfaced, and the
interrupt survives cold start so a UI can re-render it.

Halt was designed for a tool called directly by a top-level agent. Raised inside
a **sub-agent**, none of those three guarantees held.

`Middleware.SubAgent` wrapped every sub-agent interrupt as
`%{type: :subagent_hitl}` with the message `"'<task>' requires human approval."`.
The halt survived nested under `:interrupt_data`, but everything that enforces
halt semantics dispatches on the *outer* type:

| Guarantee | Mechanism | Result when wrapped |
| --- | --- | --- |
| Loop terminates | interrupt type | Parent resumed and called the LLM again |
| Survives cold start | `Haltable.restorable_interrupt?/1` | Refused. It only claims `:halt` |
| Message reaches the user | `AgentUtils.interrupt_session_changes/1` | Fell through to `present_hitl_tools/1`, which finds no `:action_requests` in a halt. `pending_halt: nil`, `pending_tools: []`, so an empty approval prompt and the message never shown |

So a tool that said "stop the workflow, here is why" produced an empty approval
dialog, and approving it resumed the parent.

## The change

Propagate the halt to the parent **as a halt** rather than wrapping it, and stop
the sub-agent process since there is nothing to resume.

Applied at **both** wrapping sites: `execute_subagent/2` and `resume_subagent/2`.
The second matters because a sub-agent can halt on a later turn, after an
approved HITL round-trip.

Two small helpers:

- `find_halt/1` locates a `:halt`, including inside a `:multiple_interrupts`
  batch. This mirrors the "halt wins" policy already implemented in
  `Haltable.restorable_interrupt?/1` and `AgentUtils.interrupt_session_changes/1`.
- `propagate_halt/3` stops the sub-agent, preserves the emitting tool's
  `:source_tool`, and adds `:source_task` naming the sub-agent that ran it.

The propagated halt deliberately drops the sub-agent's `:tool_call_id` and
carries no `:sub_agent_id`. That is what makes it pure data, and therefore
restorable. This is the same reasoning recorded on `Middleware.SubAgent`, which
declines `restorable_interrupt?/1` precisely because `:subagent_hitl` references
a process that does not survive a reboot. LangChain refills `:tool_call_id` with
the parent's `task` call when it normalizes the return.

Non-halt interrupts are untouched and still take the `:subagent_hitl` approval
round-trip with the sub-agent kept alive.

## Tests

New `test/sagents/subagent_halt_propagation_test.exs`, 9 tests. The halt ones
are end-to-end: `ChatAnthropic.call/3` is mocked so the whole real pipeline runs
(mode steps, tool execution, interrupt checks), and a sub-agent tool emits a real
`{:interrupt, msg, %{type: :halt, ...}}`.

Covered: type and message preserved, no further LLM call (asserted on a call
counter), `Haltable` claims it, `pending_halt` carries the message, no
`:sub_agent_id` and the parent's `tool_call_id`, sub-agent process stopped, halt
wins inside `:multiple_interrupts`, and a regression guard that a non-halt
sub-agent interrupt still propagates as `:subagent_hitl` with the process alive.

Five of the nine fail on `main` without the fix. The other four are the
`:multiple_interrupts` policy tests and the non-halt guard, which correctly
behave the same either way.

`mix precommit` clean: 1567 passed, credo clean, formatted.

## Relationship to #144

Complementary, no overlap. Once halts propagate as halts,
`Middleware.SubAgent.handle_resume/5` never routes a halt to
`SubAgentServer.resume/2` at all. #144 remains necessary for every *other*
tool-raised interrupt reachable inside a sub-agent. Different files, no conflict,
and this branch is cut from `main` so the two can merge in either order.

## Follow-up worth considering separately

The default sub-agent middleware block-list is `[Sagents.Middleware.SubAgent]`.
`AskUserQuestion` is inherited, so a sub-agent is handed the `ask_user_question`
tool while the task-subagent boilerplate prompt tells it *"You cannot ask the
user questions. There is no user in this conversation."* That looks worth
blocking by default, but it is a separate behavior change and is not in this PR.