### PR TITLE
Add React front end guide to published docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -173,6 +173,7 @@ defmodule Sagents.MixProject do
       "docs/conversations_architecture.md",
       "docs/lifecycle.md",
       "docs/subscriptions_and_presence.md",
+      "docs/using_with_a_react_front_end.md",
       "docs/middleware.md",
       "docs/middleware_messaging.md",
       "docs/observability.md",


### PR DESCRIPTION
## Problem

[`docs/using_with_a_react_front_end.md`](https://github.com/sagents-ai/sagents/blob/me-updates-for-doc/docs/using_with_a_react_front_end.md) shipped in v0.11.1 but was never added to `extras()`, so it does not render on HexDocs. It is in the hex package (the `docs` directory is in `package/files`) but has no browsable page.

The `groups_for_extras: [Docs: Path.wildcard("docs/*.md")]` config looks like it would pick the file up, but that wildcard only assigns sidebar groups to extras already in the list. It does not discover pages.

## Solution

Add the guide to `extras()`, placed after `docs/subscriptions_and_presence.md` since the guide names that doc as prerequisite reading and within-group sidebar order follows list order.

## Changes

- [`mix.exs`](https://github.com/sagents-ai/sagents/blob/me-updates-for-doc/mix.exs#L176): add `docs/using_with_a_react_front_end.md` to `extras()`

## Testing

Ran `mix docs` locally and confirmed:

- `using_with_a_react_front_end.html` generates
- The prerequisite link rewrites from `.md` to `.html`, so it points at the real page
- Sidebar order is `subscriptions_and_presence` then `using_with_a_react_front_end` then `middleware`
- All 6 mermaid blocks render as `<code class="mermaid">`, matching the selector in `before_closing_body_tag`

`mix format --check-formatted` passes.