### PR TITLE
Keep an open ask_user question alive when the agent sleeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ conversation is waiting on, `agent_alive?` is whether a process is backing it
 right now. Answering an interrupt now goes through `Sagents.Session.resume/4`,
 which wakes a sleeping agent and hands it the answer at boot.
 
+The same is true of any other restorable interrupt, including a `:halt` panel,
+whose Dismiss button goes through the matching `Sagents.Session.dismiss/3`. **If
+your app renders a halt panel, read step 6 of the migration guide**, since the
+button has to be routed through the new path to work on a dormant conversation.
+
 **No compile-time breakage**, and upgrading without touching host code is safe:
 everything behaves as v0.10.1 did, bug included. The fix is opt-in, because the
 affected modules were generated into your app. See
@@ -23,6 +28,15 @@ Full write-up in [#159](https://github.com/sagents-ai/sagents/pull/159).
 ### Added
 
 - `Sagents.Session.resume/4` — answer an interrupt, waking the agent if needed.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
+- `Sagents.Session.dismiss/3` — acknowledge a terminal `:halt`, waking the agent
+  if needed. The mirror of `resume/4` for the interrupt type that is dismissed
+  rather than answered. A halt is restorable, so its panel now survives a nap,
+  and `AgentServer.dismiss_interrupt/1` alone cannot clear one on a dormant
+  conversation. An interrupt that needs a real response is passed through as an
+  error rather than woken. The generated Coordinator gains
+  `dismiss_agent_session/2` and the generated `AgentLiveHelpers` gains
+  `handle_halt_dismissal/1`.
   [#159](https://github.com/sagents-ai/sagents/pull/159)
 - `:pending_resume`, a start option applied during boot before the initial status
   broadcast, so a woken agent announces `:running` rather than an `:interrupted`
@@ -46,6 +60,16 @@ Full write-up in [#159](https://github.com/sagents-ai/sagents/pull/159).
   pid has nothing to resync. If you relied on re-subscribing to force a refresh,
   use `Sagents.AgentServer.get_info/1`. This is the only non-opt-in behaviour
   change in the release. [#159](https://github.com/sagents-ai/sagents/pull/159)
+- **A `:halt` panel now survives a shutdown**, for hosts that adopt
+  `AgentUtils.shutdown_session_changes/2`. `Haltable.restorable_interrupt?/1`
+  reports `%{type: :halt}` as restorable and the shutdown helper counts
+  `:pending_halt` as a pending interrupt, so a halt is preserved on exactly the
+  same terms as an open question. Route the panel's Dismiss action through
+  `Session.dismiss/3`: `AgentServer.dismiss_interrupt/1` talks to a live process
+  and returns `{:error, :agent_not_running}` against a dormant one. See step 6 of
+  the migration guide. Previously the generated
+  `handle_agent_shutdown/2` cleared the halt on the way out, so this path was
+  unreachable. [#159](https://github.com/sagents-ai/sagents/pull/159)
 - All three `{:agent_shutdown, _}` emit sites now send the same shape.
   `terminate/2` previously sent only `%{reason:, status:}`, omitting the agent id
   hosts need to correlate the event. Additive for subset map patterns.
@@ -66,6 +90,18 @@ Full write-up in [#159](https://github.com/sagents-ai/sagents/pull/159).
 - The generated interrupt handlers crashed on a duplicate question submission and
   could resume with a fabricated HITL decision on a duplicate approval.
   [#159](https://github.com/sagents-ai/sagents/pull/159)
+- The generated `resume_or_flash/5` built the log line and the user-facing flash
+  from a single `error_prefix`, so an internal error term reached the end user
+  verbatim (`Failed to submit response: "Cannot resume, server is not
+  interrupted"`), in wording that says "agent". It now takes `:log_label` and
+  `:user_message` separately, and only the label is paired with the reason.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
+- The generated `AgentLiveHelpers` exposes a single public `agent_request_opts/1`
+  instead of a private, resume-only `resume_request_opts/1` stub. Every path that
+  can start an agent should read it, including the host's own
+  `ensure_agent_session_running/2` call sites. Two copies of this decision drift
+  silently, and the symptom is an agent configured differently only on the paths
+  that had to wake it. [#159](https://github.com/sagents-ai/sagents/pull/159)
 
 ## v0.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,29 @@ which wakes a sleeping agent and hands it the answer at boot.
 **No compile-time breakage**, and upgrading without touching host code is safe:
 everything behaves as v0.10.1 did, bug included. The fix is opt-in, because the
 affected modules were generated into your app. See
-[MIGRATION_PROMPT_v0.10.1_TO_v0.11.0.md](MIGRATION_PROMPT_v0.10.1_TO_v0.11.0.md)
+[MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md](MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md)
 — it is written to be handed to a coding agent.
+
+Full write-up in [#159](https://github.com/sagents-ai/sagents/pull/159).
 
 ### Added
 
 - `Sagents.Session.resume/4` — answer an interrupt, waking the agent if needed.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - `:pending_resume`, a start option applied during boot before the initial status
   broadcast, so a woken agent announces `:running` rather than an `:interrupted`
   snapshot it is about to leave.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - `Sagents.AgentUtils.shutdown_session_changes/2` and the `agent_alive?`
   subscriber-state key.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - `Sagents.State.interrupt_restorable?/2` is now public — the authoritative
   predicate for whether an interrupt survives a cold boot.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - `{:agent_shutdown, _}` payloads carry `:interrupt_restorable`.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - `Sagents.Session.start/3`'s `session_info` gained `:started`.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 
 ### Changed
 
@@ -37,22 +45,27 @@ affected modules were generated into your app. See
   channel.** It is a *newly registered* subscriber hook, and an already-registered
   pid has nothing to resync. If you relied on re-subscribing to force a refresh,
   use `Sagents.AgentServer.get_info/1`. This is the only non-opt-in behaviour
-  change in the release.
+  change in the release. [#159](https://github.com/sagents-ai/sagents/pull/159)
 - All three `{:agent_shutdown, _}` emit sites now send the same shape.
   `terminate/2` previously sent only `%{reason:, status:}`, omitting the agent id
   hosts need to correlate the event. Additive for subset map patterns.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - An empty `:multiple_interrupts` wrapper is no longer treated as restorable.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 
 ### Fixed
 
 - A process seeded via `:initial_subscribers` that then called `subscribe/3`
   received the boot status broadcast twice. This is the exact shape
   `Sagents.Session.ensure_running/3` produces.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - The generated `handle_agent_shutdown/2` destroyed the agent subscription rather
   than letting presence-driven recovery restore it, and cleared `agent_id`,
   breaking `handle_conversation_title_generated/3`.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 - The generated interrupt handlers crashed on a duplicate question submission and
   could resume with a fabricated HITL decision on a duplicate approval.
+  [#159](https://github.com/sagents-ai/sagents/pull/159)
 
 ## v0.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## v0.11.0
+
+An open `ask_user` question no longer disappears when the agent goes to sleep.
+
+The interrupt was always durable — it is persisted with the state, and a fresh
+boot rebuilds it and comes up `:interrupted`. The loss was in the host UI, which
+treated "the process went away" as a status change and cleared the prompt. This
+release separates the two facts hosts were conflating: `agent_status` is what the
+conversation is waiting on, `agent_alive?` is whether a process is backing it
+right now. Answering an interrupt now goes through `Sagents.Session.resume/4`,
+which wakes a sleeping agent and hands it the answer at boot.
+
+**No compile-time breakage**, and upgrading without touching host code is safe:
+everything behaves as v0.10.1 did, bug included. The fix is opt-in, because the
+affected modules were generated into your app. See
+[MIGRATION_PROMPT_v0.10.1_TO_v0.11.0.md](MIGRATION_PROMPT_v0.10.1_TO_v0.11.0.md)
+— it is written to be handed to a coding agent.
+
+### Added
+
+- `Sagents.Session.resume/4` — answer an interrupt, waking the agent if needed.
+- `:pending_resume`, a start option applied during boot before the initial status
+  broadcast, so a woken agent announces `:running` rather than an `:interrupted`
+  snapshot it is about to leave.
+- `Sagents.AgentUtils.shutdown_session_changes/2` and the `agent_alive?`
+  subscriber-state key.
+- `Sagents.State.interrupt_restorable?/2` is now public — the authoritative
+  predicate for whether an interrupt survives a cold boot.
+- `{:agent_shutdown, _}` payloads carry `:interrupt_restorable`.
+- `Sagents.Session.start/3`'s `session_info` gained `:started`.
+
+### Changed
+
+- **`on_subscribed/3` no longer fires for a pid already subscribed to that
+  channel.** It is a *newly registered* subscriber hook, and an already-registered
+  pid has nothing to resync. If you relied on re-subscribing to force a refresh,
+  use `Sagents.AgentServer.get_info/1`. This is the only non-opt-in behaviour
+  change in the release.
+- All three `{:agent_shutdown, _}` emit sites now send the same shape.
+  `terminate/2` previously sent only `%{reason:, status:}`, omitting the agent id
+  hosts need to correlate the event. Additive for subset map patterns.
+- An empty `:multiple_interrupts` wrapper is no longer treated as restorable.
+
+### Fixed
+
+- A process seeded via `:initial_subscribers` that then called `subscribe/3`
+  received the boot status broadcast twice. This is the exact shape
+  `Sagents.Session.ensure_running/3` produces.
+- The generated `handle_agent_shutdown/2` destroyed the agent subscription rather
+  than letting presence-driven recovery restore it, and cleared `agent_id`,
+  breaking `handle_conversation_title_generated/3`.
+- The generated interrupt handlers crashed on a duplicate question submission and
+  could resume with a fabricated HITL decision on a duplicate approval.
+
 ## v0.10.1
 
 Adds `:otel_attributes`, a flat map of your application's context (tenant, user,

--- a/MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md
+++ b/MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md
@@ -1,0 +1,422 @@
+# Migration Guide: v0.10.x → v0.11.0
+
+## What changed and why
+
+An open `ask_user` question used to disappear when the agent's inactivity timer
+fired, taking whatever the user had typed with it.
+
+The interrupt itself was always durable: it is persisted with the agent state,
+and a fresh boot rebuilds it and comes up `:interrupted`. The loss was entirely
+in the host UI, which treated "the process went away" as a status change and
+cleared the prompt. v0.11.0 separates the two facts a host was conflating:
+
+- `agent_status` — **what the conversation is waiting on**. Stays `:interrupted`
+  while the user owes an answer, process or no process.
+- `agent_alive?` — **whether a process is backing this session right now**.
+
+Answering an interrupt now goes through `Sagents.Session.resume/4`, which tries
+the live agent first and, if none is running, starts one with the answer already
+in hand. The woken agent applies it before its first broadcast, so subscribers
+see a single `{:status_changed, :running, nil}` rather than an `:interrupted`
+snapshot for a question that is already answered.
+
+## Read this before you start
+
+**The compiler will not help you.** Nothing in this release changed arity or
+return type. Your app compiles clean against v0.11.0 and every existing test
+passes — and the bug silently persists. There is no deprecation-warning
+checklist like the v0.7.0 migration had.
+
+That is because the affected modules were **generated into your app** by
+`mix sagents.setup`. They are your copies; a dependency bump does not touch them.
+
+So this migration is **search-driven, not warning-driven**. Work the steps in
+order and run the searches given; do not assume a clean compile means you are
+done.
+
+Nothing here is required. Upgrading and changing no host code is safe and
+behaves exactly as v0.10.1 did. Everything below is opt-in to get the fix.
+
+---
+
+## Prerequisites
+
+1. Start from a clean, committed workspace.
+2. Update the dependency to `~> 0.11.0` and run `mix deps.get`.
+3. Run `mix compile`. **It will be clean.** That is expected, not evidence that
+   there is nothing to do.
+4. Locate your generated modules. They are wherever `mix sagents.setup` put
+   them; the default names are `AgentSubscriberSession`, `Coordinator`, and
+   `AgentLiveHelpers`:
+
+   ```
+   grep -rln "Sagents.Session\|Sagents.AgentUtils\|Sagents.Subscriber" lib/ --include="*.ex"
+   ```
+
+---
+
+## Migration Steps
+
+### 1. Teach the subscriber session that liveness is not status
+
+In your `AgentSubscriberSession` (or whatever module holds your host-agnostic
+state transitions).
+
+**1a. Add the new state key.**
+
+```elixir
+# init_session_state/0
+def init_session_state do
+  %{
+    agent_status: :not_running,
+    agent_alive?: false,          # ← add
+    # ...
+  }
+end
+```
+
+**1b. Every `handle_status_*` reports the agent as alive.** An inbound agent
+event is proof a process exists, whatever the event says.
+
+```elixir
+# Before
+def handle_status_running,
+  do: Map.merge(AgentUtils.cleared_interrupt_changes(), %{agent_status: :running})
+
+# After
+def handle_status_running,
+  do:
+    Map.merge(
+      AgentUtils.cleared_interrupt_changes(),
+      %{agent_status: :running, agent_alive?: true}
+    )
+```
+
+Do this for **all** of them: running, idle, cancelled, error, and interrupted.
+
+**1c. `handle_publisher_down/3` reports the agent as gone.**
+
+```elixir
+case Subscriber.handle_publisher_down(subs, ref, reason) do
+  {:matched, new_subs} -> %{sagents_subs: new_subs, agent_alive?: false}   # ← add key
+  :no_match -> %{}
+end
+```
+
+Deliberately do not touch interrupt state here. A crashed agent with a restorable
+interrupt boots straight back into `:interrupted`; one without boots `:idle` and
+your ordinary status handler clears the prompt.
+
+---
+
+### 2. Replace `handle_agent_shutdown/2` entirely
+
+This is the core of the migration. **Deleting the old body matters as much as
+adding the new one.**
+
+```elixir
+# Before — every line of this is harmful
+def handle_agent_shutdown(state, _shutdown_data) do
+  base =
+    Map.merge(AgentUtils.cleared_interrupt_changes(), %{
+      agent_id: nil,
+      agent_status: :not_running,
+      loading: false,
+      streaming_delta: nil
+    })
+
+  case Map.get(state, :agent_id) do
+    nil ->
+      base
+
+    agent_id ->
+      subs = Map.get(state, :sagents_subs, %{})
+      new_subs = Subscriber.unsubscribe_from_agent(subs, agent_id)
+      Map.put(base, :sagents_subs, new_subs)
+  end
+end
+
+# After
+def handle_agent_shutdown(state, shutdown_data) do
+  AgentUtils.shutdown_session_changes(state, shutdown_data)
+end
+```
+
+Three separate bugs go away with that body:
+
+1. **It cleared the interrupt UI unconditionally.** That is the reported bug.
+   `shutdown_session_changes/2` keeps a *restorable* prompt on screen (returning
+   only `%{agent_alive?: false, loading: false, streaming_delta: nil}`) and
+   collapses everything else to `:not_running`, exactly as before.
+
+2. **It nil'd `agent_id`.** That value is a pure function of the conversation id
+   and is what you need in order to wake the agent again. Nil-ing it also
+   silently broke `handle_conversation_title_generated/3`, which compares an
+   inbound event's agent id against it.
+
+3. **It unsubscribed, which destroyed recovery.**
+   `Subscriber.unsubscribe_from_agent/2` *deletes* the subs entry, and
+   `Subscriber.handle_presence_diff/3` only revives entries in the `:pending`
+   state. The shutdown event is broadcast *before* the process dies, so this
+   delete always beat the `:DOWN` that would have marked the entry `:pending`.
+   The subscription was unrecoverable without a remount. Do nothing instead:
+   `handle_publisher_down/3` plus the next presence arrival is the designed
+   recovery path.
+
+`shutdown_session_changes/2` is idempotent — a single shutdown delivers the event
+more than once — and it never touches `:agent_id` or `:sagents_subs`.
+
+---
+
+### 3. Add a resume entry point to the Coordinator
+
+```elixir
+def resume_agent_session(state, resume_data, request_opts \\ []),
+  do: Sagents.Session.resume(@config, state, resume_data, request_opts: request_opts)
+```
+
+---
+
+### 4. Route every interrupt response through it
+
+Find the direct resume calls:
+
+```
+grep -rn "AgentServer.resume" lib/ --include="*.ex"
+```
+
+Each one becomes a call to `resume_agent_session/3`. The return has three shapes:
+
+```elixir
+case Coordinator.resume_agent_session(socket.assigns, resume_data, request_opts) do
+  :ok ->
+    # A live agent took it.
+    socket |> assign(changes) |> assign(running_changes)
+
+  {:ok, session_changes} ->
+    # The agent was asleep and was woken with the answer in hand.
+    # session_changes carries subscription bookkeeping — merge it.
+    socket |> assign(session_changes) |> assign(changes) |> assign(running_changes)
+
+  {:error, reason} ->
+    put_flash(socket, :error, "Could not submit response: #{inspect(reason)}")
+end
+```
+
+Pass the **same `request_opts`** you pass to `ensure_agent_session_running/2`
+(timezone, tool context, whatever your FactoryConfig consumes). An agent woken to
+accept an answer must be configured exactly like one woken any other way.
+
+**Delete any "agent is no longer running" guard.** It looked like this:
+
+```elixir
+# Delete this entire branch
+if is_nil(agent_id) do
+  put_flash(socket, :error, "Agent is no longer running. Please send a new message to restart.")
+else
+  # ...
+end
+```
+
+It existed only because the shutdown handler nil'd `agent_id`. `Session.resume/4`
+asks the agent directly, which also covers a crash that never broadcast a
+shutdown at all.
+
+**Do not route intermediate steps through it.** In a multi-question batch or a
+multi-tool HITL approval, only the *final* answer resumes; the intermediate ones
+return `{:more, changes}` and need no agent. Waking one for those is wrong.
+
+---
+
+### 5. Guard duplicate submissions
+
+Not caused by this release, but newly reachable and worth fixing while you are
+here. A click-to-select answer renders no submit button to disable, and
+`Session.resume/4` is synchronous, so a fast double click delivers a second event
+*after* the first cleared `pending_question`.
+
+```elixir
+def handle_question_response(socket, response) do
+  if is_nil(socket.assigns[:pending_question]) do
+    socket
+  else
+    # ... existing body
+  end
+end
+
+def handle_hitl_decision(socket, index, decision_type) do
+  if (socket.assigns[:pending_tools] || []) == [] do
+    socket
+  else
+    # ... existing body
+  end
+end
+```
+
+Without the first guard the LiveView crashes on the missing question. Without the
+second, `AgentUtils.advance_hitl_decisions/3` receives an empty list, reports the
+batch settled, and **resumes with a fabricated decision** — silent and worse than
+a crash.
+
+---
+
+### 6. Update the UI
+
+**6a. Gate any "wake the agent" affordance on liveness.**
+
+```
+grep -rn "agent_status == :not_running" lib/ --include="*.ex" --include="*.heex"
+```
+
+```elixir
+# Before — hides the button exactly when a dormant conversation owes an answer,
+# because that conversation now correctly stays :interrupted
+:if={@agent_status == :not_running}
+
+# After
+:if={!@agent_alive?}
+```
+
+Thread `agent_alive?` through to any component that needs it, and seed it at
+mount from the agent's status:
+
+```elixir
+|> assign(:agent_alive?, agent_status != :not_running)
+```
+
+Also set it optimistically wherever you start an agent, so the affordance updates
+on the click that caused the wake rather than a round trip later:
+
+```elixir
+{:ok, changes} -> socket |> assign(changes) |> assign(:agent_alive?, true)
+```
+
+**6b. Protect typed text, if your question form has free-text input.**
+
+Wrap the answer controls in an ignored region keyed on the question's
+`tool_call_id`:
+
+```heex
+<div id={"question-body-#{@question.tool_call_id}"} phx-update="ignore">
+  <%!-- radios / checkboxes / textareas / submit --%>
+</div>
+```
+
+Any diff at all makes LiveView patch the container, and morphdom resyncs a
+`TEXTAREA`'s value from the server's HTML for every element that is not
+`document.activeElement`. The server never renders what the user typed, so an
+unrelated assign change wipes it — and this release guarantees one, because the
+shutdown flips `agent_alive?`.
+
+Keying the id on `tool_call_id` is what still lets the *next* question in a batch
+render: morphdom replaces an ignored subtree only when its id changes. Ids are
+distinct per question on both the live and restored paths.
+
+Keep anything without typed state (a Cancel button) **outside** the region so it
+can still re-render.
+
+---
+
+### 7. Check for re-subscribe-as-resync
+
+The one behavioural change in this release that is not opt-in:
+`on_subscribed/3` no longer fires for a pid already subscribed to that channel.
+It is documented as a *newly registered* subscriber snapshot, and a pid that has
+been receiving broadcasts all along has nothing to resync.
+
+```
+grep -rn "subscribe_to_agent\|AgentServer.subscribe" lib/ --include="*.ex"
+```
+
+If any call site subscribes an already-subscribed pid specifically to force a
+state refresh, replace it with `Sagents.AgentServer.get_info/1`. Ordinary
+subscribe calls, remounts, second tabs, and presence-driven re-subscription after
+a crash are all unaffected — each is a genuinely new registration.
+
+---
+
+### 8. Collapse duplicated shutdown-event handling
+
+All three `{:agent_shutdown, _}` emit sites now send the same map:
+
+```elixir
+%{
+  agent_id: String.t(),
+  reason: :inactivity | :no_viewers | term(),
+  status: Sagents.AgentServer.status(),
+  interrupt_restorable: boolean(),
+  last_activity_at: DateTime.t() | nil,
+  shutdown_at: DateTime.t()
+}
+```
+
+Previously `terminate/2` sent only `%{reason:, status:}`, so hosts needed a clause
+per site and could not correlate the event by agent id. If you wrote two clauses
+to absorb that, they can collapse to one. Subset map patterns keep working
+unchanged.
+
+---
+
+### 9. Fix the tests that now fail
+
+This is the **only** place you get an automatic signal, and it is a good one.
+
+Any host test asserting the old shutdown behaviour will fail, for example:
+
+```elixir
+assert changes.agent_id == nil            # no longer true, and that is the fix
+assert changes.agent_status == :not_running   # no longer true for a restorable interrupt
+```
+
+Rewrite them against the new contract. Worth adding, since these are pure
+state-map-in / changes-map-out functions needing no agent, DB, or LiveView:
+
+- a restorable question survives shutdown (`agent_status` stays `:interrupted`,
+  `agent_alive?` becomes `false`)
+- a non-restorable interrupt (a sub-agent approval) still clears
+- a missing `:interrupt_restorable` key is treated as not restorable
+- the result is idempotent across two consecutive deliveries
+- `agent_id` and `sagents_subs` are untouched
+- a half-answered question batch keeps its accumulated responses
+
+---
+
+## Verifying the migration
+
+The compiler cannot confirm this worked. Test it by hand:
+
+1. Temporarily drop `inactivity_timeout` in your Coordinator's `@config` to
+   ~20 seconds.
+2. Prompt the agent so it asks a question.
+3. Wait for the nap. Watch for `shutting down due to inactivity` in the log.
+4. **The question should still be on screen.** That is the fix.
+5. Answer it. The log should show:
+
+   ```
+   Starting agent session for conversation N
+   Agent conversation-N applying a resume submitted while it was not running
+   ```
+
+   with **no** `{:status_changed, :interrupted, _}` between them.
+
+To kill the agent instantly instead of waiting, use the same path the inactivity
+timer uses:
+
+```elixir
+Sagents.AgentSupervisor.stop(YourApp.Coordinator.conversation_agent_id(conversation_id))
+```
+
+Do not use `Sagents.AgentServer.stop/1` — that kills only the server, and the
+supervisor restarts it as a permanent child.
+
+---
+
+## Recommended approach for generated files
+
+If your generated modules are close to stock, the fastest route is to start from
+a clean workspace, re-run `mix sagents.setup` with the same options used
+originally, accept the overwrites, and diff your customizations back in. The
+v0.11.0 templates contain every change in steps 1 through 5.
+
+If they have drifted, apply the steps by hand. Step 2 is the one that must not be
+skipped or half-applied.

--- a/MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md
+++ b/MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md
@@ -199,13 +199,47 @@ case Coordinator.resume_agent_session(socket.assigns, resume_data, request_opts)
     socket |> assign(session_changes) |> assign(changes) |> assign(running_changes)
 
   {:error, reason} ->
-    put_flash(socket, :error, "Could not submit response: #{inspect(reason)}")
+    # Log the term. Do not show it. A live agent in the wrong state, meaning
+    # someone answered from a second tab, returns "Cannot resume, server is not
+    # interrupted": an internal string, and one that says "agent", a word many
+    # products deliberately never put in front of a user.
+    Logger.error("resume failed: #{inspect(reason)}")
+    put_flash(socket, :error, "That response could not be saved. Please try again.")
 end
 ```
+
+Keep the log message and the flash message **separate**. It is tempting to build
+both from one `error_prefix`, and the result is a term dump in the user's face.
+The flash is a slot you are meant to write product copy into. The v0.11.0
+`AgentLiveHelpers` template passes these as two named values, `:log_label` and
+`:user_message`, for exactly this reason.
 
 Pass the **same `request_opts`** you pass to `ensure_agent_session_running/2`
 (timezone, tool context, whatever your FactoryConfig consumes). An agent woken to
 accept an answer must be configured exactly like one woken any other way.
+
+The only reliable way to guarantee that is **one function every start path reads**.
+The v0.11.0 `AgentLiveHelpers` template ships it as a public stub:
+
+```elixir
+# Generated. Fill in the body once; the resume funnel and the mount-time
+# auto-wake already read it.
+def agent_request_opts(_socket), do: []
+```
+
+**Route your own `ensure_agent_session_running/2` call sites through it too.**
+
+```
+grep -rn "ensure_agent_session_running" lib/ --include="*.ex"
+```
+
+Any call site computing its own options is a second copy of this decision. It
+compiles, it reads as finished, and it drifts: the two copies disagree about a
+missing assign or a default, and a host then boots agents on the resume and
+auto-wake paths configured *differently* from every other path. Nothing surfaces
+it: not the compiler, not your tests, not the manual check in "Verifying the
+migration". The symptom is an agent that behaves subtly wrong *only* when it was
+woken to take an answer.
 
 **Delete any "agent is no longer running" guard.** It looked like this:
 
@@ -260,9 +294,75 @@ a crash.
 
 ---
 
-### 6. Update the UI
+### 6. If you render a halt panel, make Dismiss wake the agent
 
-**6a. Gate any "wake the agent" affordance on liveness.**
+**Skip this step only if your app never renders `:pending_halt`.** Check first:
+
+```
+grep -rn "pending_halt" lib/ --include="*.ex" --include="*.heex"
+```
+
+A halt panel now **survives a shutdown**. That is intentional and matches a
+question, but it means the panel's Dismiss button must work against a dormant
+conversation, and `Sagents.AgentServer.dismiss_interrupt/1` talks to a live
+process: it returns `{:error, :agent_not_running}` when there is none.
+
+Route the dismissal through `Sagents.Session.dismiss/3`, the mirror of
+`Session.resume/4` for the interrupt that is *acknowledged* rather than answered.
+It tries the live agent first and, failing that, wakes one and dismisses against
+the halt rebuilt at boot.
+
+Add the Coordinator entry point next to `resume_agent_session/3`:
+
+```elixir
+def dismiss_agent_session(state, request_opts \\ []),
+  do: Sagents.Session.dismiss(@config, state, request_opts: request_opts)
+```
+
+Then route the panel's button through it. This is the generated
+`handle_halt_dismissal/1`, and the return has the same three shapes as a resume:
+
+```elixir
+def handle_halt_dismissal(socket) do
+  if is_nil(socket.assigns[:pending_halt]) do
+    # Duplicate event for an already-dismissed halt. Same guard as step 5.
+    socket
+  else
+    case Coordinator.dismiss_agent_session(socket.assigns, agent_request_opts(socket)) do
+      :ok ->
+        assign(socket, AgentUtils.cleared_interrupt_changes())
+
+      {:ok, session_changes} ->
+        socket
+        |> assign(session_changes)
+        |> assign(:agent_alive?, true)
+        |> assign(AgentUtils.cleared_interrupt_changes())
+
+      {:error, reason} ->
+        Logger.error("halt dismissal failed: #{inspect(reason)}")
+        put_flash(socket, :error, "That could not be dismissed. Please try again.")
+    end
+  end
+end
+```
+
+Pass the same `agent_request_opts/1` as every other start path, for the reason
+given in step 4.
+
+Note that an interrupt needing a real response (a question, a HITL batch) returns
+`{:error, "interrupt requires explicit response (use resume)"}` and is
+deliberately **not** woken. Only halts are dismissible.
+
+Do **not** "fix" this by having the host clear `:pending_halt` on shutdown. That
+makes every host re-answer a question `restorable_interrupt?/1` already answers,
+and it is a type-level mirror that drifts the moment a new interrupt type
+appears.
+
+---
+
+### 7. Update the UI
+
+**7a. Gate any "wake the agent" affordance on liveness.**
 
 ```
 grep -rn "agent_status == :not_running" lib/ --include="*.ex" --include="*.heex"
@@ -291,33 +391,45 @@ on the click that caused the wake rather than a round trip later:
 {:ok, changes} -> socket |> assign(changes) |> assign(:agent_alive?, true)
 ```
 
-**6b. Protect typed text, if your question form has free-text input.**
+**7b. Protect unsent user state in the question form.**
 
-Wrap the answer controls in an ignored region keyed on the question's
-`tool_call_id`:
+The rule: **the ignored region must contain every control that holds state the
+user has entered but not yet submitted**: text areas, radios, checkboxes. Wrap
+them in a region keyed on the question's `tool_call_id`:
 
 ```heex
 <div id={"question-body-#{@question.tool_call_id}"} phx-update="ignore">
-  <%!-- radios / checkboxes / textareas / submit --%>
+  <%!-- radios / checkboxes / textareas --%>
 </div>
 ```
 
 Any diff at all makes LiveView patch the container, and morphdom resyncs a
-`TEXTAREA`'s value from the server's HTML for every element that is not
-`document.activeElement`. The server never renders what the user typed, so an
-unrelated assign change wipes it — and this release guarantees one, because the
-shutdown flips `agent_alive?`.
+`TEXTAREA`'s value, and a radio's checked state, from the server's HTML for
+every element that is not `document.activeElement`. The server never renders what
+the user entered, so an unrelated assign change wipes it. This release
+*guarantees* such a change: the shutdown flips `agent_alive?`. This is reachable,
+not theoretical.
 
 Keying the id on `tool_call_id` is what still lets the *next* question in a batch
 render: morphdom replaces an ignored subtree only when its id changes. Ids are
-distinct per question on both the live and restored paths.
+distinct per question on both the live and restored paths, because a batch is
+several parallel `ask_user` calls, not one call carrying several questions.
 
-Keep anything without typed state (a Cancel button) **outside** the region so it
+Keep anything without unsent state (a Cancel button) **outside** the region so it
 can still re-render.
+
+**If your Submit button lives outside the region**, which is a reasonable layout
+because a long option list otherwise pushes Submit below the fold, then wrapping
+only the options band is correct, *but something must re-derive Submit's enabled
+state after the patch*. The footer re-renders with the server's `disabled` attribute
+while the preserved selection sits inside the ignored subtree, so the user picks
+an option, an unrelated assign changes, and Submit silently reverts to disabled
+with a valid selection on screen. A hook with an `updated()` callback that reads
+the current radio/checkbox state and sets `disabled` accordingly closes it.
 
 ---
 
-### 7. Check for re-subscribe-as-resync
+### 8. Check for re-subscribe-as-resync
 
 The one behavioural change in this release that is not opt-in:
 `on_subscribed/3` no longer fires for a pid already subscribed to that channel.
@@ -335,7 +447,7 @@ a crash are all unaffected — each is a genuinely new registration.
 
 ---
 
-### 8. Collapse duplicated shutdown-event handling
+### 9. Collapse duplicated shutdown-event handling
 
 All three `{:agent_shutdown, _}` emit sites now send the same map:
 
@@ -357,16 +469,27 @@ unchanged.
 
 ---
 
-### 9. Fix the tests that now fail
+### 10. Fix the tests that now fail
 
 This is the **only** place you get an automatic signal, and it is a good one.
 
-Any host test asserting the old shutdown behaviour will fail, for example:
+Two distinct failures to expect.
+
+**Shutdown assertions.** Any host test asserting the old behaviour will fail:
 
 ```elixir
 assert changes.agent_id == nil            # no longer true, and that is the fix
 assert changes.agent_status == :not_running   # no longer true for a restorable interrupt
 ```
+
+**Question fixtures missing `tool_call_id`.** If you have component or LiveView
+tests that build a question by hand, the keyed ignore region from step 7b now
+requires that key, and a fixture without it fails at render. Real questions always
+carry it: `Sagents.Middleware.AskUserQuestion` puts the originating tool call's
+id on the interrupt data, and `AgentUtils.interrupt_session_changes/1` passes the
+map through to `:pending_question` untouched. So this is a fixture that was always
+unfaithful and only now has something depending on the difference. Add the key
+rather than dropping it from the template.
 
 Rewrite them against the new contract. Worth adding, since these are pure
 state-map-in / changes-map-out functions needing no agent, DB, or LiveView:
@@ -399,6 +522,12 @@ The compiler cannot confirm this worked. Test it by hand:
 
    with **no** `{:status_changed, :interrupted, _}` between them.
 
+6. **If your app renders a halt panel, nap it too and confirm Dismiss still
+   works.** A halt is restorable, so the panel survives the nap exactly like the
+   question, and its Dismiss button is the one control that needs a live agent.
+   Without step 6 you get a panel that cannot be dismissed, and no other check in
+   this list catches it.
+
 To kill the agent instantly instead of waiting, use the same path the inactivity
 timer uses:
 
@@ -416,7 +545,13 @@ supervisor restarts it as a permanent child.
 If your generated modules are close to stock, the fastest route is to start from
 a clean workspace, re-run `mix sagents.setup` with the same options used
 originally, accept the overwrites, and diff your customizations back in. The
-v0.11.0 templates contain every change in steps 1 through 5.
+v0.11.0 templates contain every change in steps 1 through 6.
+
+Step 6 is covered on the Elixir side only: the templates generate
+`dismiss_agent_session/2` and `handle_halt_dismissal/1`, but no template renders
+a halt panel, so wiring your button's `phx-click` to that handler is still yours
+to do. Steps 7 through 10 are host UI and host tests, which no template covers
+either.
 
 If they have drifted, apply the steps by hand. Step 2 is the one that must not be
 skipped or half-applied.

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -98,8 +98,23 @@ defmodule Sagents.AgentServer do
 
   ### Shutdown Events
   - `{:agent, {:agent_shutdown, shutdown_data}}` - Agent is shutting down
+
+    A single shutdown delivers this event more than once (the trigger handler
+    fires it, then `terminate/2` fires it again). Every site emits the same
+    map shape, so consumers can handle it with one idempotent clause:
+
     - `shutdown_data.agent_id` - The agent identifier
-    - `shutdown_data.reason` - Shutdown reason (`:inactivity` | `:no_viewers`)
+    - `shutdown_data.reason` - Shutdown reason (`:inactivity` | `:no_viewers`
+      | the `terminate/2` reason term)
+    - `shutdown_data.status` - The server's status at shutdown
+    - `shutdown_data.interrupt_restorable` - `true` when the server is
+      shutting down `:interrupted` **and** the pending interrupt can be
+      rebuilt on the next boot (see `Sagents.State.interrupt_restorable?/2`).
+      A host showing an interrupt prompt can keep it on screen when this is
+      `true`, because answering it will wake an agent that boots straight
+      back into `:interrupted`. `false` whenever there is no interrupt, or
+      the interrupt is process-bound (e.g. a sub-agent approval). See
+      `Sagents.AgentUtils.shutdown_session_changes/2`.
     - `shutdown_data.last_activity_at` - DateTime of last activity
     - `shutdown_data.shutdown_at` - DateTime when shutdown was initiated
 
@@ -314,7 +329,25 @@ defmodule Sagents.AgentServer do
       # written the flag as `true` and not yet cleared it; `false` means
       # the flag is clear (or we have never written it). Used to suppress
       # redundant callback invocations.
-      interrupt_persisted: false
+      interrupt_persisted: false,
+      # A user's answer to a pending interrupt, submitted while this agent was
+      # asleep, waiting to be applied at boot.
+      #
+      # Holds whatever `resume/2` accepts. That term is middleware-owned, so the
+      # shape depends on what asked the question:
+      #
+      #     AskUserQuestion  %{type: :answer, tool_call_id: "call_1", selected: ["pg"]}
+      #                      (a list of those when several questions are pending)
+      #     HumanInTheLoop   [%{type: :approve}, %{type: :reject}]
+      #
+      # Set only by `Sagents.Session.resume/4`, and only after `resume/2` returned
+      # `{:error, :agent_not_running}`. Read exactly once, in
+      # handle_continue(:broadcast_initial_state, _): applied if we booted
+      # `:interrupted`, dropped with a warning otherwise, and nil'd either way. So
+      # no handle_call/handle_info ever sees it set. Consuming it before the first
+      # broadcast is what lets a woken agent announce `:running` rather than an
+      # `:interrupted` snapshot it is about to leave. Never persisted.
+      pending_resume: nil
     ]
 
     @type t :: %__MODULE__{
@@ -347,6 +380,7 @@ defmodule Sagents.AgentServer do
             restored: boolean(),
             interrupt_persisted: boolean(),
             pending_message: LangChain.Message.t() | nil,
+            pending_resume: term() | nil,
             consecutive_auto_executions: non_neg_integer()
           }
   end
@@ -377,6 +411,21 @@ defmodule Sagents.AgentServer do
   - `:conversation_id` - Optional conversation identifier for message persistence (default: nil)
   - `:agent_persistence` - Module implementing `Sagents.AgentPersistence` for state snapshots (default: nil)
   - `:display_message_persistence` - Module implementing `Sagents.DisplayMessagePersistence` for display messages (default: nil)
+  - `:pending_resume` - A resume payload to apply during boot, for an answer
+    submitted while no process was alive to take it. Applied in
+    `handle_continue/2` **before** the initial status broadcast, so a server
+    that boots `:interrupted` and consumes this announces `:running` once,
+    rather than announcing an `:interrupted` snapshot it is about to leave.
+    Discarded with a warning if the server boots into any other status (the
+    interrupt was demoted as non-restorable, or answered elsewhere first).
+    Prefer `Sagents.Session.resume/4`, which sets this for you and handles
+    the live-agent and already-woken cases. Default: `nil`.
+
+    Note it lives in the child spec, so a supervisor restart re-evaluates it
+    against freshly loaded persisted state. If the resume already completed,
+    that state no longer carries an interrupt and the payload is discarded;
+    if the run died before completing, re-applying it is the correct
+    recovery. The supervisor's restart intensity bounds a pathological loop.
 
   ## Examples
 
@@ -1584,7 +1633,10 @@ defmodule Sagents.AgentServer do
       # A message that was queued when the previous incarnation of this server
       # died. It drains at the next clean run boundary, exactly as if it had
       # been queued a moment ago.
-      pending_message: Keyword.get(opts, :pending_message)
+      pending_message: Keyword.get(opts, :pending_message),
+      # An interrupt response submitted while no process was alive to take it.
+      # Applied in handle_continue/2 before the first broadcast.
+      pending_resume: Keyword.get(opts, :pending_resume)
     }
 
     # Start the inactivity timer
@@ -1629,6 +1681,71 @@ defmodule Sagents.AgentServer do
        do: true
 
   defp live_interrupt?(_other), do: false
+
+  # Transition an :interrupted server into a running resume: bump execution_seq
+  # so callbacks from the prior run can't pollute the rolling state, clear the
+  # interrupt, reset the activity timer, and spawn the resume task.
+  #
+  # Deliberately does NOT broadcast. The two callers disagree on when the status
+  # event should go out: the {:resume, _} handle_call emits it immediately,
+  # while the boot path folds it into the single initial broadcast so a waking
+  # agent never announces an :interrupted status it is about to leave.
+  defp start_resume(%ServerState{status: :interrupted} = server_state, resume_data) do
+    # Capture interrupt_data before clearing -- resume_agent needs it for
+    # display message updates (e.g., marking ask_user tools as completed).
+    resolved_interrupt_data = server_state.interrupt_data
+
+    new_state = %{
+      server_state
+      | status: :running,
+        interrupt_data: nil,
+        execution_seq: server_state.execution_seq + 1
+    }
+
+    new_state = reset_inactivity_timer(new_state)
+
+    # Resume execution async (callbacks are built in resume_agent)
+    task =
+      Task.async(fn ->
+        resume_agent(new_state, resume_data, resolved_interrupt_data)
+      end)
+
+    Map.put(new_state, :task, task)
+  end
+
+  # Consume a resume handed to us at start time by `Sagents.Session.resume/4`.
+  #
+  # The answer was submitted against a conversation whose agent had gone to
+  # sleep. The interrupt itself is durable, so this boot has already rebuilt it
+  # via derive_boot_status/1 and we can take the answer immediately.
+  defp apply_pending_resume(%ServerState{pending_resume: nil} = server_state), do: server_state
+
+  defp apply_pending_resume(
+         %ServerState{pending_resume: resume_data, status: :interrupted} = server_state
+       ) do
+    Logger.info(
+      "Agent #{server_state.agent.agent_id} applying a resume submitted while it was not running"
+    )
+
+    %{server_state | pending_resume: nil}
+    |> start_resume(resume_data)
+  end
+
+  # Booted into some other status: the interrupt was demoted as non-restorable
+  # by clean_stale_interrupts/2, or it was answered elsewhere (another tab, the
+  # admin view) before this boot. Drop the answer and let the honest boot status
+  # go out — the host's ordinary non-interrupted status handler clears the
+  # prompt, which is the correct outcome. Never silently apply it to whatever
+  # the agent is doing now.
+  defp apply_pending_resume(%ServerState{} = server_state) do
+    Logger.warning(
+      "Agent #{server_state.agent.agent_id} was given a pending resume but booted " <>
+        ":#{server_state.status}, not :interrupted. Discarding the resume: the interrupt " <>
+        "was either answered elsewhere or could not be restored."
+    )
+
+    %{server_state | pending_resume: nil}
+  end
 
   # Mirror of LangChain's `extract_interrupt_data/1` — keep these in lockstep
   # so restored and freshly-fired interrupts surface identically.
@@ -1675,6 +1792,15 @@ defmodule Sagents.AgentServer do
     if server_state.restored do
       broadcast_event(server_state, {:node_transferred, %{to_node: node()}})
     end
+
+    # Apply a resume that was submitted while no process was alive to take it,
+    # BEFORE the initial status broadcast. This is deliberately ordered: the
+    # boot broadcast is how every subscriber learns current state, so it must
+    # fire, unconditionally, exactly once — but it should report the status
+    # this server genuinely has once it has consumed everything it was handed.
+    # Broadcasting :interrupted here and :running a microsecond later would
+    # make every subscriber re-present a question that is already answered.
+    server_state = apply_pending_resume(server_state)
 
     # Broadcast initial status so UI knows agent is ready. When restored from
     # persisted state with a surviving (restorable) interrupt, this fires
@@ -1765,32 +1891,12 @@ defmodule Sagents.AgentServer do
         _from,
         %ServerState{status: :interrupted} = server_state
       ) do
-    # Capture interrupt_data before clearing -- resume_agent needs it for
-    # display message updates (e.g., marking ask_user tools as completed).
-    resolved_interrupt_data = server_state.interrupt_data
-
-    # Transition back to running. Bump execution_seq so callbacks from a prior
-    # run can't pollute the rolling state.
-    new_state = %{
-      server_state
-      | status: :running,
-        interrupt_data: nil,
-        execution_seq: server_state.execution_seq + 1
-    }
+    new_state = start_resume(server_state, resume_data)
 
     broadcast_event(new_state, {:status_changed, :running, nil})
     update_presence_status(new_state, :running)
 
-    # Reset inactivity timer on resume
-    new_state = reset_inactivity_timer(new_state)
-
-    # Resume execution async (callbacks are built in resume_agent)
-    task =
-      Task.async(fn ->
-        resume_agent(new_state, resume_data, resolved_interrupt_data)
-      end)
-
-    {:reply, :ok, Map.put(new_state, :task, task)}
+    {:reply, :ok, new_state}
   end
 
   @impl true
@@ -2255,16 +2361,7 @@ defmodule Sagents.AgentServer do
     Logger.info("Agent #{agent_id} shutting down due to inactivity")
 
     # Broadcast shutdown event
-    broadcast_event(
-      server_state,
-      {:agent_shutdown,
-       %{
-         agent_id: agent_id,
-         reason: :inactivity,
-         last_activity_at: server_state.last_activity_at,
-         shutdown_at: DateTime.utc_now()
-       }}
-    )
+    broadcast_event(server_state, {:agent_shutdown, shutdown_payload(server_state, :inactivity)})
 
     {:noreply, stop_supervisor(server_state)}
   end
@@ -2275,16 +2372,7 @@ defmodule Sagents.AgentServer do
     Logger.info("Agent #{agent_id} shutting down - idle with no viewers")
 
     # Broadcast shutdown event
-    broadcast_event(
-      server_state,
-      {:agent_shutdown,
-       %{
-         agent_id: agent_id,
-         reason: :no_viewers,
-         last_activity_at: server_state.last_activity_at,
-         shutdown_at: DateTime.utc_now()
-       }}
-    )
+    broadcast_event(server_state, {:agent_shutdown, shutdown_payload(server_state, :no_viewers)})
 
     {:noreply, stop_supervisor(server_state)}
   end
@@ -2395,10 +2483,7 @@ defmodule Sagents.AgentServer do
     try do
       broadcast_event(server_state, {:node_transferring, %{from_node: node()}})
 
-      broadcast_event(
-        server_state,
-        {:agent_shutdown, %{reason: reason, status: server_state.status}}
-      )
+      broadcast_event(server_state, {:agent_shutdown, shutdown_payload(server_state, reason)})
     rescue
       _error -> :ok
     end
@@ -2409,6 +2494,36 @@ defmodule Sagents.AgentServer do
 
     :ok
   end
+
+  # Build the `{:agent_shutdown, payload}` map. Every emit site (the two
+  # timer-driven handlers and terminate/2) uses this, so a single shutdown
+  # delivers the same shape more than once and consumers need exactly one
+  # idempotent clause.
+  #
+  # `:interrupt_restorable` is the whole reason this is centralized. It is the
+  # only moment the question "can this pending interrupt survive the process
+  # dying?" is worth asking, and it is the only moment when both the
+  # interrupt_data and the agent's middleware are still in scope to answer it.
+  # A host that keeps an interrupt prompt on screen past shutdown must not
+  # guess: a mirrored predicate silently drifts the day the middleware rules
+  # change, and the failure mode is offering the user a prompt no agent can
+  # ever accept.
+  defp shutdown_payload(%ServerState{} = server_state, reason) do
+    %{
+      agent_id: server_state.agent.agent_id,
+      reason: reason,
+      status: server_state.status,
+      interrupt_restorable: interrupt_restorable?(server_state),
+      last_activity_at: server_state.last_activity_at,
+      shutdown_at: DateTime.utc_now()
+    }
+  end
+
+  defp interrupt_restorable?(%ServerState{status: :interrupted} = server_state) do
+    State.interrupt_restorable?(server_state.interrupt_data, server_state.agent.middleware)
+  end
+
+  defp interrupt_restorable?(%ServerState{}), do: false
 
   # Wait for an active Task to complete, with a timeout
   defp wait_for_task_completion(%Task{ref: ref}, max_wait_ms) do

--- a/lib/sagents/agent_supervisor.ex
+++ b/lib/sagents/agent_supervisor.ex
@@ -306,6 +306,7 @@ defmodule Sagents.AgentSupervisor do
     message_preprocessor = Keyword.get(config, :message_preprocessor)
     presence_module = Keyword.get(config, :presence_module)
     initial_subscribers = Keyword.get(config, :initial_subscribers, [])
+    pending_resume = Keyword.get(config, :pending_resume)
 
     # Build AgentServer options
     agent_server_opts = [
@@ -362,6 +363,13 @@ defmodule Sagents.AgentSupervisor do
     agent_server_opts =
       if presence_module,
         do: Keyword.put(agent_server_opts, :presence_module, presence_module),
+        else: agent_server_opts
+
+    # Add pending_resume if provided (an interrupt answer submitted while the
+    # agent was asleep, applied at boot before the initial status broadcast)
+    agent_server_opts =
+      if pending_resume,
+        do: Keyword.put(agent_server_opts, :pending_resume, pending_resume),
         else: agent_server_opts
 
     # Build child specifications

--- a/lib/sagents/agent_utils.ex
+++ b/lib/sagents/agent_utils.ex
@@ -282,6 +282,96 @@ defmodule Sagents.AgentUtils do
   end
 
   @doc """
+  Changes a host should merge when the agent process goes away.
+
+  Takes the host's state map and the `{:agent_shutdown, shutdown_data}`
+  payload (see `Sagents.AgentServer` for its shape).
+
+  ## Liveness is not status
+
+  `agent_status` describes **what the conversation is waiting on**.
+  `agent_alive?` describes **whether a producer process is backing this
+  session right now**. They are independent facts, and conflating them is
+  what loses an open question when the agent naps: the author still owes an
+  answer, so the conversation is still `:interrupted`, even though nothing
+  is running.
+
+  Hosts should therefore carry both keys:
+
+  - merge `agent_alive?: true` in every `handle_status_*` handler (an
+    inbound agent event is proof of life)
+  - merge `agent_alive?: false` here, and in the `:DOWN` handler
+  - gate "wake the agent" affordances on `agent_alive?`, not on
+    `agent_status == :not_running`
+
+  ## Behaviour
+
+  - The session has a pending interrupt and
+    `shutdown_data.interrupt_restorable` is `true`: keep every `pending_*`
+    key, keep `:interrupt_data`, and keep `agent_status: :interrupted`.
+    Returns only `%{agent_alive?: false, loading: false, streaming_delta:
+    nil}`. The prompt stays on screen; answering it wakes an agent that boots
+    straight back into `:interrupted` (see
+    `Sagents.Session.resume/4`).
+  - Otherwise: today's behaviour, `cleared_interrupt_changes/0` plus
+    `agent_status: :not_running`.
+  - `:interrupt_restorable` **absent** (an agent predating this field): treated
+    as not restorable. A version-skewed pair degrades to the old
+    clear-everything behaviour rather than to a prompt no agent can accept.
+
+  Idempotent: a shutdown delivers this event more than once, and every
+  delivery carries the same fields, so re-merging the result is a no-op.
+
+  ## What this does *not* do
+
+  It does not touch the `Sagents.Subscriber` subs map. Unsubscribing here
+  would delete the entry, and `Sagents.Subscriber.handle_presence_diff/3`
+  only revives entries in the `:pending` state, so the subscription could
+  never come back without a remount. Leave it alone:
+  `handle_publisher_down/3` flips it to `:pending` on the `:DOWN` that is
+  already on its way, and the next presence arrival re-subscribes. That is
+  the designed recovery path and exactly what is wanted after a wake.
+
+  It also does not clear `:agent_id`. That is a pure function of the
+  conversation id, it is what the host needs in order to wake the agent
+  again, and nil-ing it breaks any handler that compares an inbound event's
+  agent id against it.
+
+  ## Example
+
+      def handle_agent_shutdown(state, shutdown_data) do
+        AgentUtils.shutdown_session_changes(state, shutdown_data)
+      end
+
+  """
+  @spec shutdown_session_changes(map(), map()) :: map()
+  def shutdown_session_changes(state, shutdown_data)
+      when is_map(state) and is_map(shutdown_data) do
+    if pending_interrupt?(state) and Map.get(shutdown_data, :interrupt_restorable) == true do
+      # Dormant, but the conversation is still waiting on the author.
+      %{agent_alive?: false, loading: false, streaming_delta: nil}
+    else
+      Map.merge(cleared_interrupt_changes(), %{
+        agent_alive?: false,
+        agent_status: :not_running,
+        loading: false,
+        streaming_delta: nil
+      })
+    end
+  end
+
+  # A host is displaying an interrupt if it has interrupt_data and at least
+  # one derived pending_* key populated. Checking the derived keys (rather
+  # than agent_status alone) makes this correct on a redelivery, where the
+  # first call already collapsed the session to :not_running.
+  defp pending_interrupt?(state) do
+    Map.get(state, :interrupt_data) != nil and
+      (Map.get(state, :pending_question) != nil or
+         Map.get(state, :pending_halt) != nil or
+         (Map.get(state, :pending_tools) || []) != [])
+  end
+
+  @doc """
   Compute the state transition for a single HITL approve/reject decision
   in a host's pending-tool list.
 

--- a/lib/sagents/publisher.ex
+++ b/lib/sagents/publisher.ex
@@ -123,6 +123,15 @@ defmodule Sagents.Publisher do
   The callback runs inside the subscribe `handle_call` *after* registration
   but *before* the reply, so the snapshot is guaranteed to arrive at the
   subscriber before any later broadcasts on the same channel.
+
+  It fires only for a **newly registered** pid. A pid that is already
+  subscribed to the channel (e.g. one seeded via
+  `Sagents.Publisher.State.seed/2` as an `:initial_subscribers` entry, which
+  then calls `subscribe/3` for its own bookkeeping) has been receiving every
+  broadcast on that channel since registration, so there is nothing to
+  resync and a second snapshot would be a duplicate event. Hosts that want
+  an on-demand snapshot should expose a pull-based call instead (the
+  AgentServer's equivalent is `Sagents.AgentServer.get_info/1`).
   """
   defmacro __using__(opts) do
     state_field = Keyword.fetch!(opts, :state_field)
@@ -134,9 +143,24 @@ defmodule Sagents.Publisher do
       def handle_call({:__publisher__, channel, :subscribe, subscriber_pid}, _from, state)
           when is_atom(channel) and is_pid(subscriber_pid) do
         pub = Map.fetch!(state, @publisher_state_field)
+
+        # `add/3` is idempotent for registration, but `on_subscribed/3` is a
+        # *new subscriber* hook. A pid that is already registered has been
+        # receiving broadcasts all along, so re-running the snapshot would
+        # deliver a duplicate event, not a resync.
+        already_subscribed? =
+          Sagents.Publisher.State.subscribed?(pub, channel, subscriber_pid)
+
         {ref, new_pub} = Sagents.Publisher.State.add(pub, channel, subscriber_pid)
         new_state = Map.put(state, @publisher_state_field, new_pub)
-        new_state = on_subscribed(channel, subscriber_pid, new_state)
+
+        new_state =
+          if already_subscribed? do
+            new_state
+          else
+            on_subscribed(channel, subscriber_pid, new_state)
+          end
+
         {:reply, {:ok, self(), ref}, new_state}
       end
 

--- a/lib/sagents/session.ex
+++ b/lib/sagents/session.ex
@@ -68,7 +68,8 @@ defmodule Sagents.Session do
   @type session_info :: %{
           agent_id: String.t(),
           pid: pid(),
-          conversation_id: term()
+          conversation_id: term(),
+          started: boolean()
         }
 
   @doc """
@@ -76,6 +77,12 @@ defmodule Sagents.Session do
 
   Idempotent: if an agent is already running for `conversation_id`, returns
   the existing session info without consulting the router or factory again.
+
+  `session_info.started` distinguishes the two: `true` when this call created
+  the process, `false` when it found one already up. Callers that pass
+  start-time-only options (`:initial_subscribers`, `:pending_resume`) need
+  this, because those options are consumed by `init/1` and are silently
+  ignored on the already-running path.
 
   ## Options
 
@@ -85,6 +92,9 @@ defmodule Sagents.Session do
   - `:initial_subscribers` — list of `{channel, pid}` tuples seeded as
     subscribers before the agent's `init/1` returns. Use to atomically
     start-and-subscribe.
+  - `:pending_resume` — a resume payload applied during boot, before the
+    initial status broadcast. See `resume/4`, which is the supported way to
+    set this.
   """
   @spec start(config(), conversation_id :: term(), opts :: keyword()) ::
           {:ok, session_info()} | {:error, term()}
@@ -102,7 +112,8 @@ defmodule Sagents.Session do
          %{
            agent_id: agent_id,
            pid: pid,
-           conversation_id: conversation_id
+           conversation_id: conversation_id,
+           started: false
          }}
     end
   end
@@ -136,6 +147,16 @@ defmodule Sagents.Session do
   @spec ensure_running(config(), state_map :: map(), opts :: keyword()) ::
           {:ok, %{sagents_subs: map(), agent_id: String.t()}} | {:error, term()}
   def ensure_running(config, state, opts \\ []) when is_map(state) do
+    case do_ensure_running(config, state, opts) do
+      {:ok, changes, _session_info} -> {:ok, changes}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Same as ensure_running/3 but also returns the session_info, so callers that
+  # passed start-time-only options can tell whether their options were consumed
+  # by a fresh boot or dropped because an agent was already up.
+  defp do_ensure_running(config, state, opts) do
     conversation_id = Map.fetch!(state, :conversation_id)
     agent_id = config.agent_id_fun.(conversation_id)
     subs = Map.get(state, :sagents_subs, %{})
@@ -143,18 +164,121 @@ defmodule Sagents.Session do
     start_opts = [
       scope: Map.fetch!(state, :current_scope),
       request_opts: Keyword.get(opts, :request_opts, []),
-      initial_subscribers: [{:main, self()}]
+      initial_subscribers: [{:main, self()}],
+      pending_resume: Keyword.get(opts, :pending_resume)
     ]
 
     case start(config, conversation_id, start_opts) do
-      {:ok, %{pid: pid}} ->
+      {:ok, %{pid: pid} = session_info} ->
         new_subs =
           case Map.get(subs, {:agent, agent_id}) do
             %{state: :subscribed, server_pid: ^pid} -> subs
             _other -> Subscriber.subscribe_to_agent(subs, agent_id)
           end
 
-        {:ok, %{sagents_subs: new_subs, agent_id: agent_id}}
+        {:ok, %{sagents_subs: new_subs, agent_id: agent_id}, session_info}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Answer a pending interrupt, waking the agent first if it has gone to sleep.
+
+  Use this everywhere a host would otherwise call
+  `Sagents.AgentServer.resume/2` directly. Interrupts are durable: the
+  persisted state carries `interrupt_data`, and a fresh boot rebuilds it and
+  comes up `:interrupted`. So "the agent is not running" is not a reason an
+  answer has to fail — it is only a reason to start a process to take it.
+
+  `state` is the host's process-level map, with the same required keys as
+  `ensure_running/3` (`:conversation_id`, `:current_scope`, optionally
+  `:sagents_subs`).
+
+  ## Options
+
+  - `:request_opts` — forwarded verbatim to `ensure_running/3` on the wake
+    path. Pass the same per-request data you pass when starting a session
+    (timezone, tool context, and so on); an agent woken to take an answer is
+    configured exactly like one woken any other way.
+
+  ## Returns
+
+  - `:ok` — the answer was delivered, or the agent was started with the
+    answer in hand.
+  - `{:ok, changes}` — same, plus the state-map changes to merge (currently
+    the subscription bookkeeping from a wake). Callers that ignore the
+    second element still behave correctly, but will re-subscribe on their
+    next `ensure_running/3`.
+  - `{:error, reason}` — passed through. Note a **live** agent that is not
+    interrupted returns an error rather than being woken, because there is
+    nothing to wake and nothing to resume.
+
+  ## Ordering
+
+  On the wake path this does not poll, retry on a timer, or wait for a
+  broadcast. `Sagents.AgentsDynamicSupervisor.start_agent_sync/1` blocks
+  until the agent is registered, the boot status is computed inside
+  `init/1`, and a `GenServer.call` is serialized after `init/1` and
+  `handle_continue/2`. The `:pending_resume` option carries the answer into
+  that boot, so the woken agent applies it before it broadcasts anything:
+  subscribers see a single `{:status_changed, :running, nil}` rather than an
+  `:interrupted` snapshot for a question that is already answered.
+
+  ## Example
+
+      case Session.resume(config, socket.assigns, response, request_opts: opts) do
+        :ok ->
+          assign(socket, answered_changes)
+
+        {:ok, changes} ->
+          socket |> assign(changes) |> assign(answered_changes)
+
+        {:error, reason} ->
+          put_flash(socket, :error, "Could not submit response: \#{inspect(reason)}")
+      end
+
+  """
+  @spec resume(config(), state_map :: map(), resume_data :: term(), opts :: keyword()) ::
+          :ok | {:ok, %{sagents_subs: map(), agent_id: String.t()}} | {:error, term()}
+  def resume(config, state, resume_data, opts \\ []) when is_map(state) do
+    conversation_id = Map.fetch!(state, :conversation_id)
+    agent_id = config.agent_id_fun.(conversation_id)
+
+    # Ask the agent, not the host's assigns. Checking at call time also covers
+    # a crash that never broadcast a shutdown, and keeps the common case (a
+    # live, interrupted agent) at exactly one call.
+    case AgentServer.resume(agent_id, resume_data) do
+      :ok ->
+        :ok
+
+      {:error, :agent_not_running} ->
+        wake_and_resume(config, state, agent_id, resume_data, opts)
+
+      {:error, _reason} = error ->
+        # A live agent in the wrong state, or any other refusal. Waking would
+        # be a no-op and would hide a real problem, so pass it through.
+        error
+    end
+  end
+
+  defp wake_and_resume(config, state, agent_id, resume_data, opts) do
+    start_opts = Keyword.put(opts, :pending_resume, resume_data)
+
+    case do_ensure_running(config, state, start_opts) do
+      {:ok, changes, %{started: true}} ->
+        # We booted the agent; init/1 took the answer with it.
+        {:ok, changes}
+
+      {:ok, changes, %{started: false}} ->
+        # Someone else (another tab, an admin wake) won the race and started
+        # the agent between our failed resume and this call, so `:pending_resume`
+        # was never consumed. The agent is up now, so just ask it.
+        case AgentServer.resume(agent_id, resume_data) do
+          :ok -> {:ok, changes}
+          {:error, reason} -> {:error, reason}
+        end
 
       {:error, reason} ->
         {:error, reason}
@@ -193,6 +317,7 @@ defmodule Sagents.Session do
     scope = Keyword.get(opts, :scope)
     request_opts = Keyword.get(opts, :request_opts, [])
     initial_subscribers = Keyword.get(opts, :initial_subscribers, [])
+    pending_resume = Keyword.get(opts, :pending_resume)
 
     Logger.info("Starting agent session for conversation #{inspect(conversation_id)}")
 
@@ -218,6 +343,7 @@ defmodule Sagents.Session do
           agent,
           state,
           initial_subscribers,
+          pending_resume,
           Keyword.get(session_opts, :supervisor_opts, [])
         )
 
@@ -298,6 +424,7 @@ defmodule Sagents.Session do
          agent,
          state,
          initial_subscribers,
+         pending_resume,
          supervisor_opts
        ) do
     presence_tracking = [
@@ -318,7 +445,8 @@ defmodule Sagents.Session do
       conversation_id: conversation_id,
       agent_persistence: config.agent_persistence,
       display_message_persistence: config.display_message_persistence,
-      initial_subscribers: initial_subscribers
+      initial_subscribers: initial_subscribers,
+      pending_resume: pending_resume
     ]
     # Merge factory-supplied supervisor_opts (e.g. :message_preprocessor) last
     # so factories CAN override base defaults if they have reason to. The
@@ -330,7 +458,8 @@ defmodule Sagents.Session do
     %{
       agent_id: agent_id,
       pid: AgentServer.get_pid(agent_id),
-      conversation_id: conversation_id
+      conversation_id: conversation_id,
+      started: true
     }
   end
 

--- a/lib/sagents/session.ex
+++ b/lib/sagents/session.ex
@@ -286,6 +286,99 @@ defmodule Sagents.Session do
   end
 
   @doc """
+  Dismiss a terminal `:halt` interrupt, waking the agent first if it has gone
+  to sleep.
+
+  The mirror of `resume/4` for the one interrupt type that is *acknowledged*
+  rather than answered. Use this everywhere a host would otherwise call
+  `Sagents.AgentServer.dismiss_interrupt/1` directly.
+
+  A halt is restorable, so a dormant conversation keeps its halt panel on
+  screen (see `Sagents.AgentUtils.shutdown_session_changes/2`). The button that
+  clears it therefore has to work whether or not a process is backing the
+  session, exactly like the answer to a dormant question.
+
+  `state` is the host's process-level map, with the same required keys as
+  `ensure_running/3` (`:conversation_id`, `:current_scope`, optionally
+  `:sagents_subs`).
+
+  ## Options
+
+  - `:request_opts` - forwarded verbatim to the router on the wake path. Pass
+    the same per-request data you pass when starting a session; an agent woken
+    to accept a dismissal is configured exactly like one woken any other way.
+
+  ## Returns
+
+  - `:ok` - a live agent dismissed the halt.
+  - `{:ok, changes}` - the agent was asleep. It was woken and then dismissed.
+    Merge `changes` (subscription bookkeeping) into your state map.
+  - `{:error, reason}` - passed through. A live agent that is not interrupted,
+    or one holding an interrupt that needs an explicit response rather than an
+    acknowledgement, returns an error rather than being woken.
+
+  ## Example
+
+      case Session.dismiss(config, socket.assigns, request_opts: opts) do
+        :ok ->
+          assign(socket, AgentUtils.cleared_interrupt_changes())
+
+        {:ok, changes} ->
+          socket |> assign(changes) |> assign(AgentUtils.cleared_interrupt_changes())
+
+        {:error, reason} ->
+          put_flash(socket, :error, "Could not dismiss: \#{inspect(reason)}")
+      end
+
+  """
+  @spec dismiss(config(), state_map :: map(), opts :: keyword()) ::
+          :ok | {:ok, %{sagents_subs: map(), agent_id: String.t()}} | {:error, term()}
+  def dismiss(config, state, opts \\ []) when is_map(state) do
+    conversation_id = Map.fetch!(state, :conversation_id)
+    agent_id = config.agent_id_fun.(conversation_id)
+
+    # Ask the agent, not the host's assigns, for the same reasons as resume/4:
+    # it covers a crash that never broadcast a shutdown, and keeps the common
+    # case (a live agent holding a halt) at exactly one call.
+    case AgentServer.dismiss_interrupt(agent_id) do
+      :ok ->
+        :ok
+
+      {:error, :agent_not_running} ->
+        wake_and_dismiss(config, state, agent_id, opts)
+
+      {:error, _reason} = error ->
+        # A live agent in the wrong state, or an interrupt that needs a real
+        # response. Waking would be a no-op and would hide a real problem.
+        error
+    end
+  end
+
+  # There is deliberately no `:pending_dismiss` start option mirroring
+  # `:pending_resume`. That option exists to stop a woken agent announcing an
+  # `:interrupted` snapshot for a question it is about to leave. Here that
+  # snapshot re-presents a halt panel that is already on screen, since the panel
+  # surviving the nap is the whole point, so subscribers see no visible
+  # transition before the dismissal lands. One extra call after boot is cheaper
+  # than a second boot-time hook.
+  defp wake_and_dismiss(config, state, agent_id, opts) do
+    case do_ensure_running(config, state, opts) do
+      {:ok, changes, _session_info} ->
+        # A restorable halt is rebuilt during boot, and this call is serialized
+        # after `init/1` and `handle_continue/2`, so the retry always has
+        # something to land on. Unlike the resume path, `started: false` needs
+        # no special case: nothing was carried into the boot to be dropped.
+        case AgentServer.dismiss_interrupt(agent_id) do
+          :ok -> {:ok, changes}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
   Stop the agent session for a conversation. No-op if nothing is running.
   """
   @spec stop(config(), conversation_id :: term()) :: {:ok, :stopped | :not_running}

--- a/lib/sagents/state.ex
+++ b/lib/sagents/state.ex
@@ -585,15 +585,55 @@ defmodule Sagents.State do
 
   defp maybe_demote(other, _middleware), do: other
 
+  @doc """
+  Whether an `interrupt_data` payload can be rebuilt after the agent process
+  goes away.
+
+  This is the authoritative answer, dispatched through each middleware's
+  `c:Sagents.Middleware.restorable_interrupt?/1` callback. It is the same
+  predicate `clean_stale_interrupts/2` uses to decide which interrupted tool
+  results survive a cold boot, so a caller that consults it can never drift
+  from what the next boot will actually do.
+
+  Rules:
+
+  - `nil` (never persisted, decode failed, or written by older code) is not
+    restorable.
+  - `:multiple_interrupts` is restorable only if **every** sub-interrupt is
+    claimed by some middleware. Sub-agent approvals and `ask_user` questions
+    can mix in the same wrapper, so a partial restore would silently drop
+    some of them. An empty `:interrupts` list is not restorable: there is
+    nothing for a resume to answer. (The wrapper is only ever built from two
+    or more results, so this is a degenerate shape in practice.)
+  - Any other map is restorable if at least one middleware entry claims it.
+  - An empty `middleware_entries` list is never restorable, matching
+    `clean_stale_interrupts/2`.
+
+  Hosts do not normally call this directly. The AgentServer evaluates it once
+  on the way out and reports the answer as `:interrupt_restorable` on the
+  `{:agent_shutdown, _}` event, which is the only moment the question is
+  asked (see `Sagents.AgentUtils.shutdown_session_changes/2`).
+
+  ## Example
+
+      State.interrupt_restorable?(%{type: :ask_user_question}, agent.middleware)
+      # => true
+
+  """
+  @spec interrupt_restorable?(map() | nil, [Sagents.MiddlewareEntry.t()]) :: boolean()
+  def interrupt_restorable?(interrupt_data, middleware_entries)
+
+  def interrupt_restorable?(nil, _middleware), do: false
+
   # `:multiple_interrupts` is restorable if *every* sub-interrupt is
   # claimed by some middleware. Sub-agents and ask_user questions can mix in
   # the same wrapper, so partial restore would silently drop some questions.
-  defp interrupt_restorable?(%{type: :multiple_interrupts, interrupts: subs}, middleware)
-       when is_list(subs) do
-    Enum.all?(subs, &any_middleware_claims?(&1, middleware))
+  def interrupt_restorable?(%{type: :multiple_interrupts, interrupts: subs}, middleware)
+      when is_list(subs) and is_list(middleware) do
+    subs != [] and Enum.all?(subs, &any_middleware_claims?(&1, middleware))
   end
 
-  defp interrupt_restorable?(data, middleware) when is_map(data) do
+  def interrupt_restorable?(data, middleware) when is_map(data) and is_list(middleware) do
     any_middleware_claims?(data, middleware)
   end
 

--- a/priv/templates/agent_live_helpers.ex.eex
+++ b/priv/templates/agent_live_helpers.ex.eex
@@ -26,8 +26,11 @@ defmodule <%= module %> do
        `handle_publisher_down/2` and `handle_presence_diff/2` here.
 
     3. For the action path (send_message, wake_agent, etc.), call
-       `<%= coordinator_alias %>.ensure_agent_session_running(socket.assigns)`
-       and apply the returned changes with `assign(socket, changes)`.
+       `<%= coordinator_alias %>.ensure_agent_session_running(socket.assigns,
+       agent_request_opts(socket))` and apply the returned changes with
+       `assign(socket, changes)`. Use `agent_request_opts/1` from this module
+       rather than a second copy: every path that can start an agent must
+       configure it identically.
 
   ## Customization
 
@@ -186,7 +189,7 @@ defmodule <%= module %> do
   defp auto_wake_for_pending_interrupt(socket) do
     case <%= coordinator_alias %>.ensure_agent_session_running(
            socket.assigns,
-           resume_request_opts(socket)
+           agent_request_opts(socket)
          ) do
       {:ok, changes} ->
         socket |> assign(changes) |> assign(:agent_alive?, true)
@@ -460,7 +463,8 @@ defmodule <%= module %> do
           accumulated,
           changes,
           <%= subscriber_session_alias %>.hitl_resume_running_changes(),
-          "Failed to resume agent"
+          log_label: "HITL resume failed",
+          user_message: "That decision could not be submitted. Please try again."
         )
 
       # Intermediate decisions in a multi-tool batch settle nothing, so they
@@ -505,13 +509,54 @@ defmodule <%= module %> do
           resume_data,
           changes,
           <%= subscriber_session_alias %>.question_resume_running_changes(),
-          "Failed to submit response"
+          log_label: "question resume failed",
+          user_message: "That response could not be saved. Please try again."
         )
 
       # Intermediate answers in a multi-question batch need no agent at all,
       # so they deliberately must not wake one. Only the final answer resumes.
       {:more, changes} ->
         assign(socket, changes)
+    end
+  end
+
+  # ===========================================================================
+  # Halt dismissal
+  # ===========================================================================
+
+  @doc """
+  Acknowledge a terminal `:halt` interrupt and clear its panel.
+
+  A halt is restorable, so the panel stays on screen when the agent naps. This
+  routes through `<%= coordinator_alias %>.dismiss_agent_session/2`, which
+  wakes a sleeping agent and dismisses against the halt it rebuilt at boot, so
+  the button works on a dormant conversation.
+  """
+  def handle_halt_dismissal(socket) do
+    if is_nil(socket.assigns[:pending_halt]) do
+      # Nothing pending: a duplicate event for a halt already dismissed. The
+      # dismissal is synchronous, so a fast double click really does deliver a
+      # second event after the first cleared the panel.
+      socket
+    else
+      do_handle_halt_dismissal(socket)
+    end
+  end
+
+  defp do_handle_halt_dismissal(socket) do
+    case <%= coordinator_alias %>.dismiss_agent_session(socket.assigns, agent_request_opts(socket)) do
+      :ok ->
+        assign(socket, Sagents.AgentUtils.cleared_interrupt_changes())
+
+      {:ok, session_changes} ->
+        socket
+        |> assign(session_changes)
+        |> assign(:agent_alive?, true)
+        |> assign(Sagents.AgentUtils.cleared_interrupt_changes())
+
+      {:error, reason} ->
+        Logger.error("halt dismissal failed: #{inspect(reason)}")
+        put_flash(socket, :error, "That could not be dismissed. Please try again.")
     end
   end
 
@@ -524,11 +569,20 @@ defmodule <%= module %> do
   # sleeping one is woken with the answer already in hand. A *live* agent in
   # the wrong state (someone answered from another tab) returns an error
   # rather than being woken, because there is nothing to wake.
-  defp resume_or_flash(socket, resume_data, changes, running_changes, error_prefix) do
+  #
+  # `copy` carries two deliberately separate strings:
+  #
+  #   * `:log_label` - internal vocabulary, paired with the raw reason term.
+  #   * `:user_message` - product copy shown to the person. Never interpolate
+  #     the reason into it. A live-but-wrong-state agent returns "Cannot
+  #     resume, server is not interrupted": an internal string, and one that
+  #     says "agent", a word many products deliberately never put in front of
+  #     a user. This is a slot you are meant to edit and localize.
+  defp resume_or_flash(socket, resume_data, changes, running_changes, copy) do
     case <%= coordinator_alias %>.resume_agent_session(
            socket.assigns,
            resume_data,
-           resume_request_opts(socket)
+           agent_request_opts(socket)
          ) do
       :ok ->
         socket |> assign(changes) |> assign(running_changes)
@@ -540,14 +594,28 @@ defmodule <%= module %> do
         |> assign(running_changes)
 
       {:error, reason} ->
-        Logger.error("#{error_prefix}: #{inspect(reason)}")
-        put_flash(socket, :error, "#{error_prefix}: #{inspect(reason)}")
+        Logger.error("#{Keyword.fetch!(copy, :log_label)}: #{inspect(reason)}")
+        put_flash(socket, :error, Keyword.fetch!(copy, :user_message))
     end
   end
 
-  # Per-request data the FactoryConfig consumes when the agent has to be woken
-  # to take this answer. An agent woken to accept a response must be configured
-  # exactly like one woken any other way, so keep this in sync with whatever
-  # the host passes to `ensure_agent_session_running/2`.
-  defp resume_request_opts(_socket), do: []
+  # ===========================================================================
+  # Per-request agent configuration
+  # ===========================================================================
+
+  @doc """
+  Per-request data the `Sagents.FactoryConfig` consumes, for **every** path
+  that may have to start an agent.
+
+  Fill this in once (timezone, tool context, tenant, whatever your factory
+  reads) and route your own
+  `<%= coordinator_alias %>.ensure_agent_session_running/2` call sites through
+  it as well, rather than computing the same options separately.
+
+  An agent woken to accept an answer must be configured exactly like one woken
+  any other way. A second copy of this decision drifts silently: it compiles,
+  it passes tests, and the symptom is an agent that behaves subtly wrong only
+  on the paths that had to wake it.
+  """
+  def agent_request_opts(_socket), do: []
 end

--- a/priv/templates/agent_live_helpers.ex.eex
+++ b/priv/templates/agent_live_helpers.ex.eex
@@ -6,7 +6,7 @@ defmodule <%= module %> do
   function on `<%= subscriber_session_alias %>`, and applies the resulting
   changes via `assign/2`. LiveView-specific concerns — streams (`stream/3`,
   `stream_insert/3`), flash messages, `connected?` gates, and orchestrating
-  `AgentServer.resume/2` calls with their flash side effects — live here.
+  resume calls with their flash side effects — live here.
 
   Non-LiveView consumers (a GraphQL bridge GenServer, etc.) should bypass
   this module and call `<%= subscriber_session_alias %>` directly.
@@ -149,6 +149,7 @@ defmodule <%= module %> do
         |> assign(:agent_id, agent_id)
         |> assign(:todos, saved_todos)
         |> assign(:agent_status, agent_status)
+        |> assign(:agent_alive?, agent_status != :not_running)
         |> stream(:messages, display_messages, reset: true)
         |> assign(:has_messages, has_messages)
 
@@ -183,9 +184,12 @@ defmodule <%= module %> do
   # `:interrupted` status from sagents' derive_boot_status) reaches us via
   # handle_info and surfaces the interrupt UI without polling.
   defp auto_wake_for_pending_interrupt(socket) do
-    case <%= coordinator_alias %>.ensure_agent_session_running(socket.assigns) do
+    case <%= coordinator_alias %>.ensure_agent_session_running(
+           socket.assigns,
+           resume_request_opts(socket)
+         ) do
       {:ok, changes} ->
-        assign(socket, changes)
+        socket |> assign(changes) |> assign(:agent_alive?, true)
 
       {:error, reason} ->
         Logger.warning(
@@ -399,7 +403,13 @@ defmodule <%= module %> do
     )
   end
 
-  @doc "Agent shutdown event — clear agent_id and unsubscribe locally."
+  @doc """
+  Agent shutdown event.
+
+  A restorable interrupt prompt stays on screen (see
+  `Sagents.AgentUtils.shutdown_session_changes/2`); answering it wakes the
+  agent. Everything else collapses to `:not_running`.
+  """
   def handle_agent_shutdown(socket, shutdown_data) do
     Logger.info("Agent #{socket.assigns[:agent_id]} shutting down: #{shutdown_data.reason}")
     assign(socket, <%= subscriber_session_alias %>.handle_agent_shutdown(socket.assigns, shutdown_data))
@@ -410,51 +420,53 @@ defmodule <%= module %> do
   # ===========================================================================
 
   @doc """
-  Handle a single HITL approve/reject decision. Orchestrates the
-  `AgentServer.resume/2` call (when the last pending tool is decided) and
-  flash messages on top of the state changes from
-  `<%= subscriber_session_alias %>.handle_hitl_decision/3`.
+  Handle a single HITL approve/reject decision. Orchestrates the resume call
+  (when the last pending tool is decided) and flash messages on top of the
+  state changes from `<%= subscriber_session_alias %>.handle_hitl_decision/3`.
+
+  The resume goes through `<%= coordinator_alias %>.resume_agent_session/3`,
+  which wakes a sleeping agent and hands it the decision at boot. There is no
+  "the agent went away, start over" failure: the interrupt is durable, so the
+  worst case is a slower round trip.
   """
   def handle_hitl_decision(socket, index, decision_type) do
-    agent_id = socket.assigns[:agent_id]
-
-    if is_nil(agent_id) do
-      Logger.error("Cannot process HITL decision: agent_id is nil (agent may have shut down)")
-
-      put_flash(
-        socket,
-        :error,
-        "Agent is no longer running. Please send a new message to continue."
-      )
+    if (socket.assigns[:pending_tools] || []) == [] do
+      # Nothing pending: a duplicate event for a batch that is already settled.
+      # Falling through would hand `advance_hitl_decisions/3` an empty list, and
+      # it would happily report the batch complete and resume with a fabricated
+      # decision.
+      socket
     else
-      decision_label = if decision_type == :approve, do: "approved", else: "rejected"
+      do_handle_hitl_decision(socket, index, decision_type)
+    end
+  end
 
-      <%= subscriber_session_alias %>.persist_hitl_decision(
-        socket.assigns,
-        socket.assigns.pending_tools,
-        index,
-        decision_label
-      )
+  defp do_handle_hitl_decision(socket, index, decision_type) do
+    decision_label = if decision_type == :approve, do: "approved", else: "rejected"
 
-      Logger.info("#{String.capitalize(decision_label)} tool at index #{index}")
+    <%= subscriber_session_alias %>.persist_hitl_decision(
+      socket.assigns,
+      socket.assigns.pending_tools,
+      index,
+      decision_label
+    )
 
-      case <%= subscriber_session_alias %>.handle_hitl_decision(socket.assigns, index, decision_type) do
-        {:resume, accumulated, changes} ->
-          case AgentServer.resume(agent_id, accumulated) do
-            :ok ->
-              socket
-              |> assign(changes)
-              |> assign(<%= subscriber_session_alias %>.hitl_resume_running_changes())
-              |> put_flash(:info, "Agent resuming")
+    Logger.info("#{String.capitalize(decision_label)} tool at index #{index}")
 
-            {:error, reason} ->
-              Logger.error("Failed to resume agent: #{inspect(reason)}")
-              put_flash(socket, :error, "Failed to resume agent: #{inspect(reason)}")
-          end
+    case <%= subscriber_session_alias %>.handle_hitl_decision(socket.assigns, index, decision_type) do
+      {:resume, accumulated, changes} ->
+        resume_or_flash(
+          socket,
+          accumulated,
+          changes,
+          <%= subscriber_session_alias %>.hitl_resume_running_changes(),
+          "Failed to resume agent"
+        )
 
-        {:more, changes} ->
-          assign(socket, changes)
-      end
+      # Intermediate decisions in a multi-tool batch settle nothing, so they
+      # need no agent at all. Deliberately must not wake one.
+      {:more, changes} ->
+        assign(socket, changes)
     end
   end
 
@@ -464,38 +476,78 @@ defmodule <%= module %> do
 
   @doc """
   Handle a single answer to a pending AskUserQuestion interrupt. Orchestrates
-  the `AgentServer.resume/2` call (when the last pending question is
-  answered) on top of the state changes from
+  the resume call (when the last pending question is answered) on top of the
+  state changes from
   `<%= subscriber_session_alias %>.handle_question_response/2`.
+
+  The resume goes through `<%= coordinator_alias %>.resume_agent_session/3`,
+  so an answer composed while the agent was asleep still lands: the agent is
+  woken with the answer in hand.
   """
   def handle_question_response(socket, response) do
-    agent_id = socket.assigns[:agent_id]
-
-    if is_nil(agent_id) do
-      Logger.error("Cannot process question response: agent_id is nil (agent may have shut down)")
-
-      put_flash(
-        socket,
-        :error,
-        "Agent is no longer running. Please send a new message to restart."
-      )
+    if is_nil(socket.assigns[:pending_question]) do
+      # A second submission for a question that is already answered. The
+      # click-to-select variant has no submit button to disable, so a fast
+      # double click really does send two events, and the resume is synchronous
+      # so the second one arrives after `pending_question` has been cleared.
+      # Falling through would crash on the missing question.
+      socket
     else
-      case <%= subscriber_session_alias %>.handle_question_response(socket.assigns, response) do
-        {:resume, resume_data, changes} ->
-          case AgentServer.resume(agent_id, resume_data) do
-            :ok ->
-              socket
-              |> assign(changes)
-              |> assign(<%= subscriber_session_alias %>.question_resume_running_changes())
-
-            {:error, reason} ->
-              Logger.error("Failed to resume agent with question response: #{inspect(reason)}")
-              put_flash(socket, :error, "Failed to submit response: #{inspect(reason)}")
-          end
-
-        {:more, changes} ->
-          assign(socket, changes)
-      end
+      do_handle_question_response(socket, response)
     end
   end
+
+  defp do_handle_question_response(socket, response) do
+    case <%= subscriber_session_alias %>.handle_question_response(socket.assigns, response) do
+      {:resume, resume_data, changes} ->
+        resume_or_flash(
+          socket,
+          resume_data,
+          changes,
+          <%= subscriber_session_alias %>.question_resume_running_changes(),
+          "Failed to submit response"
+        )
+
+      # Intermediate answers in a multi-question batch need no agent at all,
+      # so they deliberately must not wake one. Only the final answer resumes.
+      {:more, changes} ->
+        assign(socket, changes)
+    end
+  end
+
+  # ===========================================================================
+  # Shared resume orchestration
+  # ===========================================================================
+
+  # Single funnel for every interrupt response. Asks the agent rather than the
+  # assigns: a live, interrupted agent takes the answer in one call, and a
+  # sleeping one is woken with the answer already in hand. A *live* agent in
+  # the wrong state (someone answered from another tab) returns an error
+  # rather than being woken, because there is nothing to wake.
+  defp resume_or_flash(socket, resume_data, changes, running_changes, error_prefix) do
+    case <%= coordinator_alias %>.resume_agent_session(
+           socket.assigns,
+           resume_data,
+           resume_request_opts(socket)
+         ) do
+      :ok ->
+        socket |> assign(changes) |> assign(running_changes)
+
+      {:ok, session_changes} ->
+        socket
+        |> assign(session_changes)
+        |> assign(changes)
+        |> assign(running_changes)
+
+      {:error, reason} ->
+        Logger.error("#{error_prefix}: #{inspect(reason)}")
+        put_flash(socket, :error, "#{error_prefix}: #{inspect(reason)}")
+    end
+  end
+
+  # Per-request data the FactoryConfig consumes when the agent has to be woken
+  # to take this answer. An agent woken to accept a response must be configured
+  # exactly like one woken any other way, so keep this in sync with whatever
+  # the host passes to `ensure_agent_session_running/2`.
+  defp resume_request_opts(_socket), do: []
 end

--- a/priv/templates/agent_subscriber_session.ex.eex
+++ b/priv/templates/agent_subscriber_session.ex.eex
@@ -6,7 +6,7 @@ defmodule <%= module %> do
   state transitions in response to agent events. It is host-agnostic — every
   function takes a plain state map (or just the inputs it needs) and returns
   a changes map (or a tagged tuple for operations that need orchestration,
-  such as HITL decisions that may trigger an `AgentServer.resume/2` call).
+  such as HITL decisions that may trigger a resume).
 
   Hosts apply the changes in their native idiom:
 
@@ -28,10 +28,11 @@ defmodule <%= module %> do
   A few handlers need to signal "the host should now perform a side effect"
   in addition to producing a state change. They return tagged tuples:
 
-  - `{:resume, resume_data, changes}` — caller should
-    `AgentServer.resume(agent_id, resume_data)`. On success, also apply
-    `hitl_resume_running_changes/0` (or `question_resume_running_changes/0`)
-    on top of `changes`.
+  - `{:resume, resume_data, changes}` — caller should resume the agent via
+    `<%= coordinator_alias %>.resume_agent_session/3`, which wakes a sleeping
+    agent and hands it the answer at boot rather than failing. On success,
+    also apply `hitl_resume_running_changes/0` (or
+    `question_resume_running_changes/0`) on top of `changes`.
   - `{:more, changes}` — no side effect required; just merge changes.
 
   See `handle_hitl_decision/3` and `handle_question_response/2`.
@@ -60,6 +61,7 @@ defmodule <%= module %> do
       conversation_id: nil,
       agent_id: nil,
       agent_status: :not_running,
+      agent_alive?: false,
       todos: [],
       has_messages: false,
       streaming_delta: nil,
@@ -84,17 +86,24 @@ defmodule <%= module %> do
   # is no pending interrupt UI. This stops a dismissed/superseded interrupt's
   # derived keys (e.g. `:pending_halt`) from re-appearing on the next
   # transition back into `:interrupted`.
+  #
+  # Every status handler also sets `agent_alive?: true`. An inbound agent event
+  # is proof that a process is backing this session, whatever it says.
 
   @doc "Status changed to :running."
   def handle_status_running,
-    do: Map.merge(AgentUtils.cleared_interrupt_changes(), %{agent_status: :running})
+    do:
+      Map.merge(
+        AgentUtils.cleared_interrupt_changes(),
+        %{agent_status: :running, agent_alive?: true}
+      )
 
   @doc "Status changed to :idle (execution completed)."
   def handle_status_idle,
     do:
       Map.merge(
         AgentUtils.cleared_interrupt_changes(),
-        %{loading: false, agent_status: :idle, streaming_delta: nil}
+        %{loading: false, agent_status: :idle, streaming_delta: nil, agent_alive?: true}
       )
 
   @doc "Status changed to :cancelled (user cancelled execution)."
@@ -102,7 +111,7 @@ defmodule <%= module %> do
     do:
       Map.merge(
         AgentUtils.cleared_interrupt_changes(),
-        %{loading: false, agent_status: :cancelled, streaming_delta: nil}
+        %{loading: false, agent_status: :cancelled, streaming_delta: nil, agent_alive?: true}
       )
 
   @doc """
@@ -116,7 +125,7 @@ defmodule <%= module %> do
     do:
       Map.merge(
         AgentUtils.cleared_interrupt_changes(),
-        %{loading: false, agent_status: :error, streaming_delta: nil}
+        %{loading: false, agent_status: :error, streaming_delta: nil, agent_alive?: true}
       )
 
   @doc """
@@ -130,7 +139,12 @@ defmodule <%= module %> do
 
   def handle_status_interrupted(interrupt_data) do
     Map.merge(
-      %{loading: false, agent_status: :interrupted, interrupt_data: interrupt_data},
+      %{
+        loading: false,
+        agent_status: :interrupted,
+        agent_alive?: true,
+        interrupt_data: interrupt_data
+      },
       AgentUtils.interrupt_session_changes(interrupt_data)
     )
   end
@@ -176,7 +190,11 @@ defmodule <%= module %> do
     subs = Map.get(state, :sagents_subs, %{})
 
     case Subscriber.handle_publisher_down(subs, ref, reason) do
-      {:matched, new_subs} -> %{sagents_subs: new_subs}
+      # The entry is now `:pending`; the next presence arrival re-subscribes.
+      # Interrupt state is deliberately untouched: a crashed agent with a
+      # restorable interrupt boots straight back into `:interrupted`, and one
+      # without boots `:idle` and the ordinary status handler clears the UI.
+      {:matched, new_subs} -> %{sagents_subs: new_subs, agent_alive?: false}
       :no_match -> %{}
     end
   end
@@ -192,27 +210,31 @@ defmodule <%= module %> do
   end
 
   @doc """
-  Agent shutdown event — clear `agent_id` and unsubscribe locally so the
-  subs map doesn't carry a stale entry.
+  Agent shutdown event.
+
+  Delegates to `Sagents.AgentUtils.shutdown_session_changes/2`, which keeps a
+  restorable interrupt prompt on screen (marking the session
+  `agent_alive?: false` but leaving `agent_status: :interrupted`) and
+  otherwise collapses the session to `:not_running`.
+
+  Note what this deliberately does *not* do:
+
+  - It does not clear `:agent_id`. That is a pure function of the conversation
+    id, it is what we need in order to wake the agent again, and nil-ing it
+    breaks `handle_conversation_title_generated/3`, which compares against it.
+  - It does not unsubscribe. `Subscriber.unsubscribe_from_agent/2` deletes the
+    subs entry, and `Subscriber.handle_presence_diff/3` only revives entries in
+    the `:pending` state, so unsubscribing here would permanently destroy the
+    auto-recovery path (the shutdown event is sent before the process dies, so
+    the delete always beats the `:DOWN` that would have marked it `:pending`).
+    Leaving it alone is what lets the subscription come back when the agent
+    wakes.
+
+  A single shutdown delivers this event more than once. Every delivery carries
+  the same payload shape, so re-applying the result is a no-op.
   """
-  def handle_agent_shutdown(state, _shutdown_data) do
-    base =
-      Map.merge(AgentUtils.cleared_interrupt_changes(), %{
-        agent_id: nil,
-        agent_status: :not_running,
-        loading: false,
-        streaming_delta: nil
-      })
-
-    case Map.get(state, :agent_id) do
-      nil ->
-        base
-
-      agent_id ->
-        subs = Map.get(state, :sagents_subs, %{})
-        new_subs = Subscriber.unsubscribe_from_agent(subs, agent_id)
-        Map.put(base, :sagents_subs, new_subs)
-    end
+  def handle_agent_shutdown(state, shutdown_data) do
+    AgentUtils.shutdown_session_changes(state, shutdown_data)
   end
 
   # ===========================================================================

--- a/priv/templates/coordinator.ex.eex
+++ b/priv/templates/coordinator.ex.eex
@@ -101,6 +101,25 @@ defmodule <%= module %> do
     do: Sagents.Session.ensure_running(@config, state, request_opts: request_opts)
 
   @doc """
+  Answer a pending interrupt, waking the agent first if it has gone to sleep.
+
+  Use this everywhere you would otherwise call `Sagents.AgentServer.resume/2`
+  directly. Interrupts are durable, so an agent that napped while the author
+  was composing an answer is only a reason to start a process to take it, not
+  a reason to lose the answer.
+
+  Returns `:ok`, `{:ok, changes}` (merge them: they carry subscription
+  bookkeeping from the wake), or `{:error, reason}`. See
+  `Sagents.Session.resume/4`.
+
+      <%= module %>.resume_agent_session(socket.assigns, response,
+        timezone: socket.assigns.timezone
+      )
+  """
+  def resume_agent_session(state, resume_data, request_opts \\ []),
+    do: Sagents.Session.resume(@config, state, resume_data, request_opts: request_opts)
+
+  @doc """
   Stop an agent session for a conversation.
 
   Note: agents automatically stop after inactivity timeout. Only call this

--- a/priv/templates/coordinator.ex.eex
+++ b/priv/templates/coordinator.ex.eex
@@ -120,6 +120,27 @@ defmodule <%= module %> do
     do: Sagents.Session.resume(@config, state, resume_data, request_opts: request_opts)
 
   @doc """
+  Dismiss a terminal `:halt` interrupt, waking the agent first if it has gone
+  to sleep.
+
+  The counterpart to `resume_agent_session/3` for the interrupt type that is
+  acknowledged rather than answered. Use this everywhere you would otherwise
+  call `Sagents.AgentServer.dismiss_interrupt/1` directly: a halt is
+  restorable, so the panel survives a nap, and its only button has to work
+  against a dormant conversation.
+
+  Returns `:ok`, `{:ok, changes}` (merge them: they carry subscription
+  bookkeeping from the wake), or `{:error, reason}`. See
+  `Sagents.Session.dismiss/3`.
+
+      <%= module %>.dismiss_agent_session(socket.assigns,
+        timezone: socket.assigns.timezone
+      )
+  """
+  def dismiss_agent_session(state, request_opts \\ []),
+    do: Sagents.Session.dismiss(@config, state, request_opts: request_opts)
+
+  @doc """
   Stop an agent session for a conversation.
 
   Note: agents automatically stop after inactivity timeout. Only call this

--- a/test/sagents/agent_server_dormant_interrupt_test.exs
+++ b/test/sagents/agent_server_dormant_interrupt_test.exs
@@ -324,4 +324,52 @@ defmodule Sagents.AgentServerDormantInterruptTest do
       assert_receive {:agent, {:status_changed, :interrupted, ^enriched}}, 500
     end
   end
+
+  # ── Dismissing a halt that was rebuilt at boot ───────────────────
+
+  describe "dismiss_interrupt/1 against a restored halt" do
+    # `Sagents.Session.dismiss/3` wakes a sleeping agent and then immediately
+    # dismisses against whatever `init/1` rebuilt. That only works if a halt
+    # survives the round trip in a shape `dismiss_interrupt/1` still recognizes
+    # as a halt. If it did not, the wake would succeed and the dismissal would
+    # fail, leaving the panel stuck with no signal to the host.
+    defp halt_state(data \\ %{type: :halt, message: "Blocked by policy"}) do
+      interrupted_state([{"call_1", data}])
+    end
+
+    test "a restored halt boots :interrupted and is then dismissible" do
+      agent = create_test_agent(middleware: [Sagents.Middleware.Haltable])
+
+      start_server(agent,
+        initial_state: halt_state(),
+        initial_subscribers: [{:main, self()}]
+      )
+
+      assert_receive {:agent, {:status_changed, :interrupted, %{type: :halt}}}, 500
+
+      assert :ok = AgentServer.dismiss_interrupt(agent.agent_id)
+      assert_receive {:agent, {:status_changed, :idle, nil}}, 500
+      assert AgentServer.get_status(agent.agent_id) == :idle
+    end
+
+    test "a restored question is not dismissible and says so" do
+      # The other half of the contract Session.dismiss/3 relies on: an interrupt
+      # needing a real response must refuse, so dismiss/3 can pass the error
+      # through instead of waking an agent that will refuse again.
+      agent = ask_agent()
+
+      start_server(agent,
+        initial_state: question_state(),
+        initial_subscribers: [{:main, self()}]
+      )
+
+      agent_id = agent.agent_id
+      assert AgentServer.get_status(agent_id) == :interrupted
+
+      assert {:error, "interrupt requires explicit response (use resume)"} =
+               AgentServer.dismiss_interrupt(agent_id)
+
+      assert AgentServer.get_status(agent_id) == :interrupted
+    end
+  end
 end

--- a/test/sagents/agent_server_dormant_interrupt_test.exs
+++ b/test/sagents/agent_server_dormant_interrupt_test.exs
@@ -1,0 +1,327 @@
+defmodule Sagents.AgentServerDormantInterruptTest do
+  @moduledoc """
+  Covers what happens to an open interrupt when the agent process goes away.
+
+  Interrupts are durable: `interrupt_data` is persisted with the state, and
+  `derive_boot_status/1` rebuilds it on the next boot. So an agent that naps
+  while a human is composing an answer has not lost anything. The two pieces
+  that make that usable to a host are exercised here:
+
+  1. The `{:agent_shutdown, _}` event reports whether the pending interrupt can
+     be rebuilt (`:interrupt_restorable`), which is the only signal a host needs
+     to decide whether to leave the prompt on screen. It is answered *here*
+     rather than by the host because this is the only place that has both the
+     interrupt payload and the agent's middleware in scope.
+
+  2. `:pending_resume` lets an answer submitted against a dead agent ride into
+     the boot, so the woken server applies it before it broadcasts anything.
+     Subscribers see one `:running` event, not an `:interrupted` snapshot for a
+     question that is already answered.
+  """
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.{Agent, AgentServer, State}
+  alias LangChain.Message
+  alias LangChain.Message.{ToolCall, ToolResult}
+
+  setup :set_mimic_global
+  setup :verify_on_exit!
+
+  setup_all do
+    Mimic.copy(Agent)
+    :ok
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────
+
+  # A state whose trailing tool message carries interrupted tool results, which
+  # is what derive_boot_status/1 scans for.
+  defp interrupted_state(entries) do
+    tool_calls =
+      Enum.map(entries, fn {call_id, _data} ->
+        ToolCall.new!(%{call_id: call_id, name: "ask_user", arguments: %{}})
+      end)
+
+    tool_results =
+      Enum.map(entries, fn {call_id, data} ->
+        ToolResult.new!(%{
+          tool_call_id: call_id,
+          name: "ask_user",
+          content: "Waiting for user...",
+          is_interrupt: true,
+          interrupt_data: data
+        })
+      end)
+
+    State.new!(%{
+      messages: [
+        Message.new_user!("hi"),
+        Message.new_assistant!(%{tool_calls: tool_calls}),
+        Message.new_tool_result!(%{content: nil, tool_results: tool_results})
+      ]
+    })
+  end
+
+  defp question_state(data \\ %{type: :ask_user_question, question: "Continue?"}) do
+    interrupted_state([{"call_1", data}])
+  end
+
+  defp ask_agent(opts \\ []) do
+    create_test_agent(Keyword.merge([middleware: [Sagents.Middleware.AskUserQuestion]], opts))
+  end
+
+  defp start_server(agent, opts) do
+    {:ok, pid} =
+      AgentServer.start_link(
+        [
+          agent: agent,
+          name: AgentServer.get_name(agent.agent_id),
+          pubsub: nil
+        ] ++ opts
+      )
+
+    pid
+  end
+
+  # ── Shutdown payload ─────────────────────────────────────────────
+
+  describe "{:agent_shutdown, _} payload" do
+    @payload_keys [
+      :agent_id,
+      :interrupt_restorable,
+      :last_activity_at,
+      :reason,
+      :shutdown_at,
+      :status
+    ]
+
+    test "the inactivity timer emits the documented shape" do
+      agent = ask_agent()
+
+      start_server(agent,
+        initial_state: State.new!(),
+        inactivity_timeout: 30,
+        initial_subscribers: [{:main, self()}]
+      )
+
+      assert_receive {:agent, {:agent_shutdown, payload}}, 500
+
+      assert Enum.sort(Map.keys(payload)) == @payload_keys
+      assert payload.agent_id == agent.agent_id
+      assert payload.reason == :inactivity
+    end
+
+    test "terminate/2 emits the same shape, not a two-key variant" do
+      # A single shutdown delivers this event more than once, from different
+      # sites. Hosts must not need a clause per site.
+      agent = ask_agent()
+
+      pid =
+        start_server(agent,
+          initial_state: State.new!(),
+          initial_subscribers: [{:main, self()}]
+        )
+
+      :ok = GenServer.stop(pid, :normal)
+
+      assert_receive {:agent, {:agent_shutdown, payload}}, 500
+
+      assert Enum.sort(Map.keys(payload)) == @payload_keys
+      # The old terminate/2 payload omitted agent_id, which is the one field a
+      # host needs in order to correlate the event.
+      assert payload.agent_id == agent.agent_id
+      assert payload.reason == :normal
+    end
+
+    test "reports interrupt_restorable: true for a question the next boot can rebuild" do
+      agent = ask_agent()
+
+      start_server(agent,
+        initial_state: question_state(),
+        inactivity_timeout: 30,
+        initial_subscribers: [{:main, self()}]
+      )
+
+      assert_receive {:agent, {:agent_shutdown, payload}}, 500
+      assert payload.status == :interrupted
+      assert payload.interrupt_restorable == true
+    end
+
+    test "reports interrupt_restorable: false when no middleware claims the interrupt" do
+      # Same interrupt, but the agent has no AskUserQuestion middleware, so
+      # clean_stale_interrupts/2 would demote it on the next boot. Telling the
+      # host to keep the prompt would offer an answer no agent could accept.
+      agent = create_test_agent(middleware: [])
+
+      start_server(agent,
+        initial_state: question_state(),
+        inactivity_timeout: 30,
+        initial_subscribers: [{:main, self()}]
+      )
+
+      assert_receive {:agent, {:agent_shutdown, payload}}, 500
+      assert payload.interrupt_restorable == false
+    end
+
+    test "reports interrupt_restorable: false for a sub-agent approval" do
+      agent =
+        create_test_agent(
+          middleware: [
+            Sagents.Middleware.AskUserQuestion,
+            Sagents.Middleware.HumanInTheLoop
+          ]
+        )
+
+      state = interrupted_state([{"call_1", %{type: :subagent_hitl, sub_agent_id: "sa-1"}}])
+
+      start_server(agent,
+        initial_state: state,
+        inactivity_timeout: 30,
+        initial_subscribers: [{:main, self()}]
+      )
+
+      assert_receive {:agent, {:agent_shutdown, payload}}, 500
+      assert payload.status == :interrupted
+      assert payload.interrupt_restorable == false
+    end
+
+    test "reports interrupt_restorable: false when there is no interrupt at all" do
+      agent = ask_agent()
+
+      start_server(agent,
+        initial_state: State.new!(),
+        inactivity_timeout: 30,
+        initial_subscribers: [{:main, self()}]
+      )
+
+      assert_receive {:agent, {:agent_shutdown, payload}}, 500
+      assert payload.status == :idle
+      assert payload.interrupt_restorable == false
+    end
+  end
+
+  # ── :pending_resume ──────────────────────────────────────────────
+
+  describe ":pending_resume on boot" do
+    test "applies the answer and broadcasts :running, never :interrupted" do
+      test_pid = self()
+
+      Agent
+      |> expect(:resume, fn _agent, state, resume_data, _opts ->
+        send(test_pid, {:resumed_with, resume_data})
+        {:ok, state}
+      end)
+
+      agent = ask_agent()
+
+      start_server(agent,
+        initial_state: question_state(),
+        initial_subscribers: [{:main, self()}],
+        pending_resume: %{type: :answer, selected: ["yes"]}
+      )
+
+      assert_receive {:resumed_with, %{type: :answer, selected: ["yes"]}}, 1_000
+
+      # The whole point: the one boot broadcast reports the status this server
+      # genuinely has. A subscriber must never be told to re-present a question
+      # that is already answered.
+      assert_receive {:agent, {:status_changed, :running, nil}}, 1_000
+      refute_received {:agent, {:status_changed, :interrupted, _}}
+    end
+
+    test "a subscriber that arrives later snapshots :running, not :interrupted" do
+      test_pid = self()
+
+      Agent
+      |> stub(:resume, fn _agent, state, _resume_data, _opts ->
+        send(test_pid, :resumed)
+
+        receive do
+          :finish -> {:ok, state}
+        after
+          2_000 -> {:ok, state}
+        end
+      end)
+
+      agent = ask_agent()
+      agent_id = agent.agent_id
+
+      start_server(agent,
+        initial_state: question_state(),
+        pending_resume: %{type: :answer, selected: ["yes"]}
+      )
+
+      assert_receive :resumed, 1_000
+
+      # A second tab subscribing mid-resume gets the on_subscribed snapshot.
+      task =
+        Task.async(fn ->
+          {:ok, _pid, _ref} = AgentServer.subscribe(agent_id)
+
+          receive do
+            {:agent, {:status_changed, status, _data}} -> status
+          after
+            1_000 -> :timeout
+          end
+        end)
+
+      assert Task.await(task, 2_000) == :running
+    end
+
+    test "is discarded with the honest status when the boot is not interrupted" do
+      # The interrupt was answered from another tab (or demoted) before this
+      # boot. Applying the stale answer to whatever the agent is doing now would
+      # be far worse than dropping it.
+      Agent
+      |> reject(:resume, 4)
+
+      agent = ask_agent()
+
+      start_server(agent,
+        initial_state: State.new!(%{messages: [Message.new_user!("hi")]}),
+        initial_subscribers: [{:main, self()}],
+        pending_resume: %{type: :answer, selected: ["yes"]}
+      )
+
+      assert_receive {:agent, {:status_changed, :idle, nil}}, 1_000
+    end
+
+    test "is discarded when the interrupt is not restorable by this agent's middleware" do
+      # No AskUserQuestion, so clean_stale_interrupts/2 demotes the tool result
+      # and the boot lands :idle rather than :interrupted.
+      Agent
+      |> reject(:resume, 4)
+
+      agent = create_test_agent(middleware: [])
+
+      state =
+        State.clean_stale_interrupts(
+          interrupted_state([{"call_1", %{type: :subagent_hitl, sub_agent_id: "sa-1"}}]),
+          agent.middleware
+        )
+
+      start_server(agent,
+        initial_state: state,
+        initial_subscribers: [{:main, self()}],
+        pending_resume: %{type: :answer, selected: ["yes"]}
+      )
+
+      assert_receive {:agent, {:status_changed, :idle, nil}}, 1_000
+    end
+
+    test "a boot without :pending_resume still broadcasts the restored :interrupted" do
+      # Guard against over-reach: the boot snapshot is how every subscriber
+      # learns current state, and it must keep firing for an ordinary wake.
+      data = %{type: :ask_user_question, question: "Continue?"}
+      enriched = Map.put(data, :tool_call_id, "call_1")
+
+      start_server(ask_agent(),
+        initial_state: question_state(data),
+        initial_subscribers: [{:main, self()}]
+      )
+
+      assert_receive {:agent, {:status_changed, :interrupted, ^enriched}}, 500
+    end
+  end
+end

--- a/test/sagents/agent_utils_test.exs
+++ b/test/sagents/agent_utils_test.exs
@@ -746,4 +746,208 @@ defmodule Sagents.AgentUtilsTest do
                [%{on_message_processed: :supplied}]
     end
   end
+
+  describe "shutdown_session_changes/2" do
+    defp shutdown(overrides \\ %{}) do
+      Map.merge(
+        %{
+          agent_id: "conversation-1",
+          reason: :inactivity,
+          status: :idle,
+          interrupt_restorable: false,
+          last_activity_at: nil,
+          shutdown_at: ~U[2026-01-01 00:00:00Z]
+        },
+        overrides
+      )
+    end
+
+    defp question_session do
+      %{
+        agent_id: "conversation-1",
+        agent_status: :interrupted,
+        agent_alive?: true,
+        loading: false,
+        streaming_delta: nil,
+        interrupt_data: %{type: :ask_user_question, tool_call_id: "call-1"},
+        pending_question: %{tool_call_id: "call-1", question: "Which one?"},
+        remaining_questions: [],
+        question_responses: [],
+        pending_tools: [],
+        pending_halt: nil,
+        hitl_decisions: [],
+        sagents_subs: %{{:agent, "conversation-1"} => %{state: :subscribed}}
+      }
+    end
+
+    test "keeps a restorable question on screen, changing only liveness" do
+      changes =
+        AgentUtils.shutdown_session_changes(
+          question_session(),
+          shutdown(%{status: :interrupted, interrupt_restorable: true})
+        )
+
+      # The author still owes an answer. Nothing about the prompt changes.
+      assert changes == %{agent_alive?: false, loading: false, streaming_delta: nil}
+    end
+
+    test "keeps a restorable pending HITL tool batch" do
+      state = %{
+        question_session()
+        | pending_question: nil,
+          pending_tools: [%{tool_call_id: "call-1", tool_name: "write_file"}],
+          interrupt_data: %{action_requests: [%{tool_call_id: "call-1"}]}
+      }
+
+      changes =
+        AgentUtils.shutdown_session_changes(
+          state,
+          shutdown(%{status: :interrupted, interrupt_restorable: true})
+        )
+
+      assert changes == %{agent_alive?: false, loading: false, streaming_delta: nil}
+    end
+
+    test "keeps a restorable halt panel" do
+      state = %{
+        question_session()
+        | pending_question: nil,
+          pending_halt: %{message: "stopping", source_tool: "halt", tool_call_id: "call-1"},
+          interrupt_data: %{type: :halt, tool_call_id: "call-1"}
+      }
+
+      changes =
+        AgentUtils.shutdown_session_changes(
+          state,
+          shutdown(%{status: :interrupted, interrupt_restorable: true})
+        )
+
+      assert changes == %{agent_alive?: false, loading: false, streaming_delta: nil}
+    end
+
+    test "clears a non-restorable interrupt" do
+      state = %{
+        question_session()
+        | pending_question: nil,
+          pending_tools: [%{tool_call_id: "call-1"}],
+          interrupt_data: %{type: :subagent_hitl}
+      }
+
+      changes =
+        AgentUtils.shutdown_session_changes(
+          state,
+          shutdown(%{status: :interrupted, interrupt_restorable: false})
+        )
+
+      assert changes.agent_status == :not_running
+      assert changes.agent_alive? == false
+      assert changes.pending_tools == []
+      assert changes.pending_question == nil
+      assert changes.pending_halt == nil
+      assert changes.interrupt_data == nil
+    end
+
+    test "treats a missing :interrupt_restorable key as not restorable" do
+      # An agent predating the field. Degrade to the old clear-everything
+      # behaviour rather than to a prompt no agent can accept.
+      changes =
+        AgentUtils.shutdown_session_changes(
+          question_session(),
+          %{agent_id: "conversation-1", reason: :inactivity, status: :interrupted}
+        )
+
+      assert changes.agent_status == :not_running
+      assert changes.pending_question == nil
+    end
+
+    test "a non-interrupted session collapses to :not_running" do
+      state = %{
+        agent_id: "conversation-1",
+        agent_status: :idle,
+        agent_alive?: true,
+        loading: true,
+        streaming_delta: %{},
+        interrupt_data: nil
+      }
+
+      changes = AgentUtils.shutdown_session_changes(state, shutdown())
+
+      assert changes.agent_status == :not_running
+      assert changes.agent_alive? == false
+      assert changes.loading == false
+      assert changes.streaming_delta == nil
+    end
+
+    test "ignores a restorable flag when the host has no prompt showing" do
+      # Defensive: interrupt_data present but every derived key empty. There is
+      # nothing on screen to preserve, so collapse.
+      state = %{
+        agent_id: "conversation-1",
+        agent_status: :interrupted,
+        interrupt_data: %{type: :ask_user_question},
+        pending_question: nil,
+        pending_tools: [],
+        pending_halt: nil
+      }
+
+      changes =
+        AgentUtils.shutdown_session_changes(
+          state,
+          shutdown(%{status: :interrupted, interrupt_restorable: true})
+        )
+
+      assert changes.agent_status == :not_running
+    end
+
+    test "never clears agent_id or touches the subs map" do
+      for restorable <- [true, false] do
+        changes =
+          AgentUtils.shutdown_session_changes(
+            question_session(),
+            shutdown(%{status: :interrupted, interrupt_restorable: restorable})
+          )
+
+        refute Map.has_key?(changes, :agent_id)
+        refute Map.has_key?(changes, :sagents_subs)
+      end
+    end
+
+    test "is idempotent across the repeated deliveries one shutdown sends" do
+      for payload <- [
+            shutdown(%{status: :interrupted, interrupt_restorable: true}),
+            shutdown(%{status: :interrupted, interrupt_restorable: false}),
+            shutdown()
+          ] do
+        first = AgentUtils.shutdown_session_changes(question_session(), payload)
+        after_first = Map.merge(question_session(), first)
+        second = AgentUtils.shutdown_session_changes(after_first, payload)
+
+        assert Map.merge(after_first, second) == after_first,
+               "not idempotent for #{inspect(payload.interrupt_restorable)}"
+      end
+    end
+
+    test "preserves a half-answered question batch so it can finish after the wake" do
+      state = %{
+        question_session()
+        | pending_question: %{tool_call_id: "call-2", question: "second?"},
+          remaining_questions: [%{tool_call_id: "call-3", question: "third?"}],
+          question_responses: [%{tool_call_id: "call-1", type: :answer}]
+      }
+
+      merged =
+        Map.merge(
+          state,
+          AgentUtils.shutdown_session_changes(
+            state,
+            shutdown(%{status: :interrupted, interrupt_restorable: true})
+          )
+        )
+
+      assert merged.question_responses == [%{tool_call_id: "call-1", type: :answer}]
+      assert merged.remaining_questions == [%{tool_call_id: "call-3", question: "third?"}]
+      assert merged.pending_question.tool_call_id == "call-2"
+      assert merged.agent_status == :interrupted
+    end
+  end
 end

--- a/test/sagents/publisher_test.exs
+++ b/test/sagents/publisher_test.exs
@@ -197,4 +197,108 @@ defmodule Sagents.PublisherTest do
       assert PubState.count(seeded) == 1
     end
   end
+
+  # A producer that overrides on_subscribed/3 to send a snapshot, and counts
+  # how many times the hook actually fired.
+  defmodule SnapshotProducer do
+    use GenServer
+    use Sagents.Publisher, state_field: :publisher
+
+    defstruct publisher: nil, snapshots: 0
+
+    def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, opts)
+
+    def snapshot_count(server), do: GenServer.call(server, :snapshot_count)
+
+    @impl true
+    def init(opts) do
+      pub =
+        PubState.new([:main, :debug])
+        |> PubState.seed(Keyword.get(opts, :initial_subscribers, []))
+
+      {:ok, %__MODULE__{publisher: pub}}
+    end
+
+    def on_subscribed(:main, subscriber_pid, state) do
+      send(subscriber_pid, {:snapshot, :main})
+      %{state | snapshots: state.snapshots + 1}
+    end
+
+    def on_subscribed(_channel, _pid, state), do: state
+
+    @impl true
+    def handle_call(:snapshot_count, _from, state), do: {:reply, state.snapshots, state}
+
+    @impl true
+    def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+      case Publisher.handle_down(state.publisher, ref, pid) do
+        {:matched, new_pub} -> {:noreply, %{state | publisher: new_pub}}
+        :no_match -> {:noreply, state}
+      end
+    end
+  end
+
+  describe "on_subscribed/3 hook" do
+    test "fires for a newly registered subscriber" do
+      {:ok, pid} = SnapshotProducer.start_link()
+
+      {:ok, ^pid, _ref} = Publisher.subscribe(pid)
+
+      assert_receive {:snapshot, :main}, 100
+      assert SnapshotProducer.snapshot_count(pid) == 1
+    end
+
+    test "does not re-fire for a pid that is already subscribed" do
+      {:ok, pid} = SnapshotProducer.start_link()
+
+      {:ok, ^pid, ref1} = Publisher.subscribe(pid)
+      assert_receive {:snapshot, :main}, 100
+
+      # Subscribing again is idempotent for registration, and must be
+      # idempotent for the snapshot too: this pid has been receiving every
+      # broadcast since the first call, so there is nothing to resync.
+      {:ok, ^pid, ref2} = Publisher.subscribe(pid)
+
+      assert ref1 == ref2
+      refute_receive {:snapshot, :main}, 50
+      assert SnapshotProducer.snapshot_count(pid) == 1
+    end
+
+    test "does not fire for a pid seeded as an initial subscriber" do
+      # This is the shape Session.ensure_running/3 produces: the caller is
+      # enrolled before init/1 returns (so it catches the boot broadcast), and
+      # then calls subscribe/3 for its own bookkeeping. Without the guard the
+      # caller receives the boot status twice.
+      {:ok, pid} = SnapshotProducer.start_link(initial_subscribers: [{:main, self()}])
+
+      {:ok, ^pid, _ref} = Publisher.subscribe(pid)
+
+      refute_receive {:snapshot, :main}, 50
+      assert SnapshotProducer.snapshot_count(pid) == 0
+    end
+
+    test "still fires per-channel for the same pid" do
+      {:ok, pid} = SnapshotProducer.start_link(initial_subscribers: [{:debug, self()}])
+
+      # Registered on :debug, but never on :main — this is a new registration
+      # on the :main channel and must snapshot.
+      {:ok, ^pid, _ref} = Publisher.subscribe(pid, :main)
+
+      assert_receive {:snapshot, :main}, 100
+      assert SnapshotProducer.snapshot_count(pid) == 1
+    end
+
+    test "fires again after an explicit unsubscribe and re-subscribe" do
+      {:ok, pid} = SnapshotProducer.start_link()
+
+      {:ok, ^pid, _ref} = Publisher.subscribe(pid)
+      assert_receive {:snapshot, :main}, 100
+
+      :ok = Publisher.unsubscribe(pid)
+      {:ok, ^pid, _ref} = Publisher.subscribe(pid)
+
+      assert_receive {:snapshot, :main}, 100
+      assert SnapshotProducer.snapshot_count(pid) == 2
+    end
+  end
 end

--- a/test/sagents/session_test.exs
+++ b/test/sagents/session_test.exs
@@ -463,4 +463,158 @@ defmodule Sagents.SessionTest do
       assert Session.running?(base_config(), 1)
     end
   end
+
+  # ===========================================================================
+  # resume/4
+  # ===========================================================================
+
+  describe "resume/4" do
+    # The host's process-level state map, as ensure_running/3 expects it.
+    defp resume_state(overrides \\ %{}) do
+      Map.merge(%{conversation_id: 1, current_scope: :my_scope, sagents_subs: %{}}, overrides)
+    end
+
+    test "a live interrupted agent takes the answer in exactly one call" do
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+
+      test_pid = self()
+
+      stub(AgentServer, :resume, fn agent_id, resume_data ->
+        send(test_pid, {:resume_called, agent_id, resume_data})
+        :ok
+      end)
+
+      # No supervisor start at all on the fast path.
+      stub(AgentsDynamicSupervisor, :start_agent_sync, fn _opts ->
+        send(test_pid, :unexpected_start)
+        {:error, :should_not_be_called}
+      end)
+
+      assert :ok = Session.resume(base_config(), resume_state(), %{type: :answer})
+
+      assert_received {:resume_called, "conversation-1", %{type: :answer}}
+      refute_received :unexpected_start
+    end
+
+    test "a sleeping agent is started with the answer in hand" do
+      test_pid = self()
+      _fake_pid = stub_supervisor_ok(test_pid)
+
+      stub(AgentServer, :resume, fn _agent_id, _resume_data ->
+        {:error, :agent_not_running}
+      end)
+
+      assert {:ok, changes} =
+               Session.resume(base_config(), resume_state(), %{type: :answer, selected: ["yes"]})
+
+      assert changes.agent_id == "conversation-1"
+      assert Map.has_key?(changes, :sagents_subs)
+
+      # The answer rides into the boot rather than being stashed by the host
+      # and replayed against a broadcast.
+      assert_receive {:supervisor_config, opts}
+      assert opts[:pending_resume] == %{type: :answer, selected: ["yes"]}
+      assert opts[:initial_subscribers] == [{:main, self()}]
+    end
+
+    test "forwards :request_opts on the wake path so the woken agent is configured normally" do
+      test_pid = self()
+      _fake_pid = stub_supervisor_ok(test_pid)
+
+      stub(AgentServer, :resume, fn _agent_id, _resume_data -> {:error, :agent_not_running} end)
+
+      Session.resume(base_config(), resume_state(), %{type: :answer},
+        request_opts: [timezone: "America/Chicago"]
+      )
+
+      assert_received {:router_resolve, :my_scope, 1, [timezone: "America/Chicago"]}
+    end
+
+    test "a live agent in the wrong state errors instead of being woken" do
+      # Nothing to wake and nothing to resume. Routing this to the wake path
+      # would be a no-op that hides a real problem (e.g. the question was
+      # already answered from another tab).
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      test_pid = self()
+
+      stub(AgentServer, :resume, fn _agent_id, _resume_data ->
+        {:error, "Cannot resume, server is not interrupted"}
+      end)
+
+      stub(AgentsDynamicSupervisor, :start_agent_sync, fn _opts ->
+        send(test_pid, :unexpected_start)
+        {:error, :should_not_be_called}
+      end)
+
+      assert {:error, "Cannot resume, server is not interrupted"} =
+               Session.resume(base_config(), resume_state(), %{type: :answer})
+
+      refute_received :unexpected_start
+    end
+
+    test "retries against the process when another caller won the wake race" do
+      # Between our failed resume and the start, another tab (or an admin wake)
+      # booted the agent. `:pending_resume` is a start-time option, so it was
+      # never consumed and the answer would otherwise be silently dropped.
+      test_pid = self()
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+
+      Process.put(:resume_calls, 0)
+
+      stub(AgentServer, :resume, fn agent_id, resume_data ->
+        case Process.get(:resume_calls) do
+          0 ->
+            Process.put(:resume_calls, 1)
+            {:error, :agent_not_running}
+
+          _already_retried ->
+            send(test_pid, {:retried, agent_id, resume_data})
+            :ok
+        end
+      end)
+
+      # The agent is up by the time Session.start/3 looks, so it returns
+      # started: false without ever reaching the supervisor.
+      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+
+      stub(AgentServer, :subscribe, fn _agent_id, _channel, _pid ->
+        {:ok, fake_pid, make_ref()}
+      end)
+
+      stub(AgentsDynamicSupervisor, :start_agent_sync, fn _opts ->
+        send(test_pid, :unexpected_start)
+        {:error, :should_not_be_called}
+      end)
+
+      assert {:ok, _changes} = Session.resume(base_config(), resume_state(), %{type: :answer})
+
+      assert_received {:retried, "conversation-1", %{type: :answer}}
+      refute_received :unexpected_start
+    end
+
+    test "passes a start failure through" do
+      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :resume, fn _agent_id, _resume_data -> {:error, :agent_not_running} end)
+      Process.put(:spy_router_response, {:error, :no_route})
+
+      assert {:error, :no_route} = Session.resume(base_config(), resume_state(), %{type: :answer})
+    end
+  end
+
+  describe "start/3 session_info :started flag" do
+    test "true when this call created the process" do
+      _fake_pid = stub_supervisor_ok(self())
+
+      assert {:ok, %{started: true}} = Session.start(base_config(), 1, scope: :s)
+    end
+
+    test "false when an agent was already running" do
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+
+      assert {:ok, %{started: false}} = Session.start(base_config(), 1, scope: :s)
+    end
+  end
 end

--- a/test/sagents/session_test.exs
+++ b/test/sagents/session_test.exs
@@ -603,6 +603,145 @@ defmodule Sagents.SessionTest do
     end
   end
 
+  describe "dismiss/3" do
+    test "a live agent holding a halt is dismissed in exactly one call" do
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+
+      test_pid = self()
+
+      stub(AgentServer, :dismiss_interrupt, fn agent_id ->
+        send(test_pid, {:dismiss_called, agent_id})
+        :ok
+      end)
+
+      stub(AgentsDynamicSupervisor, :start_agent_sync, fn _opts ->
+        send(test_pid, :unexpected_start)
+        {:error, :should_not_be_called}
+      end)
+
+      assert :ok = Session.dismiss(base_config(), resume_state())
+
+      assert_received {:dismiss_called, "conversation-1"}
+      refute_received :unexpected_start
+    end
+
+    test "a dormant halt is woken and then dismissed" do
+      # The regression this exists to prevent: a halt is restorable, so the
+      # panel survives the nap, and before this its only button returned
+      # {:error, :agent_not_running} forever.
+      test_pid = self()
+      _fake_pid = stub_supervisor_ok(test_pid)
+
+      Process.put(:dismiss_calls, 0)
+
+      stub(AgentServer, :dismiss_interrupt, fn agent_id ->
+        case Process.get(:dismiss_calls) do
+          0 ->
+            Process.put(:dismiss_calls, 1)
+            {:error, :agent_not_running}
+
+          _after_wake ->
+            send(test_pid, {:dismissed_after_wake, agent_id})
+            :ok
+        end
+      end)
+
+      assert {:ok, changes} = Session.dismiss(base_config(), resume_state())
+
+      assert changes.agent_id == "conversation-1"
+      assert Map.has_key?(changes, :sagents_subs)
+      assert_received {:dismissed_after_wake, "conversation-1"}
+
+      # No :pending_dismiss equivalent rides into the boot; the dismissal is a
+      # second call once the agent is up.
+      assert_receive {:supervisor_config, opts}
+      assert opts[:pending_resume] == nil
+      assert opts[:initial_subscribers] == [{:main, self()}]
+    end
+
+    test "forwards :request_opts on the wake path so the woken agent is configured normally" do
+      test_pid = self()
+      _fake_pid = stub_supervisor_ok(test_pid)
+
+      Process.put(:dismiss_calls, 0)
+
+      stub(AgentServer, :dismiss_interrupt, fn _agent_id ->
+        case Process.get(:dismiss_calls) do
+          0 ->
+            Process.put(:dismiss_calls, 1)
+            {:error, :agent_not_running}
+
+          _after_wake ->
+            :ok
+        end
+      end)
+
+      Session.dismiss(base_config(), resume_state(), request_opts: [timezone: "America/Chicago"])
+
+      assert_received {:router_resolve, :my_scope, 1, [timezone: "America/Chicago"]}
+    end
+
+    test "a live agent in the wrong state errors instead of being woken" do
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      test_pid = self()
+
+      stub(AgentServer, :dismiss_interrupt, fn _agent_id ->
+        {:error, "Cannot dismiss, server is not interrupted (status: idle)"}
+      end)
+
+      stub(AgentsDynamicSupervisor, :start_agent_sync, fn _opts ->
+        send(test_pid, :unexpected_start)
+        {:error, :should_not_be_called}
+      end)
+
+      assert {:error, "Cannot dismiss, server is not interrupted (status: idle)"} =
+               Session.dismiss(base_config(), resume_state())
+
+      refute_received :unexpected_start
+    end
+
+    test "an interrupt needing an explicit response is not woken and not dismissed" do
+      # AskUserQuestion and HITL interrupts must go through resume/4. Waking to
+      # retry a dismissal they will refuse again is pointless.
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      test_pid = self()
+
+      stub(AgentServer, :dismiss_interrupt, fn _agent_id ->
+        {:error, "interrupt requires explicit response (use resume)"}
+      end)
+
+      stub(AgentsDynamicSupervisor, :start_agent_sync, fn _opts ->
+        send(test_pid, :unexpected_start)
+        {:error, :should_not_be_called}
+      end)
+
+      assert {:error, "interrupt requires explicit response (use resume)"} =
+               Session.dismiss(base_config(), resume_state())
+
+      refute_received :unexpected_start
+    end
+
+    test "passes a start failure through" do
+      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :dismiss_interrupt, fn _agent_id -> {:error, :agent_not_running} end)
+      Process.put(:spy_router_response, {:error, :no_route})
+
+      assert {:error, :no_route} = Session.dismiss(base_config(), resume_state())
+    end
+
+    test "surfaces a post-wake dismissal failure rather than reporting success" do
+      test_pid = self()
+      _fake_pid = stub_supervisor_ok(test_pid)
+
+      stub(AgentServer, :dismiss_interrupt, fn _agent_id -> {:error, :agent_not_running} end)
+
+      assert {:error, :agent_not_running} = Session.dismiss(base_config(), resume_state())
+    end
+  end
+
   describe "start/3 session_info :started flag" do
     test "true when this call created the process" do
       _fake_pid = stub_supervisor_ok(self())

--- a/test/sagents/state_test.exs
+++ b/test/sagents/state_test.exs
@@ -661,6 +661,95 @@ defmodule Sagents.StateTest do
     end
   end
 
+  describe "interrupt_restorable?/2" do
+    setup do
+      %{
+        ask: Sagents.Middleware.init_middleware(Sagents.Middleware.AskUserQuestion),
+        hitl: Sagents.Middleware.init_middleware(Sagents.Middleware.HumanInTheLoop),
+        halt: Sagents.Middleware.init_middleware(Sagents.Middleware.Haltable)
+      }
+    end
+
+    test "nil is never restorable", %{ask: ask} do
+      refute State.interrupt_restorable?(nil, [ask])
+    end
+
+    test "an empty middleware list never restores anything" do
+      refute State.interrupt_restorable?(%{type: :ask_user_question}, [])
+    end
+
+    test "a question is restorable when AskUserQuestion is in the stack", %{ask: ask} do
+      assert State.interrupt_restorable?(%{type: :ask_user_question, question: "?"}, [ask])
+    end
+
+    test "a question is not restorable without AskUserQuestion", %{halt: halt} do
+      refute State.interrupt_restorable?(%{type: :ask_user_question, question: "?"}, [halt])
+    end
+
+    test "a halt is restorable when Haltable is in the stack", %{halt: halt} do
+      assert State.interrupt_restorable?(%{type: :halt, message: "done"}, [halt])
+    end
+
+    test "a sub-agent approval is never restorable: its chain dies with the process",
+         %{ask: ask, hitl: hitl, halt: halt} do
+      refute State.interrupt_restorable?(
+               %{type: :subagent_hitl, sub_agent_id: "sa-1"},
+               [ask, hitl, halt]
+             )
+    end
+
+    test ":multiple_interrupts needs every sub-interrupt claimed", %{ask: ask, halt: halt} do
+      all_questions = %{
+        type: :multiple_interrupts,
+        interrupts: [%{type: :ask_user_question}, %{type: :ask_user_question}]
+      }
+
+      mixed = %{
+        type: :multiple_interrupts,
+        interrupts: [%{type: :ask_user_question}, %{type: :subagent_hitl, sub_agent_id: "sa-1"}]
+      }
+
+      assert State.interrupt_restorable?(all_questions, [ask, halt])
+      # Partial restore is a footgun: a resumed agent would dispatch responses
+      # that don't all have valid targets.
+      refute State.interrupt_restorable?(mixed, [ask, halt])
+    end
+
+    test "a question/halt mix is restorable when both middleware are present",
+         %{ask: ask, halt: halt} do
+      data = %{
+        type: :multiple_interrupts,
+        interrupts: [%{type: :ask_user_question}, %{type: :halt, message: "stop"}]
+      }
+
+      assert State.interrupt_restorable?(data, [ask, halt])
+      refute State.interrupt_restorable?(data, [ask])
+    end
+
+    test "an empty :multiple_interrupts wrapper is not restorable", %{ask: ask} do
+      # Degenerate shape (the wrapper is only ever built from 2+ results), but
+      # there would be nothing for a resume to answer.
+      refute State.interrupt_restorable?(%{type: :multiple_interrupts, interrupts: []}, [ask])
+    end
+
+    test "agrees with what clean_stale_interrupts/2 actually does", %{ask: ask} do
+      # The whole point of exposing this: a caller must never be able to decide
+      # "keep the prompt" for an interrupt the next boot will demote.
+      for data <- [
+            %{type: :ask_user_question, question: "?"},
+            %{type: :subagent_hitl, sub_agent_id: "sa-1"},
+            %{type: :multiple_interrupts, interrupts: [%{type: :ask_user_question}]}
+          ] do
+        state = build_interrupt_state(data)
+        [tool_msg] = State.clean_stale_interrupts(state, [ask]).messages
+        [result] = tool_msg.tool_results
+
+        assert result.is_interrupt == State.interrupt_restorable?(data, [ask]),
+               "mismatch for #{inspect(data)}"
+      end
+    end
+  end
+
   describe "cancel_pending_interrupts/1" do
     alias LangChain.Message.ToolResult
 


### PR DESCRIPTION
## Problem

An open `ask_user` question vanished from the UI while it was still genuinely pending. When an idle agent hit its inactivity timer and shut down, the host treated "the process went away" as a status change: it cleared the prompt and collapsed the conversation to `:not_running`. The author returned to a conversation with no question on screen, and no route back to the one the agent was still waiting on.

The interrupt itself was never actually lost. It is persisted with the state, and a fresh boot rebuilds it and comes up `:interrupted`. What was lost was the host's ability to tell two different facts apart, because it only had one key to say them with:

- what the conversation is waiting on
- whether a process is backing it right now

Those are independent. A dormant agent with a pending question is still waiting on the author. The old code could not express that, so it guessed, and it guessed wrong in the one case that mattered.

## Solution

Split the two facts, then make an answer capable of waking the agent that needs it.

**Liveness is not status.** `agent_status` keeps its meaning (what the conversation is waiting on). A new `agent_alive?` key carries whether a producer process is up. Hosts gate "wake the agent" affordances on `agent_alive?` rather than on `agent_status == :not_running`.

**One door for answering an interrupt.** `Sagents.Session.resume/4` replaces direct `AgentServer.resume/2` calls from host code. It asks the agent first, since a live interrupted agent is the common case and costs exactly one call. On `{:error, :agent_not_running}` it starts an agent and hands the answer to `init/1` through a new `:pending_resume` start option. A live agent in the wrong state still returns its error rather than being woken, so a real problem is not masked by a pointless boot.

**Ordering is the interesting part.** `:pending_resume` is consumed in `handle_continue(:broadcast_initial_state, _)` *before* the initial status broadcast. The boot broadcast is how every subscriber learns current state, so it must fire exactly once, but it should report the status the server genuinely has after consuming everything it was handed. Broadcasting `:interrupted` and then `:running` a microsecond later would make every subscriber re-present a question that is already answered. The wake path needs no polling or retry timer: `start_agent_sync/1` blocks until registration, and a `GenServer.call` is serialized after `init/1` and `handle_continue/2`.

**The host should not have to guess whether an interrupt survives.** `AgentServer` now computes `:interrupt_restorable` and reports it on `{:agent_shutdown, _}`. Shutdown is the only moment the question is worth asking and the only moment both `interrupt_data` and the agent's middleware are still in scope to answer it. A host mirroring that predicate would drift the day the middleware rules change, and the failure mode is offering the user a prompt no agent can ever accept. `Sagents.AgentUtils.shutdown_session_changes/2` turns the flag into the changes a host merges: keep the prompt when restorable, otherwise today's clear-everything behaviour. A payload missing the key (a version-skewed agent predating this release) degrades to the old behaviour rather than to an unanswerable prompt.

**A race the wake path has to handle.** If another tab starts the agent between our failed `resume` and our `ensure_running`, `:pending_resume` is never consumed, because start options only apply on a fresh boot. `Session.start/3`'s `session_info` gained `:started` so the caller can tell the two apart and re-ask the now-live agent.

## Changes

### Library

- [`lib/sagents/session.ex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/lib/sagents/session.ex) — New `resume/4` plus its `wake_and_resume/5` path. `ensure_running/3` is refactored onto a private `do_ensure_running/3` that also returns `session_info`, so callers passing start-time-only options can tell whether those options were consumed. `session_info` gained `:started`.
- [`lib/sagents/agent_server.ex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/lib/sagents/agent_server.ex) — New `:pending_resume` start option and `ServerState` field, applied by `apply_pending_resume/1` in `handle_continue/2` and discarded with a warning if the server boots into any status other than `:interrupted`. The resume transition is extracted from the `{:resume, _}` `handle_call` into a shared `start_resume/2` that deliberately does not broadcast, because the two callers disagree on when the status event should go out. New `shutdown_payload/2` gives all three `{:agent_shutdown, _}` emit sites one shape.
- [`lib/sagents/agent_utils.ex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/lib/sagents/agent_utils.ex) — New `shutdown_session_changes/2`. Notably it does *not* touch the subscriber map (unsubscribing would delete an entry that `handle_presence_diff/3` only revives in the `:pending` state, so it could never come back without a remount) and does *not* clear `:agent_id`.
- [`lib/sagents/state.ex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/lib/sagents/state.ex) — `interrupt_restorable?/2` promoted from private to public, so callers share the exact predicate the next boot will use. An empty `:multiple_interrupts` wrapper is no longer treated as restorable: there is nothing for a resume to answer.
- [`lib/sagents/publisher.ex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/lib/sagents/publisher.ex) — `on_subscribed/3` fires only for a newly registered pid.
- [`lib/sagents/agent_supervisor.ex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/lib/sagents/agent_supervisor.ex) — Threads `:pending_resume` into the child spec.

### Generator templates

- [`priv/templates/coordinator.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/priv/templates/coordinator.ex.eex) — New `resume_agent_session/3` delegating to `Session.resume/4`.
- [`priv/templates/agent_subscriber_session.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/priv/templates/agent_subscriber_session.ex.eex) — Carries `agent_alive?`, set `true` in every status handler (an inbound agent event is proof of life) and `false` on `:DOWN` and shutdown. `handle_agent_shutdown/2` now consults `shutdown_data` instead of ignoring it.
- [`priv/templates/agent_live_helpers.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/priv/templates/agent_live_helpers.ex.eex) — Both interrupt handlers funnel through one shared resume helper against the coordinator rather than calling `AgentServer.resume/2` with an `agent_id` that may be `nil`. The "agent is no longer running, start over" dead end is gone. Intermediate decisions in a multi-item batch settle nothing and deliberately do not wake an agent.

### Docs and tests

- [`CHANGELOG.md`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/CHANGELOG.md) — v0.11.0 entry.
- [`MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/MIGRATION_PROMPT_v0.10.x_TO_v0.11.0.md) — New, 422 lines, written to be handed to a coding agent. The fix is opt-in because the affected modules were generated into the host app.
- Five test files, 878 lines added: [`agent_server_dormant_interrupt_test.exs`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/test/sagents/agent_server_dormant_interrupt_test.exs), [`agent_utils_test.exs`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/test/sagents/agent_utils_test.exs), [`session_test.exs`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/test/sagents/session_test.exs), [`publisher_test.exs`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/test/sagents/publisher_test.exs), [`state_test.exs`](https://github.com/sagents-ai/sagents/blob/me-dormant-interrupt-recovery/test/sagents/state_test.exs).

## Upgrade impact

No compile-time breakage. Nothing changed arity or return type, and upgrading without touching host code is safe: everything behaves as v0.10.1 did, bug included. The fix is opt-in because the affected modules live in the host app as generated code.

One non-opt-in behaviour change: **`on_subscribed/3` no longer fires for a pid already subscribed to that channel.** It is a newly-registered-subscriber hook, and an already-registered pid has nothing to resync. Code that re-subscribed to force a refresh should use `Sagents.AgentServer.get_info/1` instead.

## Testing

Full suite green on this branch, no live API calls: `1679 passed, 1 skipped, 10 excluded`.

New coverage:

- **Dormant interrupt boot** (327 lines) — `:pending_resume` applied at boot, the single `:running` broadcast rather than an `:interrupted` flash, discard-with-warning when the server boots into another status, and the shutdown payload shape from all three emit sites.
- **`shutdown_session_changes/2`** (204 lines) — restorable versus not, the absent-key degradation, idempotency across a redelivered shutdown, and that the subs map and `:agent_id` are left alone.
- **`Session.resume/4`** (154 lines) — the live-agent path, the wake path, the lost-race path where another starter won and the answer must be re-asked, and error passthrough for a live agent in the wrong state.
- **`Publisher`** (104 lines) — `on_subscribed/3` fires once for a new pid and not at all for an already-subscribed one, matching the `:initial_subscribers` plus `subscribe/3` shape `Session.ensure_running/3` produces.
- **`State.interrupt_restorable?/2`** (89 lines) — `nil`, the empty `:multiple_interrupts` wrapper, all-claimed versus partially-claimed sub-interrupts, and the empty middleware list.
