### PR TITLE
Let a sub-agent run without publishing its inner work

### DIFF
--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -115,6 +115,34 @@ defmodule Sagents.Middleware.SubAgent do
         block_middleware: [ConversationTitle]  # Only affects general-purpose
       ]}
 
+  ## Suppressing Debug Events
+
+  A sub-agent's events are published on the **parent's** `:debug` channel, and
+  they carry content: the initial messages, every inner LLM message live, and
+  the whole inner chain on failure or cancellation. For a sub-agent that exists
+  as a confidentiality boundary — it reads sensitive data and is meant to return
+  only a narrow result — set `:suppress_debug_events` on its config:
+
+      {SubAgent, [
+        model: model,
+        subagents: [
+          SubAgent.Config.new!(%{
+            name: "pii-extractor",
+            description: "Extract structured fields from a sensitive document",
+            tools: [extract_tool],
+            suppress_debug_events: true
+          })
+        ]
+      ]}
+
+  Nothing about that sub-agent's run reaches the parent's `:debug` channel. The
+  parent still receives the outcome as the `task` tool result; only the observer
+  fan-out is silenced. Defaults to `false`, so existing consumers are unaffected.
+
+  The setting is per sub-agent type and all-or-nothing. It does not apply to the
+  **general-purpose** sub-agent, which is created dynamically rather than
+  declared in `:subagents` and so has no config to carry the flag.
+
   ## Usage Example
 
       # Main agent decides to delegate work
@@ -253,7 +281,9 @@ defmodule Sagents.Middleware.SubAgent do
         # Names of the subagent types whose events must not reach the parent's
         # :debug channel. A set rather than a map because the setting is one
         # boolean per task name, and absence means "publish" — the default.
-        suppress_debug_events =
+        # Named `_targets` like `until_tool_targets` above: the per-config field
+        # is a boolean, this is the collapsed lookup keyed by task name.
+        suppress_debug_targets =
           for cfg <- subagents,
               Map.get(cfg, :suppress_debug_events) == true,
               into: MapSet.new(),
@@ -298,7 +328,7 @@ defmodule Sagents.Middleware.SubAgent do
           model: model,
           block_middleware: block_middleware,
           until_tool_targets: until_tool_targets,
-          suppress_debug_events: suppress_debug_events,
+          suppress_debug_targets: suppress_debug_targets,
           display_texts_map: display_texts_map,
           use_instructions_map: use_instructions_map,
           include_task_list: include_task_list
@@ -447,8 +477,8 @@ defmodule Sagents.Middleware.SubAgent do
       until_tool_targets: Map.get(config, :until_tool_targets, %{}),
       # Named here because "my sub-agent publishes no debug events" is a real
       # question an operator asks of this middleware's configuration.
-      suppress_debug_events:
-        config |> Map.get(:suppress_debug_events, MapSet.new()) |> Enum.sort(),
+      suppress_debug_targets:
+        config |> Map.get(:suppress_debug_targets, MapSet.new()) |> Enum.sort(),
       has_use_instructions: not Enum.empty?(Map.get(config, :use_instructions_map, %{}))
     }
   end
@@ -737,7 +767,7 @@ defmodule Sagents.Middleware.SubAgent do
         # :until_tool is threaded through this call.
         suppress_debug_events =
           config
-          |> Map.get(:suppress_debug_events, MapSet.new())
+          |> Map.get(:suppress_debug_targets, MapSet.new())
           |> MapSet.member?(task_name)
 
         # Extract parent's tool_context, metadata, runtime, and scope so

--- a/lib/sagents/middleware/sub_agent.ex
+++ b/lib/sagents/middleware/sub_agent.ex
@@ -250,6 +250,15 @@ defmodule Sagents.Middleware.SubAgent do
           end)
           |> Map.new()
 
+        # Names of the subagent types whose events must not reach the parent's
+        # :debug channel. A set rather than a map because the setting is one
+        # boolean per task name, and absence means "publish" — the default.
+        suppress_debug_events =
+          for cfg <- subagents,
+              Map.get(cfg, :suppress_debug_events) == true,
+              into: MapSet.new(),
+              do: cfg.name
+
         # Build display_texts map: %{task_name => display_text}.
         # Used by the :on_tool_call_identified callback to re-label the
         # `task` tool call in the UI based on which subagent was picked.
