### PR TITLE
fix summarization cutoff logic

### DIFF
--- a/lib/sagents/middleware/summarization.ex
+++ b/lib/sagents/middleware/summarization.ex
@@ -100,8 +100,10 @@ defmodule Sagents.Middleware.Summarization do
   1. Calculate target cutoff: `message_count - messages_to_keep`
   2. Search backwards from target to find safe cutoff point
   3. A point is safe if:
-     - It's not an assistant message with tool_calls
-     - The next message isn't a tool result for this assistant
+     - The first message being kept is not a tool result (its originating
+       assistant tool call must not be summarized away)
+     - The last message being summarized is not an assistant with tool calls
+       whose results follow on the kept side
   4. If no safe point found, summarize nothing (keeps all messages)
 
   ## Error Handling
@@ -285,23 +287,35 @@ defmodule Sagents.Middleware.Summarization do
     if index <= 0 or index >= length(messages) do
       true
     else
-      # Get the message at the cutoff point (last message to include in summary)
-      message_at_cutoff = Enum.at(messages, index - 1)
+      # The first message being kept (index) and the last message being
+      # summarized (index - 1) straddle the cut.
+      first_kept = Enum.at(messages, index)
+      last_summarized = Enum.at(messages, index - 1)
 
-      # Check if this is an assistant message with tool calls
-      case message_at_cutoff do
-        %Message{role: :assistant, tool_calls: tool_calls}
-        when is_list(tool_calls) and tool_calls != [] ->
-          # This is an assistant with tool calls
-          # Check if the next few messages contain tool results
-          has_pending_tool_results?(messages, index, @search_range_for_tool_pairs)
+      cond do
+        # Keeping a tool result whose originating assistant tool call was
+        # summarized away orphans it — providers reject tool outputs that have
+        # no matching call in the input (e.g. OpenAI: "No tool call found for
+        # function call output"). This also covers cuts landing between
+        # consecutive tool results from parallel tool calls.
+        match?(%Message{role: :tool}, first_kept) ->
+          false
 
-        _other ->
-          # Not an assistant with tool calls, safe to cut here
+        # Summarizing away an assistant that issued tool calls while its
+        # results remain on the kept side orphans those results the same way.
+        assistant_with_tool_calls?(last_summarized) ->
+          not has_pending_tool_results?(messages, index, @search_range_for_tool_pairs)
+
+        true ->
           true
       end
     end
   end
+
+  defp assistant_with_tool_calls?(%Message{role: :assistant, tool_calls: tool_calls}),
+    do: is_list(tool_calls) and tool_calls != []
+
+  defp assistant_with_tool_calls?(_message), do: false
 
   defp has_pending_tool_results?(messages, start_index, search_range) do
     # Check if any of the next N messages are tool results

--- a/test/sagents/middleware/summarization_test.exs
+++ b/test/sagents/middleware/summarization_test.exs
@@ -318,6 +318,118 @@ defmodule Sagents.Middleware.SummarizationTest do
 
       assert {:ok, %State{messages: ^messages}} = Summarization.before_model(state, config)
     end
