### PR TITLE
Fix ExDoc reference warnings in AgentServer docstrings

### DIFF
--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -1011,7 +1011,7 @@ defmodule Sagents.AgentServer do
 
   This is deliberate and load-bearing: previously the message was written into
   the rolling state and then silently destroyed when the canonical state from
-  `Agent.execute/3` replaced it wholesale, while the caller got a misleading
+  `Sagents.Agent.execute/3` replaced it wholesale, while the caller got a misleading
   `{:error, "Cannot execute, server is in state: running"}` despite the message
   having been accepted. Returning `:ok` is both more truthful and non-breaking
   for consumers that match only on `:ok` and `{:error, reason}`.
@@ -1037,7 +1037,7 @@ defmodule Sagents.AgentServer do
       transcript.
 
   The two halves are independent messages, **including their role**. Because
-  `Sagents.DisplayMessagePersistence.save_message/3` derives the transcript
+  `c:Sagents.DisplayMessagePersistence.save_message/3` derives the transcript
   entry's attribution from `message.role`, a message that is `:user` to the
   model can be `:assistant` in the transcript. That is the shape a
   tool-initiated injection needs: nobody typed it, so attributing it to the
@@ -1100,7 +1100,7 @@ defmodule Sagents.AgentServer do
 
   The cost is that the caller cannot learn whether the queue accepted the
   message. The `GenServer.whereis` guard below covers the dominant failure mode:
-  no server at all, which is unit tests and bare `Agent.execute/3`. It returns
+  no server at all, which is unit tests and bare `Sagents.Agent.execute/3`. It returns
   `{:error, :no_server}` so a tool can fall back to inline content rather than
   silently doing nothing.
 


### PR DESCRIPTION
## Problem

`mix docs` emitted six warnings (three unique, each reported twice) for broken documentation references in `Sagents.AgentServer`. Broken refs render as plain text instead of links on HexDocs, so readers of `add_message/3` and `queue_message_from_tool/3` lost the navigation to the two functions those docs lean on hardest to explain themselves.

Both were caused by the same class of mistake: writing a doc reference the way you would write the call in code.

## Solution

**`Agent.execute/3` → `Sagents.Agent.execute/3`** (2 occurrences). ExDoc does not apply `alias` directives when resolving references. The module aliases `Sagents.Agent`, so the bare `Agent.execute/3` compiles fine in code but resolves against Elixir's stdlib `Agent` module in docs, which has no `execute/3`. Doc references must always be fully qualified.

**`Sagents.DisplayMessagePersistence.save_message/3` → `c:Sagents.DisplayMessagePersistence.save_message/3`.** `save_message/3` is a `@callback` on the persistence behaviour ([display_message_persistence.ex:86](https://github.com/sagents-ai/sagents/blob/me-fix-doc-links/lib/sagents/display_message_persistence.ex#L86)), not a public function. ExDoc addresses callbacks with the `c:` prefix — the same family as `t:` for types and `m:` for modules. Without it the reference searched for a regular function and found nothing.

Docstring text only. No behaviour, signatures, or public API affected.

## Changes

- [lib/sagents/agent_server.ex:1014](https://github.com/sagents-ai/sagents/blob/me-fix-doc-links/lib/sagents/agent_server.ex#L1014) (`add_message/3` @doc) — Fully qualify `Sagents.Agent.execute/3`
- [lib/sagents/agent_server.ex:1040](https://github.com/sagents-ai/sagents/blob/me-fix-doc-links/lib/sagents/agent_server.ex#L1040) (`add_message/3` @doc) — Add `c:` prefix to the `save_message/3` callback reference
- [lib/sagents/agent_server.ex:1103](https://github.com/sagents-ai/sagents/blob/me-fix-doc-links/lib/sagents/agent_server.ex#L1103) (`queue_message_from_tool/3` @doc) — Fully qualify `Sagents.Agent.execute/3`

## Testing

- `mix docs` now completes with zero warnings (previously six).
- `mix precommit` passes: compile with warnings-as-errors, format check, and 1621/1622 tests.
- The one failing test, `Sagents.Horde.NodeTransferTest` "agent process is redistributed on graceful shutdown", is a pre-existing timing flake in the `:cluster`-tagged distributed suite. Verified unrelated: it fails identically on a clean tree with this change stashed, and the failing assertion moves between lines 157 and 184 across runs.

No new tests — the change is confined to documentation prose with no runtime behaviour to cover.