@@ -289,6 +298,7 @@ defmodule Sagents.Middleware.SubAgent do
           model: model,
           block_middleware: block_middleware,
           until_tool_targets: until_tool_targets,
+          suppress_debug_events: suppress_debug_events,
           display_texts_map: display_texts_map,
           use_instructions_map: use_instructions_map,
           include_task_list: include_task_list
@@ -435,6 +445,10 @@ defmodule Sagents.Middleware.SubAgent do
       descriptions: config.descriptions,
       block_middleware: config.block_middleware,
       until_tool_targets: Map.get(config, :until_tool_targets, %{}),
+      # Named here because "my sub-agent publishes no debug events" is a real
+      # question an operator asks of this middleware's configuration.
+      suppress_debug_events:
+        config |> Map.get(:suppress_debug_events, MapSet.new()) |> Enum.sort(),
       has_use_instructions: not Enum.empty?(Map.get(config, :use_instructions_map, %{}))
     }
   end
@@ -717,6 +731,15 @@ defmodule Sagents.Middleware.SubAgent do
         until_tool_targets = Map.get(config, :until_tool_targets, %{})
         {until_tool, require_tool_success} = Map.get(until_tool_targets, task_name, {nil, false})
 
+        # Does this subagent type publish its events on the parent's :debug
+        # channel? Threaded here rather than read inside SubAgentServer because
+        # the server receives only the built struct — the same reason
+        # :until_tool is threaded through this call.
+        suppress_debug_events =
+          config
+          |> Map.get(:suppress_debug_events, MapSet.new())
+          |> MapSet.member?(task_name)
+
         # Extract parent's tool_context, metadata, runtime, and scope so
         # SubAgent tools see the same context as parent tools. Agent.build_chain
         # stores the original tool_context map as an explicit :tool_context key
@@ -740,6 +763,7 @@ defmodule Sagents.Middleware.SubAgent do
                 initial_messages: final_initial,
                 until_tool: until_tool,
                 require_tool_success: require_tool_success,
+                suppress_debug_events: suppress_debug_events,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
                 parent_runtime: parent_runtime,
@@ -756,6 +780,7 @@ defmodule Sagents.Middleware.SubAgent do
                 initial_messages: per_call_initial,
                 until_tool: until_tool,
                 require_tool_success: require_tool_success,
+                suppress_debug_events: suppress_debug_events,
                 parent_tool_context: parent_tool_context,
                 parent_metadata: parent_metadata,
                 parent_runtime: parent_runtime,

--- a/lib/sagents/sub_agent.ex
+++ b/lib/sagents/sub_agent.ex
@@ -162,6 +162,14 @@ defmodule Sagents.SubAgent do
     # (50 for AgentExecution). See Agent :max_runs for details.
     field :max_runs, :integer, virtual: true
 
+    # When true, SubAgentServer publishes none of this sub-agent's events on the
+    # parent's :debug channel. Set it for a sub-agent whose inner work must not
+    # leave the sub-agent — the events carry initial messages, every inner LLM
+    # message live, the final chain on failure or cancellation, and the result.
+    # The parent still receives the run's outcome as the `task` tool result;
+    # only the debug fan-out is silenced. Defaults to false.
+    field :suppress_debug_events, :boolean, default: false, virtual: true
+
     # Metadata
     field :id, :string
     field :parent_agent_id, :string
@@ -176,6 +184,8 @@ defmodule Sagents.SubAgent do
           error: term() | nil,
           until_tool: String.t() | [String.t()] | nil,
           require_tool_success: boolean(),
+          max_runs: integer() | nil,
+          suppress_debug_events: boolean(),
           id: String.t() | nil,
           parent_agent_id: String.t() | nil,
           created_at: DateTime.t() | nil
@@ -212,6 +222,11 @@ defmodule Sagents.SubAgent do
   - `:scope` - Scope struct to inherit from the parent (optional). Propagated to
     the SubAgent's `custom_context.scope` so sub-agent tools and persistence callbacks
     see the same tenant context as the parent. Defaults to `agent_config.scope`.
