### PR TITLE
Stop sub-agents inheriting AskUserQuestion middleware

### DIFF
--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -69,8 +69,19 @@ defmodule Sagents.Middleware.SubAgent do
   1. **SubAgent middleware is ALWAYS excluded** - This prevents recursive subagent
      nesting which could lead to resource exhaustion. You cannot override this.
 
-  2. **Blocked middleware is excluded** - Any modules listed in `:block_middleware`
+  2. **AskUserQuestion middleware is excluded** - A subagent has no user to ask.
+     Its `:ask_user_question` interrupt is raised from inside a tool body, so it
+     returns to the parent wrapped as `:subagent_hitl` with the question buried
+     where the question-rendering path does not look. The task-subagent system
+     prompt already states "You cannot ask the user questions. There is no user
+     in this conversation.", so inheriting the `ask_user` tool handed the
+     subagent a capability the prompt then had to police.
+
+  3. **Blocked middleware is excluded** - Any modules listed in `:block_middleware`
      are filtered out before passing to the subagent.
+
+  Exclusions apply to *inheritance* only. A pre-configured subagent that names
+  one of these in its own `:middleware` list still receives it.
 
   ### Example: Blocking Unnecessary Middleware
 

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -111,6 +111,23 @@ defmodule Sagents.SubAgent do
   alias LangChain.Message
   alias LangChain.Utils
 
+  # Middleware never inherited by a sub-agent from its parent, whether or not
+  # the caller lists it in `:block_middleware`.
+  #
+  # `SubAgent` would allow recursive nesting. `AskUserQuestion` contributes the
+  # `ask_user` tool, but a sub-agent has no user to ask: its interrupt
+  # is raised from inside a tool body, so it comes back to the parent wrapped as
+  # `:subagent_hitl` with the question buried where nothing looks for it. See
+  # `compose_child_system_prompt/1`, which already instructs every task
+  # sub-agent that it cannot ask questions.
+  #
+  # This filters inheritance only. A `SubAgent.Config` naming one of these in
+  # its own `:middleware` list still gets it.
+  @never_inherited_middleware [
+    Sagents.Middleware.SubAgent,
+    Sagents.Middleware.AskUserQuestion
+  ]
+
   @primary_key false
   embedded_schema do
     # Core execution context - THE KEY FIELD
