### PR TITLE
fixes langchain summarization threshold to use a minimum of 2

### DIFF
--- a/lib/sagents/middleware/summarization.ex
+++ b/lib/sagents/middleware/summarization.ex
@@ -321,12 +321,14 @@ defmodule Sagents.Middleware.Summarization do
     model = config.model || get_model_from_state(state)
 
     if model do
-      # Create summarizer chain
+      # Create summarizer chain. `run/2` summarizes the pre-partitioned text we
+      # hand it and never reads the partitioning counts, but LangChain validates
+      # `threshold_count >= 2` — anything lower makes `new!/1` raise.
       summarizer =
         SummarizeConversationChain.new!(%{
           llm: model,
           keep_count: 0,
-          threshold_count: 0,
+          threshold_count: 2,
           override_system_prompt: config.summary_prompt
         })
 

--- a/test/sagents/middleware/summarization_test.exs
+++ b/test/sagents/middleware/summarization_test.exs
@@ -9,6 +9,7 @@ defmodule Sagents.Middleware.SummarizationTest do
   alias LangChain.Message.ToolCall
   alias LangChain.Message.ToolResult
   alias LangChain.ChatModels.ChatOpenAI
+  alias LangChain.LangChainError
 
   setup do
     %{agent_id: generate_test_agent_id()}
@@ -275,7 +276,8 @@ defmodule Sagents.Middleware.SummarizationTest do
         Summarization.init(
           model: ChatOpenAI.new!(%{model: "gpt-4", stream: false}),
           messages_to_keep: 2,
-          token_counter: fn _msgs -> 1_000_000 end
+          max_tokens_before_summary: 100,
+          token_counter: fn _msgs -> 1_000 end
         )
 
       messages = over_threshold_conversation()
@@ -296,6 +298,25 @@ defmodule Sagents.Middleware.SummarizationTest do
       assert ContentPart.parts_to_string(summary.content) == "Summary of the earlier conversation"
       assert kept_user == Enum.at(messages, 5)
       assert kept_assistant == Enum.at(messages, 6)
+    end
+
+    test "keeps every message when the summarizing LLM fails", %{agent_id: agent_id} do
+      stub(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "api_error", message: "summarizer unavailable")}
+      end)
+
+      {:ok, config} =
+        Summarization.init(
+          model: ChatOpenAI.new!(%{model: "gpt-4", stream: false}),
+          messages_to_keep: 2,
+          max_tokens_before_summary: 100,
+          token_counter: fn _msgs -> 1_000 end
+        )
+
+      messages = over_threshold_conversation()
+      state = State.new!(%{agent_id: agent_id, messages: messages})
+
+      assert {:ok, %State{messages: ^messages}} = Summarization.before_model(state, config)
     end
   end
 

--- a/test/sagents/middleware/summarization_test.exs
+++ b/test/sagents/middleware/summarization_test.exs
@@ -1,9 +1,11 @@
 defmodule Sagents.Middleware.SummarizationTest do
   use Sagents.BaseCase, async: true
+  use Mimic
 
   alias Sagents.Middleware.Summarization
   alias Sagents.State
   alias LangChain.Message
+  alias LangChain.Message.ContentPart
   alias LangChain.Message.ToolCall
   alias LangChain.Message.ToolResult
   alias LangChain.ChatModels.ChatOpenAI
@@ -263,6 +265,40 @@ defmodule Sagents.Middleware.SummarizationTest do
     end
   end
 
+  describe "summarization execution" do
+    test "replaces older messages with an LLM summary when over threshold", %{agent_id: agent_id} do
+      stub(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Summary of the earlier conversation")]}
+      end)
+
+      {:ok, config} =
+        Summarization.init(
+          model: ChatOpenAI.new!(%{model: "gpt-4", stream: false}),
+          messages_to_keep: 2,
+          token_counter: fn _msgs -> 1_000_000 end
+        )
+
+      messages = over_threshold_conversation()
+      state = State.new!(%{agent_id: agent_id, messages: messages})
+
+      assert {:ok, %State{messages: updated}} = Summarization.before_model(state, config)
+
+      # [system | summary user/assistant pair | the messages_to_keep tail]
+      assert [
+               %Message{role: :system} = system,
+               %Message{role: :user},
+               %Message{role: :assistant} = summary,
+               %Message{role: :user} = kept_user,
+               %Message{role: :assistant} = kept_assistant
+             ] = updated
+
+      assert system == List.first(messages)
+      assert ContentPart.parts_to_string(summary.content) == "Summary of the earlier conversation"
+      assert kept_user == Enum.at(messages, 5)
+      assert kept_assistant == Enum.at(messages, 6)
+    end
+  end
+
   describe "configuration validation" do
     test "accepts valid messages_to_keep values" do
       assert {:ok, config} = Summarization.init(messages_to_keep: 0)
@@ -332,5 +368,20 @@ defmodule Sagents.Middleware.SummarizationTest do
       # Should count substantial tokens for long text
       assert tokens > 1000
     end
+  end
+
+  # Seven messages with an all-text tail so `find_safe_cutoff` (with
+  # messages_to_keep: 2) lands cleanly: the first four get summarized, the last
+  # two are preserved.
+  defp over_threshold_conversation do
+    [
+      Message.new_system!("You are helpful"),
+      Message.new_user!("First question"),
+      Message.new_assistant!("First answer"),
+      Message.new_user!("Second question"),
+      Message.new_assistant!("Second answer"),
+      Message.new_user!("Third question"),
+      Message.new_assistant!("Third answer")
+    ]
   end
 end


### PR DESCRIPTION
## Problem

`Sagents.Middleware.Summarization` was broken at the moment it actually mattered: whenever a conversation exceeded the token threshold and the middleware attempted to summarize, it crashed instead. The middleware builds a LangChain `SummarizeConversationChain` with `threshold_count: 0`, but LangChain validates that `threshold_count >= 2`, so `SummarizeConversationChain.new!/1` raised on every summarization attempt.

The bug went unnoticed because the existing test suite only covered configuration validation, token counting, and the under-threshold (no-op) paths — nothing exercised an actual summarization run.

## Solution

- Set `threshold_count: 2` (LangChain's minimum) when building the summarizer chain. The value is behaviorally irrelevant here: Sagents does its own message partitioning (`find_safe_cutoff` / `messages_to_keep`) and only uses the chain's `run/2` to summarize pre-partitioned text, which never consults the threshold. A comment now documents this constraint at the call site.
- Added a test that exercises the full summarization path with a Mimic-stubbed `ChatOpenAI.call`, asserting that an over-threshold conversation is rewritten to `[system message | summary pair | the `messages_to_keep` tail]` — this test fails with a raise on `main` and passes with the fix.