+  - `:suppress_debug_events` - When true, none of this sub-agent's events are
+    published on the parent's `:debug` channel (optional). Use it for a
+    sub-agent whose inner messages must not leave the sub-agent. The parent
+    still receives the run's outcome through the normal return value; only the
+    debug fan-out is silenced. Defaults to `false`.
 
   ## Examples
 
@@ -261,6 +276,9 @@ defmodule Sagents.SubAgent do
   - `:scope` - Scope struct to inherit from the parent (optional). Propagated to
     the SubAgent's `custom_context.scope` so sub-agent tools and persistence callbacks
     see the same tenant context as the parent. Defaults to `compiled_agent.scope`.
+  - `:suppress_debug_events` - When true, none of this sub-agent's events are
+    published on the parent's `:debug` channel (optional). See
+    `new_from_config/1`. Defaults to `false`.
 
   ## Examples
 
@@ -319,6 +337,7 @@ defmodule Sagents.SubAgent do
     require_tool_success = Keyword.get(opts, :require_tool_success, false)
     max_runs = Keyword.get(opts, :max_runs)
     parent_trace = Keyword.get(opts, :parent_trace, %{})
+    suppress_debug_events = Keyword.get(opts, :suppress_debug_events, false)
 
     sub_agent_id = "#{parent_agent_id}-sub-#{:erlang.unique_integer([:positive])}"
 
@@ -377,6 +396,7 @@ defmodule Sagents.SubAgent do
       until_tool: until_tool,
       require_tool_success: require_tool_success,
       max_runs: max_runs,
+      suppress_debug_events: suppress_debug_events,
       status: :idle,
       created_at: DateTime.utc_now()
     }
@@ -936,6 +956,9 @@ defmodule Sagents.SubAgent do
       # exclusive with :until_tool. Stops only on a successful result.
       field :until_tool_success, :any, virtual: true
       field :max_runs, :integer, virtual: true
+      # See SubAgent.suppress_debug_events. When true, this sub-agent type
+      # publishes none of its events on the parent's :debug channel.
+      field :suppress_debug_events, :boolean, default: false
     end
 
     @type t :: %Config{
@@ -952,7 +975,8 @@ defmodule Sagents.SubAgent do
             interrupt_on: map() | nil,
             until_tool: String.t() | [String.t()] | nil,
             until_tool_success: String.t() | [String.t()] | nil,
-            max_runs: integer() | nil
+            max_runs: integer() | nil,
+            suppress_debug_events: boolean()
           }
 
     def new(attrs) do
@@ -971,7 +995,8 @@ defmodule Sagents.SubAgent do
         :interrupt_on,
         :until_tool,
         :until_tool_success,
-        :max_runs
+        :max_runs,
+        :suppress_debug_events
       ])
       |> validate_required([:name, :description, :tools])
       |> validate_length(:name, min: 1, max: 100)

--- a/lib/sagents/sub_agent_server.ex
+++ b/lib/sagents/sub_agent_server.ex
@@ -360,7 +360,9 @@ defmodule Sagents.SubAgentServer do
     )
 
     # Broadcast subagent_started via parent AgentServer
-    broadcast_subagent_event(server_state, {:subagent_started, build_started_metadata(subagent)})
+    broadcast_subagent_event(server_state, fn ->
+      {:subagent_started, build_started_metadata(subagent)}
+    end)
 
     {:ok, server_state}
   end
@@ -513,10 +515,9 @@ defmodule Sagents.SubAgentServer do
         new_state = %{server_state | subagent: completed_subagent}
 
         # Broadcast completion event
-        broadcast_subagent_event(
-          new_state,
+        broadcast_subagent_event(new_state, fn ->
           {:subagent_completed, build_completed_metadata(new_state, result)}
-        )
+        end)
 
         reply = if extra, do: {:ok, result, extra}, else: {:ok, result}
         {:reply, reply, new_state}
@@ -591,6 +592,22 @@ defmodule Sagents.SubAgentServer do
          _event
        ),
        do: :ok