+
+    test "keeps an assistant tool call with its result instead of orphaning the result", %{
+      agent_id: agent_id
+    } do
+      stub(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Summary of the earlier conversation")]}
+      end)
+
+      {:ok, config} =
+        Summarization.init(
+          model: ChatOpenAI.new!(%{model: "gpt-4", stream: false}),
+          messages_to_keep: 2,
+          max_tokens_before_summary: 100,
+          token_counter: fn _msgs -> 1_000 end
+        )
+
+      tool_call = ToolCall.new!(%{call_id: "call_1", name: "search", arguments: %{"q" => "test"}})
+
+      # The target cutoff (count - messages_to_keep) lands exactly between the
+      # assistant's tool call and its result. Cutting there orphans the kept
+      # result — providers reject tool outputs with no matching call, so the
+      # cut must move back to keep the pair together.
+      messages = [
+        Message.new_system!("You are helpful"),
+        Message.new_user!("First question"),
+        Message.new_assistant!("First answer"),
+        Message.new_user!("Search for something"),
+        Message.new_assistant!(%{tool_calls: [tool_call]}),
+        Message.new_tool_result!(%{
+          tool_results: [
+            ToolResult.new!(%{tool_call_id: "call_1", name: "search", content: "Results"})
+          ]
+        }),
+        Message.new_user!("What did you find?")
+      ]
+
+      state = State.new!(%{agent_id: agent_id, messages: messages})
+
+      assert {:ok, %State{messages: updated}} = Summarization.before_model(state, config)
+
+      assert [
+               %Message{role: :system},
+               %Message{role: :user},
+               %Message{role: :assistant},
+               %Message{role: :assistant, tool_calls: [%ToolCall{call_id: "call_1"}]},
+               %Message{role: :tool} = kept_result,
+               %Message{role: :user}
+             ] = updated
+
+      assert [%ToolResult{tool_call_id: "call_1"}] = kept_result.tool_results
+    end
+
+    test "never cuts between consecutive tool results from parallel tool calls", %{
+      agent_id: agent_id
+    } do
+      stub(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Summary of the earlier conversation")]}
+      end)
+
+      {:ok, config} =
+        Summarization.init(
+          model: ChatOpenAI.new!(%{model: "gpt-4", stream: false}),
+          messages_to_keep: 3,
+          max_tokens_before_summary: 100,
+          token_counter: fn _msgs -> 1_000 end
+        )
+
+      call_a = ToolCall.new!(%{call_id: "call_a", name: "search", arguments: %{"q" => "a"}})
+      call_b = ToolCall.new!(%{call_id: "call_b", name: "search", arguments: %{"q" => "b"}})
+
+      # The target cutoff lands between the two tool results. The message
+      # before the cut is a tool result (not an assistant), so the pre-fix
+      # algorithm called this cut safe — orphaning the second result.
+      messages = [
+        Message.new_system!("You are helpful"),
+        Message.new_user!("Search two things"),
+        Message.new_assistant!(%{tool_calls: [call_a, call_b]}),
+        Message.new_tool_result!(%{
+          tool_results: [
+            ToolResult.new!(%{tool_call_id: "call_a", name: "search", content: "A results"})
+          ]
+        }),
+        Message.new_tool_result!(%{
+          tool_results: [
+            ToolResult.new!(%{tool_call_id: "call_b", name: "search", content: "B results"})
+          ]
+        }),
+        Message.new_user!("Now compare them"),
+        Message.new_assistant!("Comparison")
+      ]
+
+      state = State.new!(%{agent_id: agent_id, messages: messages})
+
+      assert {:ok, %State{messages: updated}} = Summarization.before_model(state, config)
+
+      assert [
+               %Message{role: :system},
+               %Message{role: :user},
+               %Message{role: :assistant},
+               %Message{
+                 role: :assistant,
+                 tool_calls: [%ToolCall{call_id: "call_a"}, %ToolCall{call_id: "call_b"}]
+               },
+               %Message{role: :tool} = result_a,
+               %Message{role: :tool} = result_b,
+               %Message{role: :user},
+               %Message{role: :assistant}
+             ] = updated
+
+      assert [%ToolResult{tool_call_id: "call_a"}] = result_a.tool_results
+      assert [%ToolResult{tool_call_id: "call_b"}] = result_b.tool_results
+    end
   end
 
   describe "configuration validation" do

--- a/test/sagents/middleware/summarization_test.exs
+++ b/test/sagents/middleware/summarization_test.exs
@@ -190,7 +190,15 @@ defmodule Sagents.Middleware.SummarizationTest do
   end
 
   describe "safe cutoff detection" do
-    test "finds safe cutoff point before assistant with tool calls", %{agent_id: agent_id} do
+    test "cuts before an assistant with tool calls, keeping the pair intact", %{
+      agent_id: agent_id
+    } do
+      stub(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Summary")]}
+      end)
+
+      {:ok, config} = summarizing_config(messages_to_keep: 3)
+
       tool_call =
         ToolCall.new!(%{
           call_id: "call_1",
@@ -198,6 +206,8 @@ defmodule Sagents.Middleware.SummarizationTest do
           arguments: %{"q" => "test"}
         })
 
+      # The target cutoff lands on the assistant with tool_calls, so the whole
+      # tool cycle stays on the kept side.
       messages = [
         Message.new_system!("System"),
         Message.new_user!("Message 1"),
@@ -212,24 +222,29 @@ defmodule Sagents.Middleware.SummarizationTest do
         Message.new_user!("Recent message")
       ]
 
-      state = State.new!(%{agent_id: agent_id, messages: messages, metadata: %{model: nil}})
+      state = State.new!(%{agent_id: agent_id, messages: messages})
 
-      config = %{
-        model: nil,
-        max_tokens_before_summary: 10,
-        messages_to_keep: 3,
-        # Would keep: assistant+tool+user (last 3)
-        # Should cut before the assistant with tool_calls
-        summary_prompt: "Summarize",
-        token_counter: fn _msgs -> 1000 end
-      }
+      assert {:ok, %State{messages: updated}} = Summarization.before_model(state, config)
 
-      # Since we can't actually summarize without a model, we'll get an error
-      # but we can test the logic doesn't crash
-      assert {:ok, _result} = Summarization.before_model(state, config)
+      assert [
+               %Message{role: :system},
+               %Message{role: :user},
+               %Message{role: :assistant},
+               %Message{role: :assistant, tool_calls: [%ToolCall{call_id: "call_1"}]},
+               %Message{role: :tool} = kept_result,
+               %Message{role: :user}
+             ] = updated
+
+      assert [%ToolResult{tool_call_id: "call_1"}] = kept_result.tool_results
     end
 