@@ -1146,8 +1163,20 @@ defmodule Sagents.SubAgent do
   @doc """
   Build a middleware stack for subagents, filtering out blocked middleware.
 
-  The SubAgent middleware itself is ALWAYS filtered out to prevent recursive
-  subagent nesting, regardless of whether it appears in the block list.
+  Two middleware modules are excluded from inheritance by default, without
+  needing to appear in `:block_middleware`:
+
+  - `Sagents.Middleware.SubAgent`, to prevent recursive subagent nesting.
+  - `Sagents.Middleware.AskUserQuestion`, because a sub-agent has no user to
+    ask. `compose_child_system_prompt/1` already tells every task sub-agent
+    "You cannot ask the user questions. There is no user in this
+    conversation.", so inheriting the `ask_user` tool handed the sub-agent a
+    capability the prompt then had to police.
+
+  Only *inherited* middleware is filtered. Middleware passed explicitly as
+  `additional_middleware` (a `SubAgent.Config`'s own `:middleware` list) is
+  always kept, so a sub-agent that genuinely needs one of these can still opt
+  back in.
 
   This function handles middleware in all formats:
   - Raw module atoms (e.g., `Sagents.Middleware.SubAgent`)
@@ -1161,7 +1190,7 @@ defmodule Sagents.SubAgent do
 
   ## Examples
 
-      # Default behavior: only SubAgent middleware is filtered
+      # Default behavior: SubAgent and AskUserQuestion middleware are filtered
       subagent_middleware_stack(parent_middleware)
 
       # Block additional middleware from being inherited
@@ -1179,15 +1208,18 @@ defmodule Sagents.SubAgent do
   def subagent_middleware_stack(default_middleware, additional_middleware \\ [], opts \\ []) do
     block_list = Keyword.get(opts, :block_middleware, [])
 
-    # Always block SubAgent middleware + user-specified modules
+    # Always block the never-inherited modules + user-specified ones.
     # Use MapSet for O(1) lookup performance
-    blocked_modules = MapSet.new([Sagents.Middleware.SubAgent | block_list])
+    blocked_modules = MapSet.new(@never_inherited_middleware ++ block_list)
 
     filtered =
       Enum.reject(default_middleware, fn mw ->
         extract_middleware_module(mw) in blocked_modules
       end)
 
+    # Only inherited middleware is filtered. `additional_middleware` is the
+    # sub-agent's own explicit list, so it passes through untouched and stays
+    # the opt-back-in route for anything blocked above.
     filtered ++ additional_middleware
   end
 

--- a/test/sagents/sub_agent_test.exs
+++ b/test/sagents/sub_agent_test.exs
@@ -1819,6 +1819,80 @@ defmodule Sagents.SubAgentTest do
     end
   end
 
+  describe "subagent_middleware_stack/3 excludes AskUserQuestion from inheritance" do
+    alias Sagents.Middleware.AskUserQuestion
+    alias Sagents.Middleware.FileSystem
+    alias Sagents.Middleware.TodoList
+
+    test "is filtered without being named in block_middleware" do
+      middleware = [TodoList, AskUserQuestion, FileSystem]
+
+      result = SubAgent.subagent_middleware_stack(middleware)
+      modules = Enum.map(result, &SubAgent.extract_middleware_module/1)
+
+      assert [TodoList, FileSystem] = modules
+    end
+
+    test "is filtered from initialized MiddlewareEntry structs" do
+      # agent.middleware holds MiddlewareEntry structs rather than raw specs.
+      # This is the shape the production path actually passes in.
+      {:ok, agent} =
+        Agent.new(%{
+          model: test_model(),
+          middleware: [TodoList, AskUserQuestion, FileSystem]
+        })
+
+      assert Enum.any?(agent.middleware, &match?(%MiddlewareEntry{module: AskUserQuestion}, &1))
+
+      result = SubAgent.subagent_middleware_stack(agent.middleware)
+
+      refute Enum.any?(result, &match?(%MiddlewareEntry{module: AskUserQuestion}, &1))
+      assert Enum.any?(result, &match?(%MiddlewareEntry{module: TodoList}, &1))
+    end
+
+    test "is still filtered when block_middleware names other modules" do
+      middleware = [TodoList, AskUserQuestion, FileSystem]
+
+      result = SubAgent.subagent_middleware_stack(middleware, [], block_middleware: [FileSystem])
+      modules = Enum.map(result, &SubAgent.extract_middleware_module/1)
+
+      assert [TodoList] = modules
+    end
+
+    test "is kept when the sub-agent asks for it explicitly" do
+      # Only inheritance is filtered. A SubAgent.Config naming AskUserQuestion in
+      # its own :middleware list passes it through additional_middleware, which
+      # is the opt-back-in route.
+      result = SubAgent.subagent_middleware_stack([TodoList, AskUserQuestion], [AskUserQuestion])
+      modules = Enum.map(result, &SubAgent.extract_middleware_module/1)
+
+      assert [TodoList, AskUserQuestion] = modules
+    end
+
+    test "removes the ask_user_question tool from an inheriting sub-agent" do
+      # The point of the exclusion: the sub-agent must not be handed a tool the
+      # task-subagent system prompt then has to tell it not to use.
+      {:ok, parent} =
+        Agent.new(%{
+          model: test_model(),
+          middleware: [TodoList, AskUserQuestion]
+        })
+
+      assert "ask_user" in Enum.map(parent.tools, & &1.name)
+
+      {:ok, subagent} =
+        Agent.new(%{
+          model: test_model(),
+          middleware:
+            parent.middleware
+            |> SubAgent.subagent_middleware_stack()
+            |> MiddlewareEntry.to_raw_specs()
+        })
+
+      refute "ask_user" in Enum.map(subagent.tools, & &1.name)
+    end
+  end
+
   # Helper function to extract errors from changeset
   defp errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->


### PR DESCRIPTION
Follow-up to #150, which noted this while fixing sub-agent halt propagation.

## The problem

`subagent_middleware_stack/3` blocks exactly one module from inheritance,
`Sagents.Middleware.SubAgent`, to prevent recursive nesting. Everything else in
the parent's stack is inherited, including `AskUserQuestion`.

That hands a sub-agent the `ask_user` tool. Meanwhile
`compose_child_system_prompt/1` prepends this to every task sub-agent:

> You cannot ask the user questions. There is no user in this conversation, only
> the instructions you've been given.

So the framework grants the capability and then asks the prompt to police it. A
prompt is a suggestion, not an enforcement.

When a sub-agent does call `ask_user`, the result is not a question anyone sees.
The interrupt is raised from inside a tool body, so it comes back through
`Middleware.SubAgent` wrapped as `%{type: :subagent_hitl}`. Nothing that renders
questions dispatches on that outer type: `interrupt_session_changes/1` falls
through to `present_hitl_tools/1`, and `extract_action_requests/1` finds no
`:action_requests` inside an `:ask_user_question`. The user gets an empty
approval prompt and never sees the question. This is the same class of failure
#150 fixed for `:halt`, and the reason to remove the capability rather than
paper over it.

## The change

Promote the always-blocked list from a single hardcoded module to
`@never_inherited_middleware`, and add `AskUserQuestion` to it.

```elixir
@never_inherited_middleware [
  Sagents.Middleware.SubAgent,
  Sagents.Middleware.AskUserQuestion
]
```

This covers both stack-building paths, since general-purpose sub-agents
(`Middleware.SubAgent`) and config-defined sub-agents (`configure_new_subagent/3`)
both go through this function.

**Inheritance only.** `subagent_middleware_stack/3` filters `default_middleware`
and then appends `additional_middleware` untouched, so a `SubAgent.Config` that
names `AskUserQuestion` in its own `:middleware` list still receives it. That is
the opt-back-in route, and it is covered by a test.

## Tests

Five tests in a new describe block in `test/sagents/sub_agent_test.exs`, all of
which fail on `main` without the change:

- filtered without being named in `:block_middleware`
- filtered from initialized `MiddlewareEntry` structs, the shape the production
  path actually passes
- still filtered when `:block_middleware` names unrelated modules
- kept when passed explicitly as `additional_middleware`
- the end effect: a sub-agent built from a parent carrying `AskUserQuestion` has
  no `ask_user` tool, while the parent still does

`mix precommit` clean: 1575 passed, credo clean, formatted.

## Compatibility note

This is a behavior change for anyone who added `AskUserQuestion` to a parent
agent and relied on sub-agents inheriting it. Given that the inherited path
produced an empty approval prompt rather than a visible question, there is not
much working behavior to preserve, but it is worth a line in the changelog.