+
+  # Lazy payload. Pass a zero-arity function where building the event costs real
+  # work -- the started metadata walks every tool and every tool parameter, and
+  # the completed metadata scans the message list for token usage -- so a
+  # suppressed sub-agent does not pay to build an event the clause above throws
+  # away. Events whose payload is a literal term are passed directly; wrapping
+  # those would allocate a closure to avoid allocating nothing.
+  #
+  # The suppression clause is matched first and never invokes the function.
+  # Ordering is an optimisation, not a correctness constraint: reaching this
+  # clause first would build the payload and then discard it downstream, which
+  # is the behaviour being avoided rather than a wrong result.
+  defp broadcast_subagent_event(%ServerState{} = server_state, build_event)
+       when is_function(build_event, 0) do
+    broadcast_subagent_event(server_state, build_event.())
+  end
 
   defp broadcast_subagent_event(%ServerState{subagent: subagent}, event) do
     parent_id = subagent.parent_agent_id

--- a/lib/sagents/sub_agent_server.ex
+++ b/lib/sagents/sub_agent_server.ex
@@ -576,6 +576,22 @@ defmodule Sagents.SubAgentServer do
   # will wrap them as {:agent, {:debug, {:subagent, ...}}} for consistent routing.
   # Reaches only subscribers enrolled on the parent's :debug channel via
   # `Sagents.Publisher`; with zero such subscribers the broadcast is a no-op.
+  #
+  # A sub-agent built with `suppress_debug_events: true` publishes nothing here.
+  # This is the single choke point for every sub-agent event, so the flag covers
+  # all of them — the initial messages at init, every inner LLM message live,
+  # the final chain on failure or cancellation, the result on completion, and
+  # the status transitions. Suppressing only the message-bearing events would
+  # leave the caller guessing which ones those are as new events are added, and
+  # would still announce a run whose whole point is that it is not observable
+  # from outside. The parent still learns the outcome through the sub-agent's
+  # return value; only the observer fan-out is silenced.
+  defp broadcast_subagent_event(
+         %ServerState{subagent: %SubAgent{suppress_debug_events: true}},
+         _event
+       ),
+       do: :ok
+
   defp broadcast_subagent_event(%ServerState{subagent: subagent}, event) do
     parent_id = subagent.parent_agent_id
     subagent_id = subagent.id

--- a/test/sagents/middleware/sub_agent_test.exs
+++ b/test/sagents/middleware/sub_agent_test.exs
@@ -3,6 +3,7 @@ defmodule Sagents.Middleware.SubAgentTest do
   use Mimic
 
   alias Sagents.Agent
+  alias Sagents.AgentServer
   alias Sagents.Middleware.SubAgent, as: SubAgentMiddleware
   alias Sagents.SubAgent
   alias Sagents.SubAgentServer
@@ -207,6 +208,125 @@ defmodule Sagents.Middleware.SubAgentTest do
       # why the production guard combines both calls.
       assert Code.ensure_loaded?(SubAgentMiddleware)
       assert function_exported?(SubAgentMiddleware, :debug_summary, 1)