-    test "allows cutting after completed tool cycle", %{agent_id: agent_id} do
+    test "summarizes a completed tool cycle as a unit", %{agent_id: agent_id} do
+      stub(ChatOpenAI, :call, fn _model, _messages, _tools ->
+        {:ok, [Message.new_assistant!("Summary")]}
+      end)
+
+      {:ok, config} = summarizing_config(messages_to_keep: 2)
+
       tool_call =
         ToolCall.new!(%{
           call_id: "call_1",
@@ -237,6 +252,8 @@ defmodule Sagents.Middleware.SummarizationTest do
           arguments: %{"q" => "test"}
         })
 
+      # The target cutoff lands after the tool result, so the call and its
+      # result go into the summary together.
       messages = [
         Message.new_system!("System"),
         Message.new_user!("Search request"),
@@ -246,23 +263,24 @@ defmodule Sagents.Middleware.SummarizationTest do
             ToolResult.new!(%{tool_call_id: "call_1", name: "search", content: "Results"})
           ]
         }),
-        # Safe to cut here - tool cycle is complete
         Message.new_user!("Thanks!"),
         Message.new_assistant!("You're welcome!")
       ]
 
       state = State.new!(%{agent_id: agent_id, messages: messages})
 
-      config = %{
-        model: nil,
-        max_tokens_before_summary: 10,
-        messages_to_keep: 2,
-        # Keep last 2 messages
-        summary_prompt: "Summarize",
-        token_counter: fn _msgs -> 1000 end
-      }
+      assert {:ok, %State{messages: updated}} = Summarization.before_model(state, config)
 
-      assert {:ok, _result} = Summarization.before_model(state, config)
+      assert [
+               %Message{role: :system},
+               %Message{role: :user},
+               %Message{role: :assistant},
+               %Message{role: :user} = kept_user,
+               %Message{role: :assistant} = kept_assistant
+             ] = updated
+
+      assert ContentPart.parts_to_string(kept_user.content) == "Thanks!"
+      assert ContentPart.parts_to_string(kept_assistant.content) == "You're welcome!"
     end
   end
 
@@ -501,6 +519,18 @@ defmodule Sagents.Middleware.SummarizationTest do
       # Should count substantial tokens for long text
       assert tokens > 1000
     end
+  end
+
+  # A config that always trips the token threshold, so `before_model/2` runs a
+  # real (stubbed) compaction rather than short-circuiting.
+  defp summarizing_config(opts) do
+    Summarization.init(
+      [
+        model: ChatOpenAI.new!(%{model: "gpt-4", stream: false}),
+        max_tokens_before_summary: 100,
+        token_counter: fn _msgs -> 1_000 end
+      ] ++ opts
+    )
   end
 
   # Seven messages with an all-text tail so `find_safe_cutoff` (with


### PR DESCRIPTION

## Problem

`Summarization.find_safe_cutoff/2` is supposed to refuse cut points that separate
an assistant's tool calls from their tool results. It currently does the opposite,
in two ways:

1. **Inverted safety check.** `is_safe_cutoff_point?/2` returns
   `has_pending_tool_results?(...)` as the safety value — without a `not`. So
   "this assistant's tool results are on the kept side of the cut" evaluates as
   *safe* (the exact configuration the check exists to prevent), while genuinely
   safe cuts evaluate as unsafe. The backwards search therefore actively prefers
   the orphaning cut.
2. **Tool-result blind spot.** A cut landing immediately after a *tool* message
   falls into the `_other -> true` clause and is declared safe. With consecutive
   tool-result messages (parallel tool calls), the cut lands between results and
   strands the later ones after their originating call is summarized away.

Either defect leaves a `tool` message in the kept tail whose originating assistant
tool call went into the summary. The next model call then fails hard — e.g. the
OpenAI Responses API rejects the request with:

`No tool call found for function call output with call_id …`

Because the compacted message list is persisted, the conversation fails on every
subsequent turn. Hit in real usage on the first compaction of a tool-heavy
conversation; not caught earlier because no test drove an actual compaction with
tool messages in the cut region (the tests added in #164 use text-only
conversations).

## Solution

`is_safe_cutoff_point?/2` now evaluates both sides of the cut:

- **Unsafe if the first kept message is a tool result** — its originating call
  would be summarized away. This single rule covers the parallel/consecutive
  results case and every other orphan shape, without call-id bookkeeping.
- **Unsafe if the last summarized message is an assistant with tool calls whose
  results follow on the kept side** — the original intent, now correctly negated.

Fallback behavior is unchanged: when no safe point exists, the middleware keeps
all messages. The moduledoc's "Safe Cutoff Algorithm" section is updated to match.

## Tests

Two regressions drive real (stubbed) compactions and assert the full post-compaction
message shape:

- the target cutoff landing exactly between an assistant's tool call and its result
- the target cutoff landing between consecutive results from parallel tool calls

Both reproduce the orphaned-tool-result shape against the pre-fix code.