+    end
+  end
+
+  describe "init/1 with suppress_debug_events" do
+    # The per-config boolean is collapsed at init into one set of task names,
+    # the same way :until_tool becomes :until_tool_targets.
+    defp init_with_suppression do
+      quiet =
+        SubAgent.Config.new!(%{
+          name: "quiet",
+          description: "Handles sensitive input",
+          system_prompt: "Test agent quiet",
+          tools: [test_tool()],
+          suppress_debug_events: true
+        })
+
+      loud = build_subagent_config("loud", "Ordinary work")
+
+      SubAgentMiddleware.init(
+        agent_id: "parent",
+        model: test_model(),
+        middleware: [],
+        subagents: [quiet, loud]
+      )
+    end
+
+    test "collects only the names of subagents that opted in" do
+      {:ok, config} = init_with_suppression()
+
+      assert MapSet.member?(config.suppress_debug_targets, "quiet")
+      refute MapSet.member?(config.suppress_debug_targets, "loud")
+    end
+
+    test "builds an empty set when no subagent opts in" do
+      {:ok, config} =
+        SubAgentMiddleware.init(
+          agent_id: "parent",
+          model: test_model(),
+          middleware: [],
+          subagents: [build_subagent_config("loud", "Ordinary work")]
+        )
+
+      assert MapSet.size(config.suppress_debug_targets) == 0
+    end
+
+    test "debug_summary reports the suppressed names as a sorted list" do
+      {:ok, config} = init_with_suppression()
+
+      assert %{suppress_debug_targets: ["quiet"]} =
+               SubAgentMiddleware.debug_summary(config)
+    end
+  end
+
+  describe "task tool honours suppress_debug_events" do
+    # Covers the link between the middleware's collapsed set and the SubAgent
+    # struct the server guards on: the `task` tool must look the flag up by task
+    # name and thread it through. Both sub-agents live in one config so the two
+    # tests also prove the lookup is per name rather than global.
+    setup do
+      parent_agent = create_test_agent()
+
+      {:ok, _pid} = AgentServer.start_link(agent: parent_agent)
+      start_supervised({SubAgentsDynamicSupervisor, agent_id: parent_agent.agent_id})
+      {:ok, _server_pid, _ref} = AgentServer.subscribe(parent_agent.agent_id, :debug)
+
+      quiet =
+        SubAgent.Config.new!(%{
+          name: "quiet",
+          description: "Handles sensitive input",
+          system_prompt: "Test agent quiet",
+          tools: [test_tool()],
+          suppress_debug_events: true
+        })
+
+      {:ok, middleware_config} =
+        SubAgentMiddleware.init(
+          agent_id: parent_agent.agent_id,
+          model: test_model(),
+          middleware: [],
+          subagents: [quiet, build_subagent_config("loud", "Ordinary work")]
+        )
+
+      assistant_message = Message.new_assistant!(%{content: "Done"})
+
+      LLMChain
+      |> stub(:run, fn chain, _opts ->
+        {:ok,
+         chain
+         |> Map.put(:messages, chain.messages ++ [assistant_message])
+         |> Map.put(:last_message, assistant_message)
+         |> Map.put(:needs_response, false)}
+      end)
+
+      [task_tool] = SubAgentMiddleware.tools(middleware_config)
+
+      %{task_tool: task_tool}
+    end
+
+    defp run_task(task_tool, task_name) do
+      task_tool.function.(
+        %{"instructions" => "Do the work", "task_name" => task_name},
+        %{state: State.new!(%{messages: []})}
+      )
+    end
+
+    test "publishes nothing for a sub-agent configured to suppress", %{task_tool: task_tool} do
+      # The result still comes back through the tool -- only the debug fan-out
+      # is silenced.
+      assert {:ok, "Done"} = run_task(task_tool, "quiet")
+
+      refute_receive {:agent, {:debug, {:subagent, _, _}}}, 200
+    end
+
+    test "publishes for a sub-agent in the same config that did not opt in", %{
+      task_tool: task_tool
+    } do
+      assert {:ok, "Done"} = run_task(task_tool, "loud")
+
+      assert_receive {:agent, {:debug, {:subagent, _, {:subagent_started, _}}}}, 1000
     end
   end
 

--- a/test/sagents/sub_agent_server_broadcast_test.exs
+++ b/test/sagents/sub_agent_server_broadcast_test.exs
@@ -41,7 +41,8 @@ defmodule Sagents.SubAgentServerBroadcastTest do
       parent_agent_id: parent_agent_id,
       instructions: instructions,
       agent_config: agent,
-      parent_state: parent_state
+      parent_state: parent_state,
+      suppress_debug_events: Keyword.get(opts, :suppress_debug_events, false)
     )
   end
 
@@ -448,6 +449,104 @@ defmodule Sagents.SubAgentServerBroadcastTest do
 
       assert data.result == "I've written the file test.txt successfully."
       assert is_integer(data.duration_ms)
+    end
+  end
+
+  describe "suppress_debug_events" do
+    # A sub-agent used as a confidentiality boundary: its instructions carry
+    # content the parent's debug subscribers must not see.
+    @secret "PATIENT-SSN-078-05-1120"
+
+    test "publishes nothing across a successful run when suppressed", context do
+      parent_agent = start_parent_agent(context)
+
+      subagent =
+        create_subagent(parent_agent.agent_id,
+          instructions: "Summarize this record: #{@secret}",
+          suppress_debug_events: true
+        )
+
+      {:ok, _pid} = SubAgentServer.start_link(subagent: subagent)
+
+      ChatAnthropic
+      |> stub(:call, fn _model, _messages, _callbacks ->
+        {:ok, [Message.new_assistant!("Record summarized")]}
+      end)
+
+      # The outcome still reaches the caller. Only the observer fan-out is silenced.
+      assert {:ok, "Record summarized"} = SubAgentServer.execute(subagent.id)
+
+      # Nothing from this sub-agent reached the subscribed :debug channel: not the
+      # started metadata, not the status transitions, not the inner messages, not
+      # the completion. Matching the whole `{:subagent, _, _}` family rather than
+      # each event keeps this assertion correct as new events are added.
+      refute_receive {:agent, {:debug, {:subagent, _, _}}}, 200
+    end
+
+    test "publishes the failure chain when not suppressed", context do
+      # The control for the test below: without suppression a failed run
+      # republishes the whole inner chain, secret included. This is the leak
+      # reported in #157, and asserting it here keeps the suppressed case from
+      # passing vacuously.
+      parent_agent = start_parent_agent(context)
+
+      subagent =
+        create_subagent(parent_agent.agent_id,
+          instructions: "Summarize this record: #{@secret}"
+        )
+
+      {:ok, _pid} = SubAgentServer.start_link(subagent: subagent)
+
+      ChatAnthropic
+      |> stub(:call, fn _model, _messages, _callbacks ->
+        {:error, LangChain.LangChainError.exception(message: "validator refused output")}
+      end)
+
+      assert {:error, _reason} = SubAgentServer.execute(subagent.id)
+
+      assert_receive {:agent, {:debug, {:subagent, _, {:subagent_failed_with_context, ctx}}}},
+                     1000
+
+      assert Enum.any?(ctx.final_messages, fn msg ->
+               msg.role == :user and
+                 String.contains?(ContentPart.parts_to_string(msg.content), @secret)
+             end)
+    end
+
+    test "publishes nothing on a failed run when suppressed", context do
+      parent_agent = start_parent_agent(context)
+
+      subagent =
+        create_subagent(parent_agent.agent_id,
+          instructions: "Summarize this record: #{@secret}",
+          suppress_debug_events: true
+        )
+
+      {:ok, _pid} = SubAgentServer.start_link(subagent: subagent)
+
+      ChatAnthropic
+      |> stub(:call, fn _model, _messages, _callbacks ->
+        {:error, LangChain.LangChainError.exception(message: "validator refused output")}
+      end)
+
+      # A rejected result is a failed run, so this is the path that leaked the
+      # refused content in #157.
+      assert {:error, _reason} = SubAgentServer.execute(subagent.id)
+
+      refute_receive {:agent, {:debug, {:subagent, _, _}}}, 200
+    end
+
+    test "publishes normally when suppress_debug_events is explicitly false", context do
+      # Pins the guard to `true` only. A clause that matched any truthy or
+      # non-nil value would silence sub-agents that never asked for it.
+      parent_agent = start_parent_agent(context)
+
+      subagent = create_subagent(parent_agent.agent_id, suppress_debug_events: false)
+
+      {:ok, _pid} = SubAgentServer.start_link(subagent: subagent)
+
+      assert_receive {:agent, {:debug, {:subagent, sub_id, {:subagent_started, _data}}}}, 100
+      assert sub_id == subagent.id
     end
   end
 end

--- a/test/sagents/sub_agent_test.exs
+++ b/test/sagents/sub_agent_test.exs
@@ -1591,6 +1591,73 @@ defmodule Sagents.SubAgentTest do
     end
   end
 
+  describe "suppress_debug_events" do
+    test "Config.new casts suppress_debug_events" do
+      attrs = %{
+        name: "test-agent",
+        description: "A test agent",
+        system_prompt: "You are a test agent",
+        tools: [test_tool()],
+        suppress_debug_events: true
+      }
+
+      assert {:ok, config} = SubAgentConfig.new(attrs)
+      assert config.suppress_debug_events == true
+    end
+
+    test "Config.new defaults suppress_debug_events to false" do
+      attrs = %{
+        name: "test-agent",
+        description: "A test agent",
+        system_prompt: "You are a test agent",
+        tools: [test_tool()]
+      }
+
+      assert {:ok, config} = SubAgentConfig.new(attrs)
+      assert config.suppress_debug_events == false
+    end
+
+    test "new_from_config passes suppress_debug_events to the SubAgent struct" do
+      subagent =
+        SubAgent.new_from_config(
+          parent_agent_id: "test-parent",
+          instructions: "Do something",
+          agent_config: test_agent(),
+          parent_state: %{messages: []},
+          suppress_debug_events: true
+        )
+
+      assert %SubAgent{suppress_debug_events: true} = subagent
+    end
+
+    test "new_from_compiled passes suppress_debug_events to the SubAgent struct" do
+      subagent =
+        SubAgent.new_from_compiled(
+          parent_agent_id: "test-parent",
+          instructions: "Do something",
+          compiled_agent: test_agent(),
+          parent_state: %{messages: []},
+          suppress_debug_events: true
+        )
+
+      assert %SubAgent{suppress_debug_events: true} = subagent
+    end
+
+    test "both constructors default suppress_debug_events to false" do
+      opts = [
+        parent_agent_id: "test-parent",
+        instructions: "Do something",
+        parent_state: %{messages: []}
+      ]
+
+      from_config = SubAgent.new_from_config([agent_config: test_agent()] ++ opts)
+      from_compiled = SubAgent.new_from_compiled([compiled_agent: test_agent()] ++ opts)
+
+      assert %SubAgent{suppress_debug_events: false} = from_config
+      assert %SubAgent{suppress_debug_events: false} = from_compiled
+    end
+  end
+
   describe "build_mode_opts/1" do
     test "returns just mode when no HITL and no until_tool" do
       agent_config = test_agent()


### PR DESCRIPTION
Closes #157 if this is the shape you want — but please read the last section before reviewing in depth.

## What this does

Adds `suppress_debug_events`, a boolean on `SubAgent` and `SubAgent.Config`. When set for a sub-agent type, `SubAgentServer` publishes none of that sub-agent's events on the parent's `:debug` channel.

The guard is a single clause on `broadcast_subagent_event/2`, which is the one function all five content-carrying events funnel through:

```elixir
defp broadcast_subagent_event(
       %ServerState{subagent: %SubAgent{suppress_debug_events: true}},
       _event
     ),
     do: :ok
```

Guarding there rather than at each call site means the flag cannot fall out of sync as events are added — there are 13 call sites today and they all pass through this one place.

The value is threaded from `SubAgent.Config` through the middleware to `SubAgentServer` the same way `:until_tool` already is, because the server receives only the built struct. It also reaches `debug_summary/1`, since "does this sub-agent publish its events" is a real question to ask of a middleware's configuration.

Defaults to `false`. Nothing changes for existing consumers.

## Why all five events

Partial suppression seemed worse than none: a consumer would have to track which events carry content as new ones are added, and a run whose whole point is that it is unobservable would still announce itself. The parent still receives the run's outcome through the `task` tool result — only the observer fan-out is silenced.

## This is a workaround, and I would rather have your direction

I am running this in my own fork today because I needed the boundary to hold, not because I think a boolean is the right long-term answer. Two things I would rather raise myself than have you find in review:

**It is all-or-nothing.** A consumer wanting selective visibility is not served by this at all.

**A subscriber-side filter is probably the better design.** What I actually want is "this channel does not carry this sub-agent's content", which is a property of the subscription, not of the sub-agent. I did not propose that because no such seam exists today and building one is a much larger change to `Publisher` — but if that is the direction you would take, I am happy to close this and work toward it instead.

There may also be a third framing I have not seen. The underlying need is that a consumer sometimes has a confidentiality boundary around a sub-agent, and right now the library gives no way to express that. However you would like to solve that, I am glad to help build it.
