### PR TITLE
Guard registry lookups so draining nodes fail loudly, not wrongly

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -188,4 +188,19 @@ Horde.Cluster.members(Sagents.FileSystem.FileSystemSupervisor)
 
 # Total registered entries cluster-wide:
 Sagents.ProcessRegistry.count()
+
+# Can THIS node answer lookups at all? False while starting, and after
+# Sagents.Supervisor has shut down while the BEAM drains.
+Sagents.ready?()
 ```
+
+## Taking a node out of the cluster
+
+Membership handles a node *leaving*. It does not handle the window where the
+node has stopped its Sagents supervision tree but is still receiving HTTP
+traffic, which is every rolling deploy. Requests arriving in that window cannot
+be served on that node no matter how healthy the rest of the cluster is.
+
+See [Deployments, draining, and readiness](deployment.md) for the readiness
+signal (`Sagents.ready?/0`), the required shutdown sequence, and platform
+examples.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,261 @@
+# Deployments, draining, and readiness
+
+This guide covers what has to happen when a node goes away: a rolling deploy, a
+scale-down, a machine migration, a restart. It applies to `:local` and `:horde`
+alike, and it matters more the more nodes you run.
+
+The short version:
+
+> A node stops being able to serve agent requests **the moment
+> `Sagents.Supervisor` shuts down**, but it keeps accepting TCP connections for
+> the rest of the platform's grace period. If your load balancer is still
+> routing there, every one of those requests fails. Tell the platform the node
+> is not ready *before* you let the supervision tree stop.
+
+## The problem, concretely
+
+`Sagents.Registry` is the map from `agent_id` to a process. Every agent lookup
+reads it. It lives in ETS tables owned by the registry process on the local
+node, so when that process stops, the tables go with it.
+
+On SIGTERM, OTP shuts your application's supervision tree down in reverse child
+order. `Sagents.Supervisor` and its registry terminate. **The BEAM keeps running
+after that** for however long the platform allows, commonly 30 to 60 seconds.
+During that window:
+
+- the node still holds open connections and still accepts new ones,
+- but no agent lookup on it can succeed,
+- and no retry helps, because the registry is not coming back on this node.
+
+This is not a race with a small window. It is a stable condition for the whole
+drain period. It is also **local**: other nodes in the cluster are healthy and
+can serve the request perfectly well. That is what makes it a routing problem
+rather than an outage.
+
+## The sequence you need
+
+```
+1. platform signals shutdown
+2. node reports NOT ready          <-- Sagents.ready?() goes false
+3. load balancer stops routing to it
+4. in-flight requests finish
+5. supervision tree stops           <-- registry goes away here
+6. BEAM exits
+```
+
+Out of the box, only steps 5 and 6 happen. Steps 2 through 4 are yours to wire
+up, and they are the whole fix. The library gives you the signal for step 2 and
+a clean error if a request slips through anyway.
+
+## Step 1: readiness, not liveness
+
+`Sagents.ready?/0` answers whether this node can host and route agent sessions.
+Wire it into your **readiness** check. Do not wire it into a liveness check: a
+draining node is not unhealthy, and restarting it is the wrong response.
+
+```elixir
+# lib/my_app_web/controllers/health_controller.ex
+defmodule MyAppWeb.HealthController do
+  use MyAppWeb, :controller
+
+  # Liveness: is the BEAM up at all? Never consults Sagents.
+  def alive(conn, _params), do: send_resp(conn, 200, "ok")
+
+  # Readiness: should this node receive traffic?
+  def ready(conn, _params) do
+    if Sagents.ready?() do
+      send_resp(conn, 200, "ok")
+    else
+      send_resp(conn, 503, "draining")
+    end
+  end
+end
+```
+
+```elixir
+# lib/my_app_web/router.ex
+scope "/health", MyAppWeb do
+  get "/alive", HealthController, :alive
+  get "/ready", HealthController, :ready
+end
+```
+
+Keep these routes outside any authentication pipeline, and outside any plug that
+itself touches Sagents.
+
+## Step 2: supervision tree order
+
+`Sagents.Supervisor` must come **before** your Endpoint:
+
+```elixir
+children = [
+  MyApp.Repo,
+  {Phoenix.PubSub, name: MyApp.PubSub},
+  MyAppWeb.Presence,
+  Sagents.Supervisor,
+  MyAppWeb.Endpoint      # after, so OTP stops it FIRST
+]
+```
+
+OTP shuts children down in reverse order. Listed this way, the Endpoint stops
+accepting requests first and the registry is still alive to serve whatever is
+already in flight. Listed the other way around, the Endpoint outlives the
+registry and serves the entire drain period with a dead registry underneath it.
+
+Correct ordering narrows the window. It does not remove it: the node is still
+reachable by the load balancer until the platform stops sending traffic, which
+is what step 1 is for. Do both.
+
+## Step 3: give the platform time to notice
+
+A readiness check that flips to `false` at the same instant the tree comes down
+buys you nothing. The platform needs to poll it, observe the change, and update
+its routing table before shutdown proceeds. That is what a pre-stop hook or a
+drain delay is for.
+
+The general principle, whatever the platform:
+
+1. Intercept the shutdown signal.
+2. Make readiness report false.
+3. Wait longer than `(readiness poll interval × unhealthy threshold)`, plus the
+   time your longest ordinary request takes.
+4. Only then let the supervision tree stop.
+
+### Fly.io
+
+Fly sends `SIGINT` first (then `SIGTERM` after `kill_timeout`). Set a
+`kill_timeout` that covers your drain, and make sure your health check interval
+is short enough that the proxy notices within it.
+
+```toml
+# fly.toml
+kill_signal = "SIGINT"
+kill_timeout = "45s"
+
+[[services.http_checks]]
+  path = "/health/ready"
+  interval = "5s"
+  timeout = "2s"
+  grace_period = "10s"
+```
+
+With a 5 second interval, the proxy notices within a few seconds of readiness
+flipping, so a 45 second `kill_timeout` leaves plenty of room. Handle the signal
+so the wait happens before the tree stops, for example by trapping it in a small
+process started *before* `Sagents.Supervisor` in your tree, or by using a
+release `pre_stop` hook.
+
+If you run agents in more than one region, read the partition section of
+[Clustering](clustering.md) as well: `fly-replay` routing a request to the wrong
+region has a different and worse failure mode than draining does.
+
+### Kubernetes
+
+```yaml
+readinessProbe:
+  httpGet: { path: /health/ready, port: 4000 }
+  periodSeconds: 5
+  failureThreshold: 2
+
+lifecycle:
+  preStop:
+    exec:
+      command: ["sleep", "20"]
+
+terminationGracePeriodSeconds: 60
+```
+
+`preStop` runs before `SIGTERM` is delivered, and endpoint removal happens
+concurrently with it, so the sleep is what gives the service mesh time to stop
+routing. `terminationGracePeriodSeconds` must exceed the `preStop` sleep plus
+your longest request.
+
+## Step 4: handle the error if one slips through
+
+Even with all of the above, a request can arrive mid-transition. Sagents reports
+that as a value rather than raising, so you can answer it correctly:
+
+```elixir
+case Sagents.Session.ensure_running(config, socket.assigns, request_opts: opts) do
+  {:ok, changes} ->
+    assign(socket, changes)
+
+  {:error, :registry_unavailable} ->
+    # This node is draining. Another node can serve this fine.
+    {:error, message: "Service is restarting, please retry", code: 503}
+
+  {:error, reason} ->
+    {:error, message: "Could not start session: #{inspect(reason)}"}
+end
+```
+
+**Answer 503, not 500.** A 500 says the request cannot be served. A 503 says it
+cannot be served *here*, which is true, and it is the answer clients and load
+balancers know how to retry.
+
+The same `{:error, :registry_unavailable}` is returned by `Sagents.Session.start/3`,
+`resume/4`, `dismiss/3` and `stop/2`, by `Sagents.AgentServer.fetch_pid/1`, and
+by the `Sagents.AgentServer` lifecycle calls (`execute/1`, `cancel/1`,
+`resume/2`, `add_message/3`, `reset/1`, `dismiss_interrupt/1`).
+
+### Why it is not just `nil`
+
+`:registry_unavailable` is deliberately **not** folded into "no agent is
+running". They mean different things and require different responses:
+
+| answer | meaning | correct response |
+| --- | --- | --- |
+| `{:error, :not_running}` | the registry answered; nothing is running | start an agent |
+| `{:error, :registry_unavailable}` | the registry could not answer | retry elsewhere |
+
+If the second were reported as the first, every request during every drain would
+start a *new* agent for a conversation that already has one somewhere else. Two
+processes would then hold and persist state for the same conversation, silently.
+That is why the distinction is load-bearing rather than cosmetic.
+
+A handful of functions cannot express the condition in their return value:
+`Sagents.AgentServer.get_pid/1` returns `pid() | nil`,
+`Sagents.Session.running?/2` returns a boolean, and
+`Sagents.ProcessRegistry.select/1` returns a list. Those **raise**
+`Sagents.RegistryUnavailableError` rather than answering with a plausible
+default. On request paths, prefer the tuple-returning forms
+(`fetch_pid/1`, `ensure_running/3`, `Sagents.ProcessRegistry.fetch/1`).
+
+## What happens to running agents
+
+Agent state is durable, which is what makes all of this recoverable.
+
+- **Graceful shutdown.** Agents terminate, persist their state, and broadcast a
+  shutdown event. Under `:horde`, surviving members pick up the work when a
+  request next asks for it.
+- **A node vanishing abruptly.** Horde detects the departure and redistributes.
+  The new process starts from persisted state.
+- **The next request either way.** `Sagents.Session.ensure_running/3` starts the
+  agent from persisted state on whichever node handles it. A conversation that
+  was mid-run resumes as a fresh run rather than continuing the interrupted one.
+
+So a deploy costs you in-flight LLM turns, not conversations. Sizing your drain
+window is a question of how long you are willing to wait for those turns, not of
+whether state survives.
+
+## Verifying it
+
+The failure mode this guide exists to prevent has direct test coverage in
+`test/sagents/horde/rolling_deploy_test.exs`, which drives real Erlang nodes
+through a shutdown while probing them:
+
+```bash
+mix test test/sagents/horde/rolling_deploy_test.exs --include cluster --include slow
+```
+
+To check your own application, hit `/health/ready` while a deploy is in flight
+and confirm it reports 503 before the node stops answering agent requests. If
+readiness is still reporting 200 at the moment lookups start failing, steps 1
+through 3 are not wired correctly.
+
+## Related
+
+- [Clustering & distribution (Horde)](clustering.md) for membership, placement,
+  and partitioning.
+- [Lifecycle](lifecycle.md) for what an individual agent does on shutdown.
+- [Persistence](persistence.md) for what survives and how it is restored.

--- a/lib/sagents.ex
+++ b/lib/sagents.ex
@@ -97,4 +97,37 @@ defmodule Sagents do
   See `Sagents.Agent` for agent creation and execution, and `Sagents.State` for
   state management functions.
   """
+
+  @doc """
+  Whether this node can currently host and route agent sessions.
+
+  Wire this into your application's **readiness** check (not its liveness
+  check). It reports `false` in exactly two situations, both normal:
+
+  - the node has not finished starting `Sagents.Supervisor`, and
+  - `Sagents.Supervisor` has shut down while the BEAM is still draining, which
+    is every rolling deploy.
+
+  In that second window the node is still reachable and will still accept HTTP
+  connections, but every agent lookup on it fails. A readiness check that
+  ignores this keeps the load balancer routing requests to a node that cannot
+  serve them. See `docs/deployment.md` for the full sequence and a Fly.io
+  example.
+
+  ## Examples
+
+      # Phoenix router
+      get "/ready", MyAppWeb.HealthController, :ready
+
+      # Controller
+      def ready(conn, _params) do
+        if Sagents.ready?() do
+          send_resp(conn, 200, "ok")
+        else
+          send_resp(conn, 503, "draining")
+        end
+      end
+  """
+  @spec ready?() :: boolean()
+  def ready?, do: Sagents.ProcessRegistry.available?()
 end

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -511,16 +511,62 @@ defmodule Sagents.AgentServer do
   @doc """
   Get the pid of the AgentServer process for a specific agent.
 
+  Returns `nil` when no AgentServer is registered for `agent_id`.
+
+  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
+  answer at all, which happens while the node is starting and while it drains
+  during a rolling deploy. Returning `nil` there would be indistinguishable from
+  "not running", and callers act on that by starting a duplicate agent. Use
+  `fetch_pid/1` on request paths, where the condition is a value rather than a
+  raise.
+
   ## Examples
 
-      pid = AgentServer.get_pit("my-agent-1")
+      pid = AgentServer.get_pid("my-agent-1")
       send(pid, message)
   """
-  @spec get_pid(String.t()) :: pid() | {atom(), node()} | nil
+  @spec get_pid(String.t()) :: pid() | nil
   def get_pid(agent_id) when is_binary(agent_id) do
-    agent_id
-    |> get_name()
-    |> GenServer.whereis()
+    case fetch_pid(agent_id) do
+      {:ok, pid} ->
+        pid
+
+      {:error, :not_running} ->
+        nil
+
+      {:error, :registry_unavailable} ->
+        raise Sagents.RegistryUnavailableError, operation: :"AgentServer.get_pid/1"
+    end
+  end
+
+  @doc """
+  Get the pid of the AgentServer for `agent_id`, without raising.
+
+  The three outcomes are kept distinct on purpose:
+
+  - `{:ok, pid}` - an AgentServer is running
+  - `{:error, :not_running}` - the registry answered, no AgentServer is registered
+  - `{:error, :registry_unavailable}` - this node's registry could not answer
+
+  Prefer this over `get_pid/1` anywhere a web request can reach, and map
+  `:registry_unavailable` to a retryable response (503) rather than a 500. The
+  cluster can serve the request, just not on this node. See `docs/deployment.md`.
+
+  ## Examples
+
+      case AgentServer.fetch_pid("my-agent-1") do
+        {:ok, pid} -> send(pid, message)
+        {:error, :not_running} -> start_it()
+        {:error, :registry_unavailable} -> {:error, :draining}
+      end
+  """
+  @spec fetch_pid(String.t()) :: {:ok, pid()} | {:error, :not_running | :registry_unavailable}
+  def fetch_pid(agent_id) when is_binary(agent_id) do
+    case ProcessRegistry.fetch({:agent_server, agent_id}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, :not_registered} -> {:error, :not_running}
+      {:error, :registry_unavailable} = error -> error
+    end
   end
 
   @doc """
@@ -936,7 +982,7 @@ defmodule Sagents.AgentServer do
   @doc false
   @spec get_state(String.t()) :: State.t()
   def get_state(agent_id) do
-    GenServer.call(get_name(agent_id), :get_state)
+    call!(agent_id, :get_state)
   end
 
   @doc """
@@ -958,7 +1004,7 @@ defmodule Sagents.AgentServer do
   @spec get_status(String.t()) :: status() | :not_running
   def get_status(agent_id) do
     try do
-      GenServer.call(get_name(agent_id), :get_status)
+      call!(agent_id, :get_status)
     catch
       :exit, _reason ->
         :not_running
@@ -980,7 +1026,7 @@ defmodule Sagents.AgentServer do
   """
   @spec get_info(String.t()) :: map()
   def get_info(agent_id) do
-    GenServer.call(get_name(agent_id), :get_info)
+    call!(agent_id, :get_info)
   end
 
   @doc """
@@ -1208,13 +1254,13 @@ defmodule Sagents.AgentServer do
       when is_binary(agent_id) and is_list(opts) do
     # Cheap, non-blocking guard. Mirrors TodoList.save_todo_snapshot/2 so unit
     # tests and serverless Agent.execute/3 degrade to a reportable no-op rather
-    # than raising out of a tool body.
-    case GenServer.whereis(get_name(agent_id)) do
-      nil ->
-        {:error, :no_server}
-
-      _pid ->
-        GenServer.cast(get_name(agent_id), {:queue_message, message, opts})
+    # than raising out of a tool body. A draining node folds into the same
+    # no-server answer: this runs inside tool code, which has no better move
+    # than its fallback path, and raising out of a tool body is exactly what
+    # the guard exists to prevent.
+    case fetch_pid(agent_id) do
+      {:ok, pid} -> GenServer.cast(pid, {:queue_message, message, opts})
+      {:error, _reason} -> {:error, :no_server}
     end
   end
 
@@ -1271,7 +1317,7 @@ defmodule Sagents.AgentServer do
   """
   @spec get_inactivity_status(String.t()) :: map()
   def get_inactivity_status(agent_id) do
-    GenServer.call(get_name(agent_id), :get_inactivity_status)
+    call!(agent_id, :get_inactivity_status)
   end
 
   @doc """
@@ -1311,6 +1357,7 @@ defmodule Sagents.AgentServer do
   """
   @spec stop(String.t()) :: :ok
   def stop(agent_id) do
+    ProcessRegistry.ensure_available!(:"AgentServer.stop/1")
     GenServer.stop(get_name(agent_id))
   end
 
@@ -1341,7 +1388,7 @@ defmodule Sagents.AgentServer do
   """
   @spec export_state(String.t()) :: map()
   def export_state(agent_id) do
-    GenServer.call(get_name(agent_id), :export_state)
+    call!(agent_id, :export_state)
   end
 
   @doc """
@@ -1363,7 +1410,7 @@ defmodule Sagents.AgentServer do
   """
   @spec restore_state(String.t(), map()) :: :ok | {:error, term()}
   def restore_state(agent_id, persisted_state) when is_map(persisted_state) do
-    GenServer.call(get_name(agent_id), {:restore_state, persisted_state})
+    call!(agent_id, {:restore_state, persisted_state})
   end
 
   @doc """
@@ -1395,7 +1442,7 @@ defmodule Sagents.AgentServer do
   - `{:error, reason}` - If agent server is not running or update fails
   """
   def update_agent_and_state(agent_id, agent, state) do
-    GenServer.call(get_name(agent_id), {:update_agent_and_state, agent, state})
+    call!(agent_id, {:update_agent_and_state, agent, state})
   end
 
   @doc """
@@ -4048,18 +4095,42 @@ defmodule Sagents.AgentServer do
     Sagents.Presence.untrack(presence_mod, @agent_presence_topic, agent_id)
   end
 
-  # Wrap GenServer.call against an agent's via-tuple name with try/catch so
-  # callers get a clear {:error, :agent_not_running} tuple when the
-  # AgentServer has shut down (inactivity timeout, supervisor restart, Horde
-  # migration in flight) instead of a raw `(EXIT) no process` signal.
+  # Wrap GenServer.call against an agent with try/catch so callers get a clear
+  # {:error, :agent_not_running} tuple when the AgentServer has shut down
+  # (inactivity timeout, supervisor restart, Horde migration in flight) instead
+  # of a raw `(EXIT) no process` signal.
   #
   # Same intent as the existing pattern in `get_metadata/1` and `get_agent/1`,
-  # but routed through the via-tuple registry name so a single helper covers
-  # every lifecycle-action callsite (execute/1, cancel/1, resume/2,
-  # add_message/2, reset/1).
+  # but routed through the registry so a single helper covers every
+  # lifecycle-action callsite (execute/1, cancel/1, resume/2, add_message/2,
+  # reset/1).
+  #
+  # Resolves the pid through fetch_pid/1 rather than handing GenServer.call a
+  # via-tuple. GenServer.call resolves a via name itself, and that resolution
+  # raises out of :ets while this node's registry is unavailable, which covers
+  # the whole drain window of a rolling deploy. fetch_pid/1 makes it a value the
+  # caller can act on, so this helper is the single guard point for the
+  # lifecycle API.
   defp safe_call(agent_id, request, timeout \\ 5000) do
-    GenServer.call(get_name(agent_id), request, timeout)
+    case fetch_pid(agent_id) do
+      {:ok, pid} -> GenServer.call(pid, request, timeout)
+      {:error, :not_running} -> {:error, :agent_not_running}
+      {:error, :registry_unavailable} = error -> error
+    end
   catch
     :exit, _reason -> {:error, :agent_not_running}
   end
+
+  # For calls whose return shape has no room for an error tuple. Raises a named
+  # Sagents.RegistryUnavailableError when the registry cannot answer, so the
+  # condition is diagnosable and is never reported as a plausible-looking
+  # default value.
+  defp call!(agent_id, request, timeout \\ 5000) do
+    ProcessRegistry.ensure_available!(:"AgentServer.#{elem_name(request)}")
+    GenServer.call(get_name(agent_id), request, timeout)
+  end
+
+  defp elem_name(request) when is_atom(request), do: request
+  defp elem_name(request) when is_tuple(request), do: elem(request, 0)
+  defp elem_name(_request), do: :call
 end

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -4130,7 +4130,8 @@ defmodule Sagents.AgentServer do
     GenServer.call(get_name(agent_id), request, timeout)
   end
 
+  # Every call!/3 request is either a bare atom or a tagged tuple, so these two
+  # clauses are exhaustive. No catch-all: dialyzer proves it unreachable.
   defp elem_name(request) when is_atom(request), do: request
   defp elem_name(request) when is_tuple(request), do: elem(request, 0)
-  defp elem_name(_request), do: :call
 end

--- a/lib/sagents/agent_supervisor.ex
+++ b/lib/sagents/agent_supervisor.ex
@@ -97,16 +97,22 @@ defmodule Sagents.AgentSupervisor do
   @doc """
   Get the PID of an AgentSupervisor by agent_id.
 
+  `{:error, :registry_unavailable}` means this node's registry could not answer,
+  not that nothing is running. It is deliberately distinct from `:not_found`:
+  treating it as "not found" makes callers start a second AgentSupervisor for an
+  agent that already has one. See `docs/deployment.md`.
+
   ## Examples
 
       {:ok, pid} = AgentSupervisor.get_pid("my-agent-1")
       {:error, :not_found} = AgentSupervisor.get_pid("non-existent")
   """
-  @spec get_pid(String.t()) :: {:ok, pid()} | {:error, :not_found}
+  @spec get_pid(String.t()) :: {:ok, pid()} | {:error, :not_found | :registry_unavailable}
   def get_pid(agent_id) when is_binary(agent_id) do
-    case ProcessRegistry.lookup({:agent_supervisor, agent_id}) do
-      [{pid, _value}] -> {:ok, pid}
-      [] -> {:error, :not_found}
+    case ProcessRegistry.fetch({:agent_supervisor, agent_id}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, :not_registered} -> {:error, :not_found}
+      {:error, :registry_unavailable} = error -> error
     end
   end
 
@@ -448,8 +454,8 @@ defmodule Sagents.AgentSupervisor do
   end
 
   defp do_wait_for_agent_ready(agent_id, deadline, retry_delay_ms, attempt) do
-    case AgentServer.get_pid(agent_id) do
-      nil ->
+    case AgentServer.fetch_pid(agent_id) do
+      {:error, :not_running} ->
         now = System.monotonic_time(:millisecond)
         time_left = deadline - now
 
@@ -473,8 +479,14 @@ defmodule Sagents.AgentSupervisor do
           do_wait_for_agent_ready(agent_id, deadline, next_delay, attempt + 1)
         end
 
-      pid when is_pid(pid) ->
+      {:ok, pid} when is_pid(pid) ->
         :ok
+
+      {:error, :registry_unavailable} = error ->
+        # This node is starting down while an agent is starting up. Retrying
+        # cannot succeed here, so surface the condition instead of spending the
+        # whole timeout on it.
+        error
     end
   end
 end

--- a/lib/sagents/agents_dynamic_supervisor.ex
+++ b/lib/sagents/agents_dynamic_supervisor.ex
@@ -244,7 +244,8 @@ defmodule Sagents.AgentsDynamicSupervisor do
       :ok = AgentsDynamicSupervisor.stop_agent("conversation-123")
       :ok = AgentsDynamicSupervisor.stop_agent("conversation-123", reason: :shutdown, timeout: 5000)
   """
-  @spec stop_agent(String.t(), keyword()) :: :ok | {:error, :not_found}
+  @spec stop_agent(String.t(), keyword()) ::
+          :ok | {:error, :not_found | :registry_unavailable}
   def stop_agent(agent_id, opts \\ []) when is_binary(agent_id) do
     supervisor = Keyword.get(opts, :supervisor, __MODULE__)
 
@@ -254,7 +255,7 @@ defmodule Sagents.AgentsDynamicSupervisor do
         Logger.debug("Stopped AgentSupervisor for agent_id=#{agent_id}")
         :ok
 
-      {:error, :not_found} = error ->
+      {:error, _reason} = error ->
         error
     end
   end
@@ -350,6 +351,11 @@ defmodule Sagents.AgentsDynamicSupervisor do
         else
           {:error, :timeout_waiting_for_agent}
         end
+
+      {:error, :registry_unavailable} = error ->
+        # The node started shutting down mid-start. Polling cannot succeed
+        # again on this node, so fail fast instead of burning the timeout.
+        error
     end
   end
 end

--- a/lib/sagents/process_registry.ex
+++ b/lib/sagents/process_registry.ex
@@ -19,6 +19,35 @@ defmodule Sagents.ProcessRegistry do
 
   When `:horde` is selected, Horde.Registry is started with `members: :auto`
   so it automatically discovers other nodes in the Erlang cluster.
+
+  ## Availability
+
+  A lookup can only be answered while the registry process is alive on *this*
+  node. Two normal situations leave it unavailable: the node has not finished
+  starting `Sagents.Supervisor`, and `Sagents.Supervisor` has shut down while
+  the BEAM drains during a rolling deploy. In that second window the node is
+  still reachable by a load balancer but can serve no agent request at all.
+
+  Neither backend reports this condition on its own. `Horde.Registry.lookup/2`
+  derives its ETS table name arithmetically and reads it unguarded, and Elixir's
+  `Registry` does the same through `Registry.key_info!/1`, so both raise
+  `ArgumentError` from inside `:ets` when the table's owning process is gone.
+  This module puts a guard in front of them so the condition is reported rather
+  than escaping as an `:ets` error:
+
+  - `available?/0` reports it as a boolean.
+  - `fetch/1` returns `{:error, :registry_unavailable}`, distinct from
+    `{:error, :not_registered}`.
+  - `lookup/1`, `select/1`, `count/0` and `keys/1` cannot express it in their
+    return values, so they raise `Sagents.RegistryUnavailableError`.
+
+  **`:registry_unavailable` must never be collapsed into "not registered".**
+  A caller that reads "nothing is running" responds by starting an agent, so
+  collapsing the two lets a draining node start a second agent for a
+  conversation that already has one elsewhere. Both would then hold and persist
+  state for the same conversation, with nothing reporting it.
+
+  See `Sagents.ready?/0` and `docs/deployment.md`.
   """
 
   @compile {:no_warn_undefined, [Horde.Registry, Sagents.Horde.RegistryImpl]}
@@ -65,22 +94,110 @@ defmodule Sagents.ProcessRegistry do
   end
 
   @doc """
+  Whether this node's registry can currently answer lookups.
+
+  `false` while the node is still starting `Sagents.Supervisor`, and after that
+  supervisor has shut down while the BEAM drains during a rolling deploy.
+
+  Checks the ETS table each backend actually reads, rather than the registry
+  process name, because the table is what the read touches and what its owner
+  takes with it when it dies.
+
+  ## Examples
+
+      if Sagents.ProcessRegistry.available?() do
+        # this node can host and route agent sessions
+      end
+  """
+  @spec available?() :: boolean()
+  def available? do
+    :ets.whereis(keys_table_name()) != :undefined
+  end
+
+  @doc """
+  Raise `Sagents.RegistryUnavailableError` unless the registry can answer.
+
+  Used by the functions here whose return shape cannot carry the condition.
+  `operation` names the caller and appears in the message.
+  """
+  @spec ensure_available!(atom() | nil) :: :ok
+  def ensure_available!(operation \\ nil) do
+    if available?() do
+      :ok
+    else
+      raise Sagents.RegistryUnavailableError, operation: operation, registry: @registry_name
+    end
+  end
+
+  @doc """
+  Look up a single process by key, without raising on an unavailable registry.
+
+  This is the form to use on request paths. The three outcomes are kept
+  distinct on purpose:
+
+  - `{:ok, pid}` - registered and alive
+  - `{:error, :not_registered}` - the registry answered, nothing is registered
+  - `{:error, :registry_unavailable}` - the registry could not answer at all
+
+  The second and third must stay distinct in whatever the caller does next.
+  "Nothing is registered" means start one; "cannot answer" means this node
+  cannot know, so it must not guess, because guessing produces a duplicate
+  agent for a conversation that already has one on another node.
+
+  ## Examples
+
+      case Sagents.ProcessRegistry.fetch({:agent_server, "agent-123"}) do
+        {:ok, pid} -> GenServer.call(pid, :get_status)
+        {:error, :not_registered} -> {:error, :agent_not_running}
+        {:error, :registry_unavailable} = error -> error
+      end
+  """
+  @spec fetch(term()) :: {:ok, pid()} | {:error, :not_registered | :registry_unavailable}
+  def fetch(key) do
+    if available?() do
+      case registry_module().lookup(@registry_name, key) do
+        [{pid, _value}] -> {:ok, pid}
+        [] -> {:error, :not_registered}
+      end
+    else
+      {:error, :registry_unavailable}
+    end
+  rescue
+    error in ArgumentError ->
+      # The registry went away between the check above and the read. Re-check
+      # rather than swallowing every ArgumentError, so a genuine argument bug
+      # still surfaces as itself.
+      if available?() do
+        reraise(error, __STACKTRACE__)
+      else
+        {:error, :registry_unavailable}
+      end
+  end
+
+  @doc """
   Look up a process by key.
 
   Returns `[{pid, value}]` if found, `[]` otherwise.
+
+  Raises `Sagents.RegistryUnavailableError` when the registry cannot answer,
+  because `[]` would be indistinguishable from "not registered". Prefer
+  `fetch/1` on request paths.
 
   ## Examples
 
       [{pid, _}] = Sagents.ProcessRegistry.lookup({:agent_server, "agent-123"})
   """
   def lookup(key) do
-    registry_module().lookup(@registry_name, key)
+    guarded(:lookup, fn -> registry_module().lookup(@registry_name, key) end)
   end
 
   @doc """
   Select processes matching a match specification.
 
   The match spec format is the same as `Registry.select/2`.
+
+  Raises `Sagents.RegistryUnavailableError` when the registry cannot answer, so
+  a draining node never reports an empty list as though it were a real result.
 
   ## Examples
 
@@ -89,18 +206,24 @@ defmodule Sagents.ProcessRegistry do
       ])
   """
   def select(match_spec) do
-    registry_module().select(@registry_name, match_spec)
+    guarded(:select, fn -> registry_module().select(@registry_name, match_spec) end)
   end
 
   @doc """
   Returns the count of all registered entries.
+
+  Raises `Sagents.RegistryUnavailableError` when the registry cannot answer, so
+  a draining node never reports a truthful-looking `0`.
   """
   def count do
-    registry_module().count(@registry_name)
+    guarded(:count, fn -> registry_module().count(@registry_name) end)
   end
 
   @doc """
   Returns the keys for the given process `pid`.
+
+  Raises `Sagents.RegistryUnavailableError` when the registry cannot answer, so
+  a draining node never reports an empty list as though it were a real result.
 
   ## Examples
 
@@ -108,7 +231,7 @@ defmodule Sagents.ProcessRegistry do
       # => [{:agent_supervisor, "agent-123"}]
   """
   def keys(pid) do
-    registry_module().keys(@registry_name, pid)
+    guarded(:keys, fn -> registry_module().keys(@registry_name, pid) end)
   end
 
   @doc """
@@ -132,6 +255,39 @@ defmodule Sagents.ProcessRegistry do
 
   defp distribution_type do
     Application.get_env(:sagents, :distribution, :local)
+  end
+
+  # The named ETS table each backend reads on a key lookup, and which its owning
+  # process destroys when it exits.
+  #
+  #   - Horde: `Horde.RegistryImpl` creates `:"keys_<name>"` in init/1, and
+  #     `Horde.Registry.lookup/2` reads it via `:"keys_#{registry}"`.
+  #   - Elixir Registry: the table is named after the registry itself, and
+  #     `Registry.key_info!/1` reads it.
+  defp keys_table_name do
+    case distribution_type() do
+      :local -> @registry_name
+      :horde -> :"keys_#{@registry_name}"
+    end
+  end
+
+  # Run a registry read that cannot report unavailability in its return value.
+  # Checks first, and re-checks on ArgumentError to cover the small window
+  # between the check and the read without swallowing unrelated argument errors.
+  defp guarded(operation, fun) do
+    ensure_available!(operation)
+    fun.()
+  rescue
+    error in ArgumentError ->
+      if available?() do
+        reraise(error, __STACKTRACE__)
+      else
+        reraise(
+          Sagents.RegistryUnavailableError,
+          [operation: operation, registry: @registry_name],
+          __STACKTRACE__
+        )
+      end
   end
 
   defp assert_horde_available! do

--- a/lib/sagents/registry_unavailable_error.ex
+++ b/lib/sagents/registry_unavailable_error.ex
@@ -1,0 +1,69 @@
+defmodule Sagents.RegistryUnavailableError do
+  @moduledoc """
+  Raised when `Sagents.Registry` cannot answer on this node.
+
+  This is a **lifecycle condition, not a bug**. The registry is unavailable in
+  two normal situations:
+
+  - the node has not finished starting `Sagents.Supervisor` yet, or
+  - `Sagents.Supervisor` has already shut down while the BEAM is still running,
+    which is the drain window of a rolling deploy.
+
+  During that second window the node is still reachable by a load balancer while
+  being unable to host or route agent sessions. See `Sagents.ready?/0` and
+  `docs/deployment.md`.
+
+  ## Why an exception here
+
+  Functions whose return shape can express the condition report
+  `{:error, :registry_unavailable}` rather than raising. This exception covers
+  the ones whose shape cannot, such as `Sagents.AgentServer.get_pid/1`
+  (`pid() | nil`) and `Sagents.ProcessRegistry.select/1` (a list).
+
+  Those functions raise rather than answering `nil` or `[]`, because a caller
+  reads "nothing is registered" as "nothing is running" and responds by starting
+  an agent. On a draining node that produces a duplicate for a conversation that
+  already has one elsewhere, silently. A loud, named error is the safer answer.
+
+  ## Handling it
+
+  Prefer the tuple-returning APIs on request paths:
+
+      case Sagents.Session.ensure_running(config, assigns, opts) do
+        {:ok, changes} -> ...
+        {:error, :registry_unavailable} -> send_resp(conn, 503, "draining")
+        {:error, reason} -> ...
+      end
+  """
+
+  defexception [:operation, :registry]
+
+  @type t :: %__MODULE__{operation: atom() | nil, registry: atom() | nil}
+
+  @impl true
+  def exception(opts) when is_list(opts) do
+    %__MODULE__{
+      operation: Keyword.get(opts, :operation),
+      registry: Keyword.get(opts, :registry, Sagents.ProcessRegistry.registry_name())
+    }
+  end
+
+  @impl true
+  def message(%__MODULE__{operation: operation, registry: registry}) do
+    """
+    #{inspect(registry)} is not available on this node#{operation_suffix(operation)}.
+
+    The registry process is not running, so lookups cannot be answered. This
+    happens while the node is still starting up, and after Sagents.Supervisor
+    has shut down while the BEAM drains during a rolling deploy.
+
+    If this surfaced from a web request, the node was still receiving traffic
+    after it stopped being able to serve it. Wire Sagents.ready?/0 into your
+    readiness check so the load balancer stops routing here first. See
+    docs/deployment.md.
+    """
+  end
+
+  defp operation_suffix(nil), do: ""
+  defp operation_suffix(operation), do: " (called from #{operation})"
+end

--- a/lib/sagents/registry_watcher.ex
+++ b/lib/sagents/registry_watcher.ex
@@ -1,0 +1,124 @@
+defmodule Sagents.RegistryWatcher do
+  @moduledoc """
+  Propagates a registry restart into `Sagents.Supervisor`'s `:rest_for_one`
+  restart chain.
+
+  ## What it protects
+
+  Every `AgentSupervisor` and `AgentServer` registers its `:via` name in
+  `Sagents.Registry` exactly once, when it starts, and nothing re-registers it
+  afterwards. A registry that loses its contents therefore leaves those
+  processes running but invisible to every lookup. Lookups answer "nothing is
+  running", the next request responds by starting an agent, and the conversation
+  ends up with two AgentServers holding and persisting state for it, with
+  nothing reporting the conflict.
+
+  `Sagents.Supervisor` uses `:rest_for_one` so a registry failure restarts
+  everything listed after it, which re-establishes those registrations. The
+  watcher is what connects a registry failure to that chain, because the failure
+  happens one level below where the strategy can see it:
+
+      Sagents.Supervisor
+      └── Sagents.Horde.RegistryImpl   <- the child Sagents.Supervisor supervises (a supervisor)
+          ├── Horde.RegistryImpl       <- the process registered as Sagents.Registry
+          └── Sagents.Registry.Crdt
+
+  `Horde.Registry.start_link/3` starts a supervisor, and the process registered
+  under the name is its child. When that child crashes, Horde's own supervisor
+  restarts it with fresh, empty ETS tables, so `Sagents.Supervisor` sees no
+  failed child of its own. Elixir's `Registry` is shaped the same way.
+
+  This watcher monitors the process registered as `Sagents.Registry` directly
+  and stops when it dies. Listed immediately after the registry in
+  `Sagents.Supervisor`, its stop is a child failure the `:rest_for_one` strategy
+  does act on, taking the agent and filesystem supervisors down with it. Agents
+  stop, and the next request re-creates them from persisted state with fresh
+  registrations.
+
+  ## The trade being made
+
+  A registry crash costs running agents rather than leaving duplicates behind.
+  That is deliberate. Agent state is durable, so a restart is recoverable and
+  mostly invisible to a user. A silent duplicate is neither: it corrupts the
+  conversation, and nothing reports it.
+
+  This is a rare event. It does not fire on a normal shutdown, when the whole
+  tree is coming down anyway, and it does not fire when Horde repairs a
+  restarted registry from a peer's CRDT without the registered process ever
+  dying.
+
+  Started automatically by `Sagents.Supervisor`. You do not start it yourself.
+  """
+
+  use GenServer
+
+  require Logger
+
+  # How often to look for the registry when it is not registered yet, which
+  # happens briefly while a backend supervisor restarts its own child.
+  @poll_interval 100
+
+  @doc """
+  Start the watcher.
+
+  ## Options
+
+  - `:name` - registered name, defaults to this module. `nil` starts it
+    unnamed, which tests use to run more than one at a time.
+  - `:registry_name` - the process name to watch, defaults to
+    `Sagents.ProcessRegistry.registry_name/0`. Overridden only in tests.
+  """
+  def start_link(opts \\ []) do
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    registry_name =
+      Keyword.get(opts, :registry_name, Sagents.ProcessRegistry.registry_name())
+
+    {:ok, %{ref: nil, pid: nil, registry_name: registry_name}, {:continue, :monitor}}
+  end
+
+  @impl true
+  def handle_continue(:monitor, state) do
+    {:noreply, monitor_registry(state)}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    {:noreply, monitor_registry(state)}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, reason}, %{ref: ref, pid: pid} = state) do
+    Logger.warning(
+      "#{inspect(state.registry_name)} went down (#{inspect(reason)}). " <>
+        "Restarting agent and filesystem supervisors so their registrations are " <>
+        "re-established. Running agents will restart from persisted state."
+    )
+
+    # A `{:shutdown, _}` reason still restarts a :permanent child, and unlike a
+    # bare error it is not reported as a crash. This is a deliberate, handled
+    # condition, not a bug in this process.
+    {:stop, {:shutdown, {:registry_down, reason}}, %{state | ref: nil, pid: nil}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # Watch whatever process currently holds the registry name. If the name is
+  # unclaimed, poll rather than failing: a backend supervisor may be mid-restart
+  # of its own child, and this process must not turn that into a restart storm.
+  defp monitor_registry(state) do
+    case Process.whereis(state.registry_name) do
+      nil ->
+        Process.send_after(self(), :poll, @poll_interval)
+        state
+
+      pid ->
+        %{state | ref: Process.monitor(pid), pid: pid}
+    end
+  end
+end

--- a/lib/sagents/session.ex
+++ b/lib/sagents/session.ex
@@ -101,11 +101,11 @@ defmodule Sagents.Session do
   def start(config, conversation_id, opts \\ []) do
     agent_id = config.agent_id_fun.(conversation_id)
 
-    case AgentServer.get_pid(agent_id) do
-      nil ->
+    case AgentServer.fetch_pid(agent_id) do
+      {:error, :not_running} ->
         do_start(config, conversation_id, agent_id, opts)
 
-      pid ->
+      {:ok, pid} ->
         Logger.debug("Agent session already running for conversation #{inspect(conversation_id)}")
 
         {:ok,
@@ -115,6 +115,17 @@ defmodule Sagents.Session do
            conversation_id: conversation_id,
            started: false
          }}
+
+      {:error, :registry_unavailable} = error ->
+        # This node cannot answer whether an agent is running, so it must not
+        # guess. Starting one anyway is how a conversation ends up with two
+        # AgentServers. Report it and let the caller retry elsewhere.
+        Logger.warning(
+          "Refusing to start agent session for conversation " <>
+            "#{inspect(conversation_id)}: registry unavailable on this node"
+        )
+
+        error
     end
   end
 
@@ -381,25 +392,47 @@ defmodule Sagents.Session do
   @doc """
   Stop the agent session for a conversation. No-op if nothing is running.
   """
-  @spec stop(config(), conversation_id :: term()) :: {:ok, :stopped | :not_running}
+  @spec stop(config(), conversation_id :: term()) ::
+          {:ok, :stopped | :not_running} | {:error, :registry_unavailable}
   def stop(config, conversation_id) do
     agent_id = config.agent_id_fun.(conversation_id)
 
-    case AgentServer.get_pid(agent_id) do
-      nil ->
+    case AgentServer.fetch_pid(agent_id) do
+      {:error, :not_running} ->
         {:ok, :not_running}
 
-      _pid ->
+      {:ok, _pid} ->
         AgentServer.stop(agent_id)
         {:ok, :stopped}
+
+      {:error, :registry_unavailable} = error ->
+        error
     end
   end
 
-  @doc "Whether an agent session is currently running for `conversation_id`."
+  @doc """
+  Whether an agent session is currently running for `conversation_id`.
+
+  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
+  answer. A boolean has no room for "cannot tell", and `false` would be read as
+  "nothing is running", which callers respond to by starting a duplicate agent.
+  Guard with `Sagents.ready?/0`, or use `ensure_running/3`, which reports the
+  condition as a value.
+  """
   @spec running?(config(), conversation_id :: term()) :: boolean()
   def running?(config, conversation_id) do
     agent_id = config.agent_id_fun.(conversation_id)
-    AgentServer.get_pid(agent_id) != nil
+
+    case AgentServer.fetch_pid(agent_id) do
+      {:ok, _pid} ->
+        true
+
+      {:error, :not_running} ->
+        false
+
+      {:error, :registry_unavailable} ->
+        raise Sagents.RegistryUnavailableError, operation: :"Session.running?/2"
+    end
   end
 
   # ===========================================================================
@@ -442,7 +475,7 @@ defmodule Sagents.Session do
 
       case AgentsDynamicSupervisor.start_agent_sync(supervisor_config) do
         {:ok, _supervisor_pid} ->
-          {:ok, session_info(agent_id, conversation_id)}
+          session_info(agent_id, conversation_id)
 
         {:error, reason} ->
           Logger.error("Failed to start agent session: #{inspect(reason)}")
@@ -547,13 +580,24 @@ defmodule Sagents.Session do
     |> Keyword.merge(supervisor_opts)
   end
 
+  # `start_agent_sync/1` only returns `:ok` once the AgentServer is registered,
+  # so this lookup normally succeeds. It can still fail if the node began
+  # shutting down in between, in which case the error is passed on rather than
+  # reporting `pid: nil` for an agent that was just confirmed running.
   defp session_info(agent_id, conversation_id) do
-    %{
-      agent_id: agent_id,
-      pid: AgentServer.get_pid(agent_id),
-      conversation_id: conversation_id,
-      started: true
-    }
+    case AgentServer.fetch_pid(agent_id) do
+      {:ok, pid} ->
+        {:ok,
+         %{
+           agent_id: agent_id,
+           pid: pid,
+           conversation_id: conversation_id,
+           started: true
+         }}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   defp presence_topic(conversation_id), do: "conversation:#{conversation_id}"

--- a/lib/sagents/supervisor.ex
+++ b/lib/sagents/supervisor.ex
@@ -16,7 +16,7 @@ defmodule Sagents.Supervisor do
   ## Usage
 
   Add `Sagents.Supervisor` to your application's supervision tree after your
-  Repo, PubSub, and Presence:
+  Repo, PubSub, and Presence, and **before** your Endpoint:
 
       # lib/my_app/application.ex
       def start(_type, _args) do
@@ -32,6 +32,19 @@ defmodule Sagents.Supervisor do
         Supervisor.start_link(children, opts)
       end
 
+  > #### The Endpoint must come after `Sagents.Supervisor` {: .warning}
+  >
+  > Reverse shutdown order is the whole point of that placement. Listed after,
+  > the Endpoint stops accepting requests *first*, and the registry is still
+  > alive to serve whatever is in flight.
+  >
+  > Listed **before** `Sagents.Supervisor`, the Endpoint keeps serving requests
+  > after the registry is gone, and every one of them fails until the BEAM
+  > exits. Correct ordering narrows that window but does not remove it, because
+  > the node stays reachable for the platform's whole drain period. Wire
+  > `Sagents.ready?/0` into your readiness check as well. See
+  > `docs/deployment.md`.
+
   ## What it starts
 
   - `Sagents.ProcessRegistry` — Process registry (local `Registry` or
@@ -46,6 +59,27 @@ defmodule Sagents.Supervisor do
 
       # Distributed cluster
       config :sagents, :distribution, :horde
+
+  ## Restart strategy
+
+  Children are supervised `:rest_for_one`, with the registry first. Everything
+  listed after it depends on it: an `AgentSupervisor` and an `AgentServer`
+  register their `:via` names in the registry once, at start, and nothing
+  re-registers them afterwards. A registry that loses its contents would
+  otherwise leave them running but invisible to every lookup, which lets a
+  conversation acquire a second AgentServer.
+
+  `:rest_for_one` expresses that dependency. A registry failure takes the
+  dynamic supervisors down with it, agents stop, and the next request re-creates
+  them from persisted state. That is a real cost, and it is the right one: agent
+  state is durable, so a restart is recoverable, while a silent duplicate is
+  not.
+
+  `Sagents.RegistryWatcher` sits between the registry and its dependents to
+  connect a registry failure to that chain. Both backends run the registered
+  process under a supervisor of their own and restart it internally, so the
+  failure is never a failed child of *this* supervisor. The watcher monitors the
+  registered process directly and fails in its place.
   """
 
   use Supervisor
@@ -63,11 +97,22 @@ defmodule Sagents.Supervisor do
     children =
       [
         Sagents.ProcessRegistry.child_spec([]),
+        # Sits between the registry and its dependents on purpose. Both Horde
+        # and Elixir's Registry run the registered process under their own
+        # supervisor, so a crash there is restarted internally and
+        # Sagents.Supervisor never sees a child fail. The watcher observes the
+        # registered process directly and fails in its place, which is what
+        # puts the restart below into the :rest_for_one chain.
+        Sagents.RegistryWatcher,
         Sagents.ProcessSupervisor.agents_supervisor_child_spec([]),
         Sagents.ProcessSupervisor.filesystem_supervisor_child_spec([])
       ] ++ membership_children()
 
-    Supervisor.init(children, strategy: :one_for_one)
+    # :rest_for_one because everything after the registry holds `:via`
+    # registrations in it that are established once at start. A registry
+    # failure has to take them down so they re-register on the way back up.
+    # See the moduledoc.
+    Supervisor.init(children, strategy: :rest_for_one)
   end
 
   # With `members: :participation`, start the `:pg` scope and the membership

--- a/mix.exs
+++ b/mix.exs
@@ -179,7 +179,8 @@ defmodule Sagents.MixProject do
       "docs/observability.md",
       "docs/persistence.md",
       "docs/filesystem_setup.md",
-      "docs/clustering.md"
+      "docs/clustering.md",
+      "docs/deployment.md"
     ]
   end
 

--- a/test/sagents/horde/rolling_deploy_test.exs
+++ b/test/sagents/horde/rolling_deploy_test.exs
@@ -1,0 +1,416 @@
+defmodule Sagents.Horde.RollingDeployTest do
+  @moduledoc """
+  How Sagents behaves on a node that is draining during a rolling deploy, and
+  when a registry crashes.
+
+  These tests use real Erlang nodes via LocalCluster. They are slow by design:
+  the behaviour under test is a lifecycle transition, and the only honest way to
+  observe it is to drive real supervision trees up and down.
+
+      mix test test/sagents/horde/rolling_deploy_test.exs --include cluster --include slow
+
+  ## What is asserted
+
+  1. **The unguarded lookup raises.** `Horde.Registry`'s ETS tables are owned by
+     the local `Horde.RegistryImpl` process, and `Horde.Registry.lookup/2`
+     derives the table name arithmetically (`:"keys_\#{registry}"`) and reads it
+     with no liveness guard. Once that process is gone, a raw lookup raises
+     `ArgumentError` from `:ets` rather than answering `:undefined`. This is
+     what `Sagents.ProcessRegistry`'s guard exists to sit in front of.
+
+  2. **The guarded API reports it as a value.** On the same node,
+     `Sagents.AgentServer.fetch_pid/1` answers
+     `{:error, :registry_unavailable}` and `Sagents.ready?/0` answers `false`,
+     so a host can pull the node out of rotation and answer 503.
+
+  3. **The condition persists for the rest of the node's life.** Once
+     `Sagents.Supervisor` has shut down, every subsequent lookup on that node
+     reports unavailable for as long as the BEAM lives, which is the whole drain
+     period. Retrying on the same node never recovers; the request has to go
+     elsewhere.
+
+  4. **Only the draining node is affected.** Survivors keep resolving the agent
+     and keep reporting ready, so this is a routing and readiness concern rather
+     than a cluster-wide outage.
+
+  5. **A registry crash self-heals from a peer.** Horde replicates membership
+     through the same CRDT as registrations, so a surviving peer restores both
+     within milliseconds and no agent is lost.
+
+  6. **Without a peer, the restart chain does the work instead.**
+     `Sagents.Supervisor` is `:rest_for_one` and `Sagents.RegistryWatcher` puts
+     a registry failure into that chain, so agents stop and are re-created from
+     persisted state rather than surviving unregistered. A conversation never
+     ends up with two AgentServers.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :cluster
+  @moduletag :slow
+  @moduletag timeout: 180_000
+
+  alias Sagents.ClusterTestHelper, as: Helper
+
+  @converge_timeout 15_000
+
+  setup_all do
+    LocalCluster.start()
+
+    unless Node.alive?() do
+      raise """
+      Distributed Erlang did not start. LocalCluster.start/0 could not make this \
+      node distributed, most likely because EPMD is not running on localhost:4369.
+
+      Start EPMD and retry:
+
+          epmd -daemon
+      """
+    end
+
+    :ok
+  end
+
+  # ===========================================================================
+  # 1. A node whose Sagents tree has shut down
+  # ===========================================================================
+
+  describe "lookups against a shut-down registry" do
+    test "the raw Horde lookup raises, and the Sagents API reports the condition" do
+      {cluster, [node1]} = start_cluster(1)
+      start_supervisor_on([node1])
+
+      agent_id = "conversation-sconv_2b39f4bd8eec45beadb"
+
+      # Baseline: with the registry up, an unknown agent answers cleanly.
+      assert {:ok, nil} = rpc(node1, :probe_once, [agent_id])
+      assert rpc(node1, :registry_table_present?, [])
+
+      # An orderly OTP shutdown of the Sagents tree, what SIGTERM does on a
+      # rolling deploy. The node stays up, exactly as it does while draining.
+      assert :ok = rpc(node1, :stop_supervisor, [])
+
+      # Horde's own lookup, bypassing the guard. Sagents.ProcessRegistry wraps
+      # this rather than replacing it, so the raw behaviour is what the guard
+      # has to protect against.
+      assert {:raised, ArgumentError, message, stacktrace} =
+               rpc(node1, :raw_whereis_probe, [agent_id])
+
+      assert message =~ "the table identifier does not refer to an existing ETS table"
+
+      # The frames that carry the raise up to a caller, in order.
+      assert stacktrace =~ ~s|:ets.lookup(:"keys_Elixir.Sagents.Registry"|
+      assert stacktrace =~ "Horde.Registry.lookup/2"
+      assert stacktrace =~ "Horde.Registry.whereis_name/2"
+      assert stacktrace =~ "GenServer.whereis/1"
+
+      # The precondition Horde.Registry.lookup/2 needs but never checks is
+      # cheaply observable: `:ets.whereis/1` answers `:undefined` rather than
+      # raising. That is what Sagents.ProcessRegistry.available?/0 checks.
+      refute rpc(node1, :registry_table_present?, [])
+
+      # The Sagents API keeps that :ets error away from a caller. get_pid/1
+      # raises a named error that says what to do, because its pid()|nil shape
+      # cannot carry the condition, and fetch_pid/1 reports it as a value.
+      assert {:raised, Sagents.RegistryUnavailableError, sagents_message, _stack} =
+               rpc(node1, :probe_once, [agent_id])
+
+      assert sagents_message =~ "Sagents.Registry is not available on this node"
+      assert sagents_message =~ "Sagents.ready?/0"
+
+      assert {:error, :registry_unavailable} = rpc(node1, :fetch_probe, [agent_id])
+
+      LocalCluster.stop(cluster)
+    end
+
+    test "the condition persists for the rest of the node's life, it is not transient" do
+      {cluster, [node1]} = start_cluster(1)
+      start_supervisor_on([node1])
+
+      # A caller outside the Sagents tree, in the position a Phoenix Endpoint
+      # and its Absinthe resolvers occupy, polling as requests arrive through
+      # the guarded API a request path should use.
+      probe = rpc(node1, :start_probe, ["conversation-drain", 2, :fetch_probe])
+
+      Process.sleep(300)
+      assert :ok = rpc(node1, :stop_supervisor, [])
+      Process.sleep(700)
+
+      send(probe, {:report, self()})
+      assert_receive {:probe_report, results}, 5_000
+
+      counts = Enum.frequencies(results)
+      unavailable = {:error, :registry_unavailable}
+
+      assert Map.get(counts, :not_registered, 0) > 0,
+             "expected clean answers before shutdown, got #{inspect(counts)}"
+
+      assert Map.get(counts, unavailable, 0) > 0,
+             "expected :registry_unavailable after shutdown, got #{inspect(counts)}"
+
+      # Nothing ever raised: the whole point of the guard is that this path
+      # stays a value.
+      assert Enum.all?(results, &(not match?({:raised, _}, &1))),
+             "expected no raises through the guarded API, got #{inspect(counts)}"
+
+      # The condition is terminal for this node, not transient. Once it starts,
+      # nothing on this node recovers, so there is no retry-here that helps and
+      # the request has to be answered 503 and retried elsewhere.
+      tail = Enum.drop_while(results, &(&1 != unavailable))
+      assert Enum.uniq(tail) == [unavailable]
+
+      LocalCluster.stop(cluster)
+    end
+  end
+
+  # ===========================================================================
+  # 2. Rolling deploy: which node is affected
+  # ===========================================================================
+
+  describe "rolling deploy across a 3 node cluster" do
+    test "only the draining node is affected; survivors keep answering" do
+      {cluster, [node1, node2, node3]} = start_cluster(3)
+      start_supervisor_on([node1, node2, node3])
+
+      assert wait_until(fn ->
+               member_nodes(node1, Sagents.Registry) == Enum.sort([node1, node2, node3])
+             end),
+             "cluster did not converge"
+
+      agent_id = "conversation-rolling-#{System.unique_integer([:positive])}"
+      {:ok, _pid} = rpc(node1, :start_agent, [agent_id])
+
+      assert wait_until(fn ->
+               match?({:ok, pid} when is_pid(pid), rpc(node2, :probe_once, [agent_id]))
+             end),
+             "agent registration did not replicate to node2"
+
+      # Probes on all three nodes, then take node1 out of service the way a
+      # rolling deploy does: stop its supervision tree, drain, then kill it.
+      probes =
+        for n <- [node1, node2, node3],
+            do: {n, rpc(n, :start_probe, [agent_id, 5, :fetch_probe])}
+
+      Process.sleep(300)
+      assert :ok = rpc(node1, :stop_supervisor, [])
+      Process.sleep(1_500)
+
+      reports =
+        for {n, probe} <- probes, into: %{} do
+          send(probe, {:report, self()})
+          assert_receive {:probe_report, results}, 5_000
+          {n, Enum.frequencies(results)}
+        end
+
+      unavailable = {:error, :registry_unavailable}
+
+      # The draining node reports :registry_unavailable for every request it is
+      # handed, and reports itself not ready.
+      assert Map.get(reports[node1], unavailable, 0) > 0,
+             "draining node should report unavailable: #{inspect(reports[node1])}"
+
+      refute rpc(node1, :ready?, [])
+
+      # Survivors are unaffected: they still resolve the agent, they never see
+      # the condition, and they still report ready. The fault is local to the
+      # node whose registry went away, so this is not a cluster-wide outage. It
+      # is a routing and readiness failure, and the request belongs on one of
+      # these nodes instead.
+      for n <- [node2, node3] do
+        assert Map.get(reports[n], unavailable, 0) == 0,
+               "surviving node #{inspect(n)} saw the condition: #{inspect(reports[n])}"
+
+        assert Map.get(reports[n], :found, 0) > 0,
+               "surviving node #{inspect(n)} should still resolve the agent: " <>
+                 inspect(reports[n])
+
+        assert rpc(n, :ready?, [])
+      end
+
+      LocalCluster.stop(cluster)
+    end
+  end
+
+  # ===========================================================================
+  # 2b. The drain window through the guarded API
+  # ===========================================================================
+
+  describe "guarded API on a draining node" do
+    test "reports readiness false and returns :registry_unavailable instead of raising" do
+      {cluster, [node1]} = start_cluster(1)
+      start_supervisor_on([node1])
+
+      agent_id = "conversation-guarded-#{System.unique_integer([:positive])}"
+
+      assert rpc(node1, :ready?, [])
+      assert {:error, :not_running} = rpc(node1, :fetch_probe, [agent_id])
+
+      assert :ok = rpc(node1, :stop_supervisor, [])
+
+      # Readiness flips, which is the signal a load balancer needs before the
+      # tree comes down. See docs/deployment.md.
+      refute rpc(node1, :ready?, [])
+
+      # And the request path gets a value it can turn into a 503, rather than
+      # the ArgumentError asserted above.
+      assert {:error, :registry_unavailable} = rpc(node1, :fetch_probe, [agent_id])
+
+      LocalCluster.stop(cluster)
+    end
+
+    test "an agent that IS running is never reported as merely not running" do
+      {cluster, [node1]} = start_cluster(1)
+      start_supervisor_on([node1])
+
+      agent_id = "conversation-nolie-#{System.unique_integer([:positive])}"
+      {:ok, _sup} = rpc(node1, :start_agent, [agent_id])
+      assert {:ok, pid} = rpc(node1, :fetch_probe, [agent_id])
+      assert is_pid(pid)
+
+      assert :ok = rpc(node1, :stop_supervisor, [])
+
+      # The distinction that matters: a draining node must not answer
+      # :not_running, because the caller acts on that by starting a duplicate.
+      assert {:error, :registry_unavailable} = rpc(node1, :fetch_probe, [agent_id])
+
+      LocalCluster.stop(cluster)
+    end
+  end
+
+  # ===========================================================================
+  # 3. Registry crash: heals from a peer, restarts without one
+  # ===========================================================================
+
+  describe "registry crash under Sagents.Supervisor's :one_for_one strategy" do
+    test "a peer repairs both membership and registrations after a registry crash" do
+      {cluster, [node1, node2]} = start_cluster(2)
+      start_supervisor_on([node1, node2])
+
+      both = Enum.sort([node1, node2])
+
+      assert wait_until(fn -> member_nodes(node1, Sagents.Registry) == both end),
+             "registry membership did not converge: " <>
+               inspect(member_nodes(node1, Sagents.Registry))
+
+      agent_id = "conversation-crash-#{System.unique_integer([:positive])}"
+      {:ok, _sup_pid} = rpc(node1, :start_agent, [agent_id])
+
+      assert wait_until(fn ->
+               match?({:ok, pid} when is_pid(pid), rpc(node2, :probe_once, [agent_id]))
+             end),
+             "registration did not replicate to node2"
+
+      {:ok, before_pid} = rpc(node1, :probe_once, [agent_id])
+      assert is_pid(before_pid)
+
+      assert {:ok, _dead_pid} = rpc(node1, :kill_registry, [])
+
+      assert wait_until(fn -> rpc(node1, :registered?, [Sagents.Registry]) end),
+             "registry was not restarted by Sagents.Supervisor"
+
+      # `ClusterConfig.resolve_members/1` seeds the restarted registry with a
+      # self-only member set, and MembershipManager only re-applies members on a
+      # :pg join or leave, neither of which happened. Membership is nonetheless
+      # restored, because Horde replicates the member set through the same CRDT
+      # as registrations and node2 still lists node1 as a neighbour.
+      assert wait_until(fn -> member_nodes(node1, Sagents.Registry) == both end),
+             "membership did not heal from the peer: " <>
+               inspect(member_nodes(node1, Sagents.Registry))
+
+      # The registration comes back for the same reason, pointing at the same
+      # still-running process. No agent was lost.
+      assert wait_until(fn -> rpc(node1, :probe_once, [agent_id]) == {:ok, before_pid} end),
+             "registration did not heal from the peer: " <>
+               inspect(rpc(node1, :probe_once, [agent_id]))
+
+      LocalCluster.stop(cluster)
+    end
+
+    test "on a single-node cluster the crash takes the agent down rather than orphaning it" do
+      {cluster, [node1]} = start_cluster(1)
+      start_supervisor_on([node1])
+
+      agent_id = "conversation-orphan-#{System.unique_integer([:positive])}"
+      {:ok, first} = rpc(node1, :start_agent, [agent_id])
+
+      {:ok, ^first} = rpc(node1, :agent_supervisor_pid, [agent_id])
+
+      assert {:ok, _dead_pid} = rpc(node1, :kill_registry, [])
+      assert wait_until(fn -> rpc(node1, :registered?, [Sagents.Registry]) end)
+
+      # No peer here, so nothing re-supplies the CRDT the way the previous test
+      # relies on. Sagents.RegistryWatcher notices the registry going down and
+      # fails in its place, and Sagents.Supervisor's :rest_for_one strategy
+      # takes the registry's dependents down with it.
+      assert wait_until(fn -> not :rpc.call(node1, Process, :alive?, [first]) end),
+             "the AgentSupervisor should have been restarted with the registry"
+
+      # Settle, then confirm this is a steady state and not a mid-restart sample.
+      Process.sleep(3_000)
+
+      assert wait_until(fn ->
+               rpc(node1, :registered?, [Sagents.AgentsDynamicSupervisor])
+             end),
+             "the agents supervisor should have been restarted too"
+
+      assert {:ok, nil} = rpc(node1, :probe_once, [agent_id])
+      assert :rpc.call(node1, Sagents.AgentsDynamicSupervisor, :count_agents, []) == 0
+
+      # Starting again yields one agent, not two, and state is durable so the
+      # replacement picks up where its predecessor left off.
+      assert {:ok, second} = rpc(node1, :start_agent, [agent_id])
+      assert second != first
+      assert :rpc.call(node1, Process, :alive?, [second])
+
+      assert :rpc.call(node1, Sagents.AgentsDynamicSupervisor, :count_agents, []) == 1
+      assert :rpc.call(node1, Sagents.AgentsDynamicSupervisor, :list_agents, []) == [agent_id]
+
+      LocalCluster.stop(cluster)
+    end
+  end
+
+  # ===========================================================================
+  # Helpers
+  # ===========================================================================
+
+  defp start_cluster(count, opts \\ []) do
+    members = Keyword.get(opts, :members, :participation)
+
+    {:ok, cluster} =
+      LocalCluster.start_link(count,
+        environment: [
+          sagents: [distribution: :horde, horde: [members: members]]
+        ]
+      )
+
+    {:ok, nodes} = LocalCluster.nodes(cluster)
+    {cluster, nodes}
+  end
+
+  defp start_supervisor_on(nodes) do
+    for node <- nodes do
+      {:ok, _pid} = :rpc.call(node, Helper, :start_supervisor, [])
+    end
+  end
+
+  defp rpc(node, fun, args), do: :rpc.call(node, Helper, fun, args)
+
+  defp member_nodes(node, horde), do: rpc(node, :member_nodes, [horde])
+
+  defp wait_until(fun, timeout \\ @converge_timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:millisecond) < deadline do
+        Process.sleep(100)
+        do_wait_until(fun, deadline)
+      else
+        false
+      end
+    end
+  end
+end

--- a/test/sagents/process_registry_availability_test.exs
+++ b/test/sagents/process_registry_availability_test.exs
@@ -1,0 +1,129 @@
+defmodule Sagents.ProcessRegistryAvailabilityTest do
+  @moduledoc """
+  Unit coverage for `Sagents.ProcessRegistry`'s availability contract: which
+  functions report an unavailable registry as a value, which raise, and the
+  guarantee that neither ever answers with a plausible-looking default.
+
+  The test suite runs with `config :sagents, :distribution, :local` and a live
+  `Sagents.Supervisor`, so the available path is exercised directly. The
+  unavailable path is exercised by pointing the backend at a registry name that
+  has no table, which is precisely the condition a draining node is in.
+
+  The multi-node behaviour is covered in
+  `test/sagents/horde/rolling_deploy_test.exs`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Sagents.{AgentServer, AgentSupervisor, ProcessRegistry}
+
+  describe "available?/1 with a live registry" do
+    test "reports true and names the registry the tests actually use" do
+      assert ProcessRegistry.available?()
+      assert ProcessRegistry.registry_name() == Sagents.Registry
+    end
+
+    test "ensure_available!/1 passes through" do
+      assert :ok = ProcessRegistry.ensure_available!(:some_operation)
+    end
+
+    test "the ETS table it checks is the one the backend reads" do
+      # :local reads a table named after the registry itself, via
+      # Registry.key_info!/1. If that ever stops being true, available?/0 would
+      # silently start reporting the wrong thing, so pin it here.
+      assert :ets.whereis(Sagents.Registry) != :undefined
+    end
+  end
+
+  describe "fetch/1 keeps 'not registered' and 'cannot answer' distinct" do
+    test "returns {:error, :not_registered} for an unknown key" do
+      assert {:error, :not_registered} =
+               ProcessRegistry.fetch({:agent_server, "no-such-agent-#{unique()}"})
+    end
+
+    test "returns {:ok, pid} for a registered key" do
+      agent_id = "fetch-test-#{unique()}"
+      name = ProcessRegistry.via_tuple({:agent_server, agent_id})
+      {:ok, pid} = Agent.start_link(fn -> :ok end, name: name)
+
+      assert {:ok, ^pid} = ProcessRegistry.fetch({:agent_server, agent_id})
+    end
+  end
+
+  describe "with no registry table (a draining node)" do
+    setup do
+      # Point the abstraction at a backend whose table does not exist. This is
+      # the same observable state as a shut-down registry: the name resolves to
+      # an atom, and no ETS table answers to it.
+      original = Application.get_env(:sagents, :distribution, :local)
+      Application.put_env(:sagents, :distribution, :horde)
+      on_exit(fn -> Application.put_env(:sagents, :distribution, original) end)
+
+      # Sanity: the horde keys table for Sagents.Registry is genuinely absent
+      # in this (local-backed) test VM.
+      refute ProcessRegistry.available?()
+      :ok
+    end
+
+    test "available?/0 reports false" do
+      refute ProcessRegistry.available?()
+      refute Sagents.ready?()
+    end
+
+    test "fetch/1 returns :registry_unavailable, never :not_registered" do
+      assert {:error, :registry_unavailable} =
+               ProcessRegistry.fetch({:agent_server, "anything"})
+    end
+
+    test "AgentServer.fetch_pid/1 returns :registry_unavailable, never :not_running" do
+      assert {:error, :registry_unavailable} = AgentServer.fetch_pid("anything")
+    end
+
+    test "AgentSupervisor.get_pid/1 returns :registry_unavailable, never :not_found" do
+      assert {:error, :registry_unavailable} = AgentSupervisor.get_pid("anything")
+    end
+
+    test "AgentServer.get_pid/1 raises rather than answering nil" do
+      # nil would be indistinguishable from "not running", and callers act on
+      # that by starting a duplicate agent.
+      assert_raise Sagents.RegistryUnavailableError, fn ->
+        AgentServer.get_pid("anything")
+      end
+    end
+
+    test "lookup/1 raises rather than answering []" do
+      assert_raise Sagents.RegistryUnavailableError, fn ->
+        ProcessRegistry.lookup({:agent_server, "anything"})
+      end
+    end
+
+    test "select/1 raises rather than answering []" do
+      assert_raise Sagents.RegistryUnavailableError, fn ->
+        ProcessRegistry.select([{{{:agent_server, :"$1"}, :_, :_}, [], [:"$1"]}])
+      end
+    end
+
+    test "count/0 raises rather than answering 0" do
+      assert_raise Sagents.RegistryUnavailableError, fn -> ProcessRegistry.count() end
+    end
+
+    test "keys/1 raises rather than answering []" do
+      assert_raise Sagents.RegistryUnavailableError, fn -> ProcessRegistry.keys(self()) end
+    end
+
+    test "ensure_available!/1 raises with an actionable message" do
+      error =
+        assert_raise Sagents.RegistryUnavailableError, fn ->
+          ProcessRegistry.ensure_available!(:my_operation)
+        end
+
+      message = Exception.message(error)
+
+      assert message =~ "Sagents.Registry is not available on this node"
+      assert message =~ "my_operation"
+      assert message =~ "Sagents.ready?/0"
+      assert message =~ "docs/deployment.md"
+    end
+  end
+
+  defp unique, do: System.unique_integer([:positive])
+end

--- a/test/sagents/registry_watcher_test.exs
+++ b/test/sagents/registry_watcher_test.exs
@@ -1,0 +1,131 @@
+defmodule Sagents.RegistryWatcherTest do
+  @moduledoc """
+  Unit coverage for the watcher that puts a registry restart into
+  `Sagents.Supervisor`'s `:rest_for_one` chain.
+
+  These tests drive a watcher against a stand-in registry name rather than the
+  live `Sagents.Registry` the suite depends on. The end-to-end behaviour, where
+  the restart actually takes the agent supervisors down, is covered against real
+  nodes in `test/sagents/horde/rolling_deploy_test.exs`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Sagents.RegistryWatcher
+
+  describe "monitoring" do
+    test "stays up while the registry it watches is alive" do
+      {name, _stand_in} = start_stand_in_registry()
+      watcher = start_watcher(name)
+
+      Process.sleep(200)
+
+      assert Process.alive?(watcher)
+    end
+
+    test "stops when the watched process dies, so :rest_for_one restarts the chain" do
+      {name, stand_in} = start_stand_in_registry()
+      watcher = start_watcher(name)
+
+      watcher_ref = Process.monitor(watcher)
+      Process.exit(stand_in, :kill)
+
+      assert_receive {:DOWN, ^watcher_ref, :process, ^watcher, reason}, 2_000
+
+      # A {:shutdown, _} reason still restarts a :permanent child, and unlike a
+      # bare error it is not reported as a crash. This is a handled condition.
+      assert {:shutdown, {:registry_down, :killed}} = reason
+    end
+
+    test "waits rather than failing when the name is not claimed yet" do
+      # A backend supervisor mid-restart of its own child leaves the name
+      # briefly unclaimed. The watcher must poll through that rather than turn
+      # it into a restart storm.
+      name = unique_name()
+      watcher = start_watcher(name)
+
+      Process.sleep(300)
+      assert Process.alive?(watcher)
+
+      # Once something claims the name, it gets picked up and watched.
+      stand_in = start_named_process(name)
+      Process.sleep(300)
+      assert Process.alive?(watcher)
+
+      watcher_ref = Process.monitor(watcher)
+      Process.exit(stand_in, :kill)
+
+      assert_receive {:DOWN, ^watcher_ref, :process, ^watcher, {:shutdown, _}}, 2_000
+    end
+
+    test "ignores unrelated DOWN messages" do
+      {name, _stand_in} = start_stand_in_registry()
+      watcher = start_watcher(name)
+
+      unrelated = spawn(fn -> Process.sleep(:infinity) end)
+      send(watcher, {:DOWN, make_ref(), :process, unrelated, :normal})
+
+      Process.sleep(200)
+      assert Process.alive?(watcher)
+    end
+  end
+
+  describe "supervision wiring" do
+    test "Sagents.Supervisor supervises the registry chain :rest_for_one" do
+      # The strategy is the mechanism the watcher depends on: without it, the
+      # watcher's own restart would not take the dynamic supervisors with it.
+      {:ok, {sup_flags, children}} = Sagents.Supervisor.init([])
+
+      assert sup_flags.strategy == :rest_for_one
+
+      ids = Enum.map(children, & &1.id)
+
+      registry_index =
+        Enum.find_index(ids, &(&1 in [Sagents.Registry, Sagents.Horde.RegistryImpl]))
+
+      watcher_index = Enum.find_index(ids, &(&1 == Sagents.RegistryWatcher))
+
+      agents_index =
+        Enum.find_index(
+          ids,
+          &(&1 in [Sagents.AgentsDynamicSupervisor, Sagents.Horde.AgentsSupervisorImpl])
+        )
+
+      assert is_integer(registry_index), "no registry child found in #{inspect(ids)}"
+      assert is_integer(watcher_index), "no watcher child found in #{inspect(ids)}"
+      assert is_integer(agents_index), "no agents supervisor found in #{inspect(ids)}"
+
+      # Order is load-bearing: the watcher must sit after the registry (so it
+      # can watch it) and before the dynamic supervisors (so its restart takes
+      # them down).
+      assert registry_index < watcher_index
+      assert watcher_index < agents_index
+    end
+  end
+
+  # ===========================================================================
+  # Helpers
+  # ===========================================================================
+
+  defp start_stand_in_registry do
+    name = unique_name()
+    {name, start_named_process(name)}
+  end
+
+  defp start_named_process(name) do
+    pid = spawn(fn -> Process.sleep(:infinity) end)
+    Process.register(pid, name)
+    on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+    pid
+  end
+
+  # Start a watcher pointed at `name`, unnamed and unlinked so its deliberate
+  # stop does not take the test process with it.
+  defp start_watcher(name) do
+    {:ok, pid} = RegistryWatcher.start_link(name: nil, registry_name: name)
+    Process.unlink(pid)
+    on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+    pid
+  end
+
+  defp unique_name, do: :"stand_in_registry_#{System.unique_integer([:positive])}"
+end

--- a/test/sagents/session_test.exs
+++ b/test/sagents/session_test.exs
@@ -160,7 +160,7 @@ defmodule Sagents.SessionTest do
     fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
     monitor_ref = make_ref()
 
-    stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+    stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
 
     # Subscriber.subscribe_to_agent calls AgentServer.subscribe to set up the
     # producer-side monitor. We don't have a live AgentServer in these tests,
@@ -173,7 +173,7 @@ defmodule Sagents.SessionTest do
     stub(AgentsDynamicSupervisor, :start_agent_sync, fn opts ->
       send(captured_ref, {:supervisor_config, opts})
       # After the start, simulate the agent being registered.
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
       {:ok, fake_pid}
     end)
 
@@ -245,7 +245,7 @@ defmodule Sagents.SessionTest do
     end
 
     test "propagates {:error, _} from the factory" do
-      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
 
       Process.put(:spy_factory_module, ErrorFactory)
       config = base_config()
@@ -254,7 +254,7 @@ defmodule Sagents.SessionTest do
     end
 
     test "propagates {:error, _} from the router" do
-      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
 
       Process.put(:spy_router_response, {:error, :no_route})
       config = base_config()
@@ -324,7 +324,7 @@ defmodule Sagents.SessionTest do
 
     test "is idempotent — returns existing session without re-consulting router" do
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
 
       config = base_config()
 
@@ -437,14 +437,14 @@ defmodule Sagents.SessionTest do
 
   describe "stop/2" do
     test "returns {:ok, :not_running} when no agent is running" do
-      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
 
       assert {:ok, :not_running} = Session.stop(base_config(), 1)
     end
 
     test "stops the running agent and returns {:ok, :stopped}" do
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
       stub(AgentServer, :stop, fn _agent_id -> :ok end)
 
       assert {:ok, :stopped} = Session.stop(base_config(), 1)
@@ -453,13 +453,13 @@ defmodule Sagents.SessionTest do
 
   describe "running?/2" do
     test "false when no agent is registered" do
-      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
       refute Session.running?(base_config(), 1)
     end
 
     test "true when an agent is registered" do
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
       assert Session.running?(base_config(), 1)
     end
   end
@@ -476,7 +476,7 @@ defmodule Sagents.SessionTest do
 
     test "a live interrupted agent takes the answer in exactly one call" do
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
 
       test_pid = self()
 
@@ -536,7 +536,7 @@ defmodule Sagents.SessionTest do
       # would be a no-op that hides a real problem (e.g. the question was
       # already answered from another tab).
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
       test_pid = self()
 
       stub(AgentServer, :resume, fn _agent_id, _resume_data ->
@@ -577,7 +577,7 @@ defmodule Sagents.SessionTest do
 
       # The agent is up by the time Session.start/3 looks, so it returns
       # started: false without ever reaching the supervisor.
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
 
       stub(AgentServer, :subscribe, fn _agent_id, _channel, _pid ->
         {:ok, fake_pid, make_ref()}
@@ -595,7 +595,7 @@ defmodule Sagents.SessionTest do
     end
 
     test "passes a start failure through" do
-      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
       stub(AgentServer, :resume, fn _agent_id, _resume_data -> {:error, :agent_not_running} end)
       Process.put(:spy_router_response, {:error, :no_route})
 
@@ -606,7 +606,7 @@ defmodule Sagents.SessionTest do
   describe "dismiss/3" do
     test "a live agent holding a halt is dismissed in exactly one call" do
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
 
       test_pid = self()
 
@@ -684,7 +684,7 @@ defmodule Sagents.SessionTest do
 
     test "a live agent in the wrong state errors instead of being woken" do
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
       test_pid = self()
 
       stub(AgentServer, :dismiss_interrupt, fn _agent_id ->
@@ -706,7 +706,7 @@ defmodule Sagents.SessionTest do
       # AskUserQuestion and HITL interrupts must go through resume/4. Waking to
       # retry a dismissal they will refuse again is pointless.
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
       test_pid = self()
 
       stub(AgentServer, :dismiss_interrupt, fn _agent_id ->
@@ -725,7 +725,7 @@ defmodule Sagents.SessionTest do
     end
 
     test "passes a start failure through" do
-      stub(AgentServer, :get_pid, fn _agent_id -> nil end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
       stub(AgentServer, :dismiss_interrupt, fn _agent_id -> {:error, :agent_not_running} end)
       Process.put(:spy_router_response, {:error, :no_route})
 
@@ -751,7 +751,7 @@ defmodule Sagents.SessionTest do
 
     test "false when an agent was already running" do
       fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
-      stub(AgentServer, :get_pid, fn _agent_id -> fake_pid end)
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
 
       assert {:ok, %{started: false}} = Session.start(base_config(), 1, scope: :s)
     end

--- a/test/support/sagents/cluster_test_helper.ex
+++ b/test/support/sagents/cluster_test_helper.ex
@@ -7,6 +7,8 @@ defmodule Sagents.ClusterTestHelper do
   anonymous functions are not available across node boundaries.
   """
 
+  alias LangChain.ChatModels.ChatAnthropic
+
   @doc """
   Start the Sagents.Supervisor on the current node and unlink it from the caller.
 
@@ -18,5 +20,209 @@ defmodule Sagents.ClusterTestHelper do
     {:ok, pid} = Sagents.Supervisor.start_link(name: Sagents.Supervisor)
     Process.unlink(pid)
     {:ok, pid}
+  end
+
+  @doc """
+  Stop the Sagents supervision tree on this node, the way OTP does during an
+  orderly application shutdown (SIGTERM on a rolling deploy).
+
+  The node itself stays up, which is the whole point: on a real deploy the BEAM
+  lingers for the drain period after its supervision tree has come down, and
+  in-flight web requests keep arriving during that window.
+  """
+  def stop_supervisor(reason \\ :shutdown) do
+    Supervisor.stop(Sagents.Supervisor, reason)
+  end
+
+  @doc """
+  Brutally kill the local Horde registry process, leaving `Sagents.Supervisor`
+  to restart it. Simulates a registry crash rather than a clean shutdown.
+  """
+  def kill_registry do
+    case Process.whereis(Sagents.Registry) do
+      nil ->
+        {:error, :not_running}
+
+      pid ->
+        ref = Process.monitor(pid)
+        Process.exit(pid, :kill)
+
+        receive do
+          {:DOWN, ^ref, :process, ^pid, _reason} -> {:ok, pid}
+        after
+          5_000 -> {:error, :timeout}
+        end
+    end
+  end
+
+  @doc "Whether the named process is registered and alive on this node."
+  def registered?(name), do: Process.whereis(name) != nil
+
+  @doc "The AgentSupervisor pid for `agent_id`, as seen from this node."
+  def agent_supervisor_pid(agent_id), do: Sagents.AgentSupervisor.get_pid(agent_id)
+
+  @doc """
+  Whether the local Horde registry's `keys` ETS table exists.
+
+  This is the precondition `Horde.Registry.lookup/2` requires, and the same
+  thing `Sagents.ProcessRegistry.available?/0` checks. `:ets.whereis/1` answers
+  `:undefined` rather than raising, which is what makes it usable as a guard.
+  """
+  def registry_table_present? do
+    :ets.whereis(:"keys_#{Sagents.ProcessRegistry.registry_name()}") != :undefined
+  end
+
+  @doc """
+  The `node()`s in `horde`'s member set as seen from this node.
+  """
+  def member_nodes(horde) do
+    Horde.Cluster.members(horde)
+    |> Enum.map(fn {_name, member_node} -> member_node end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Lookup probes
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Call `Sagents.AgentServer.get_pid/1`, capturing a raise instead of letting it
+  propagate.
+
+  `get_pid/1` raises `Sagents.RegistryUnavailableError` on a draining node,
+  since its `pid() | nil` shape cannot report the condition. Use `fetch_probe/1`
+  for the tuple-returning form.
+
+  Returns one of:
+
+  - `{:ok, pid | nil}`: the registry answered
+  - `{:raised, module, message, formatted_stacktrace}`
+  - `{:caught, kind, reason}`
+  """
+  def probe_once(agent_id) do
+    {:ok, Sagents.AgentServer.get_pid(agent_id)}
+  rescue
+    error ->
+      {:raised, error.__struct__, Exception.message(error),
+       Exception.format_stacktrace(__STACKTRACE__)}
+  catch
+    kind, reason ->
+      {:caught, kind, reason}
+  end
+
+  @doc """
+  A lookup that bypasses the guard: `GenServer.whereis/1` on the registry's
+  `:via` tuple with no availability check.
+
+  Exercises Horde's own behaviour directly, which is what
+  `Sagents.ProcessRegistry` wraps rather than replaces. Use it to assert what
+  the guard is protecting against.
+
+  Same return shape as `probe_once/1`.
+  """
+  def raw_whereis_probe(agent_id) do
+    name =
+      {:via, Horde.Registry, {Sagents.ProcessRegistry.registry_name(), {:agent_server, agent_id}}}
+
+    {:ok, GenServer.whereis(name)}
+  rescue
+    error ->
+      {:raised, error.__struct__, Exception.message(error),
+       Exception.format_stacktrace(__STACKTRACE__)}
+  catch
+    kind, reason ->
+      {:caught, kind, reason}
+  end
+
+  @doc """
+  The guarded lookup, called the way a request path should call it.
+
+  Unlike `probe_once/1` this does not raise: a draining node answers
+  `{:error, :registry_unavailable}`. The rescue is here so a test failure
+  reports the raise rather than crashing the probe.
+  """
+  def fetch_probe(agent_id) do
+    Sagents.AgentServer.fetch_pid(agent_id)
+  rescue
+    error ->
+      {:raised, error.__struct__, Exception.message(error)}
+  end
+
+  @doc "Whether this node reports itself ready to host agent sessions."
+  def ready?, do: Sagents.ready?()
+
+  @doc """
+  Reduce any probe result to a comparable tag, for frequency counting.
+  """
+  def classify({:ok, nil}), do: :not_registered
+  def classify({:ok, pid}) when is_pid(pid), do: :found
+  def classify({:ok, {name, node}}) when is_atom(name) and is_atom(node), do: :found
+  def classify({:error, :not_running}), do: :not_registered
+  def classify({:error, reason}), do: {:error, reason}
+  def classify({:raised, module, _message}), do: {:raised, module}
+  def classify({:raised, module, _message, _stacktrace}), do: {:raised, module}
+  def classify({:caught, kind, _reason}), do: {:caught, kind}
+
+  @doc """
+  Spawn a process on this node that polls a lookup in a loop, the way a web
+  front end keeps serving requests while the node drains.
+
+  Deliberately spawned *outside* the Sagents supervision tree. That is where a
+  Phoenix Endpoint or Absinthe resolver lives, and it is why the probe survives
+  `stop_supervisor/1` and keeps observing.
+
+  `probe_fun` selects which lookup to poll: `:fetch_probe` for the guarded API a
+  request path should use, `:probe_once` or `:raw_whereis_probe` for the
+  unguarded ones.
+
+  Send `{:report, pid}` to the returned pid to receive
+  `{:probe_report, [tag]}` in call order.
+  """
+  def start_probe(agent_id, interval_ms \\ 2, probe_fun \\ :fetch_probe) do
+    spawn(__MODULE__, :probe_loop, [agent_id, interval_ms, probe_fun, []])
+  end
+
+  @doc false
+  def probe_loop(agent_id, interval_ms, probe_fun, acc) do
+    receive do
+      {:report, from} ->
+        send(from, {:probe_report, Enum.reverse(acc)})
+        probe_loop(agent_id, interval_ms, probe_fun, acc)
+    after
+      interval_ms ->
+        tag = classify(apply(__MODULE__, probe_fun, [agent_id]))
+        probe_loop(agent_id, interval_ms, probe_fun, [tag | acc])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Agent placement
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Start a minimal agent on this node through the real supervisor path.
+
+  Uses a stub chat model config; nothing here makes an API call.
+  """
+  def start_agent(agent_id) do
+    agent =
+      Sagents.Agent.new!(%{
+        agent_id: agent_id,
+        model:
+          ChatAnthropic.new!(%{
+            model: "claude-sonnet-4-5-20250929",
+            api_key: "test_key"
+          }),
+        base_system_prompt: "Rolling deploy test agent",
+        replace_default_middleware: true,
+        middleware: []
+      })
+
+    Sagents.AgentsDynamicSupervisor.start_agent_sync(
+      agent_id: agent_id,
+      agent: agent,
+      initial_state: Sagents.State.new!(%{})
+    )
   end
 end


### PR DESCRIPTION
## Problem

During a rolling deploy a node receives SIGTERM, OTP shuts `Sagents.Supervisor` down, and **the BEAM keeps running** for the platform's whole grace period (commonly 30 to 60 seconds). The load balancer may still route requests to that node for all of it.

Every agent lookup in that window raised:

```
** (ArgumentError) errors were found at the given arguments:
  * 1st argument: the table identifier does not refer to an existing ETS table
    :ets.lookup(:"keys_Elixir.Sagents.Registry", {:agent_server, "conversation-..."})
    (horde) lib/horde/registry.ex:251: Horde.Registry.lookup/2
    (horde) lib/horde/registry.ex:393: Horde.Registry.whereis_name/2
    (elixir) lib/gen_server.ex:1355: GenServer.whereis/1
    (sagents) lib/sagents/session.ex:94: Sagents.Session.start/3
```

`Horde.Registry.lookup/2` derives its ETS table name arithmetically (`:"keys_#{registry}"`) and reads it with no liveness check. Named ETS tables die with their owning process, so the precondition for any read is "the local `Horde.RegistryImpl` is alive" — and nothing verifies it. Elixir's `Registry` has the same hole via `Registry.key_info!/1`. Neither backend can report the condition, so it escaped to callers as an `:ets` error.

This is not a narrow race. It is a stable failure mode for the entire drain period, and no client-side or in-process retry can recover on that node.

Investigating it surfaced a second, independent defect. A registry crash left running `AgentSupervisor`s and `AgentServer`s alive but **unregistered** — their `:via` names are established once at start and nothing re-registers them. Lookups then answered "not running", and the next request started a *second* AgentServer for a conversation that already had one. Both held and persisted state for it, with nothing reporting the conflict. In a multi-node cluster Horde repairs this from a peer's CRDT within ~200ms; on a single node nothing does.

## Solution

**Model "registry unavailable" as a value, and never let it collapse into "not registered."**

`Sagents.ProcessRegistry` gains `available?/0`, which checks the ETS table each backend actually reads via `:ets.whereis/1` — that answers `:undefined` instead of raising, and it tests exactly the precondition the read requires. On top of it:

- `fetch/1` returns three distinct outcomes: `{:ok, pid}`, `{:error, :not_registered}`, `{:error, :registry_unavailable}`.
- `lookup/1`, `select/1`, `count/0` and `keys/1` cannot express the condition in their return values, so they raise the new `Sagents.RegistryUnavailableError` rather than answering `[]` or `0`.

The split is deliberate and is the whole point of the change. A caller reading "nothing is registered" responds by starting an agent; on a draining node that manufactures the duplicate described above. `fetch/1` and `guarded/2` re-check `available?/0` inside their `rescue` so a genuine `ArgumentError` still surfaces as itself, closing the microsecond TOCTOU window without swallowing unrelated bugs.

`AgentServer.fetch_pid/1` is the new request-path lookup. `AgentServer`'s internal `safe_call/3` now resolves through it instead of handing `GenServer.call` a `:via` tuple, which puts the whole lifecycle API (`execute/1`, `cancel/1`, `resume/2`, `add_message/3`, `reset/1`, `dismiss_interrupt/1`) behind the guard in one place. `Session.start/3` refuses to start an agent it cannot rule out. (`GenServer.cast` on a `:via` tuple was already safe — Elixir wraps name resolution in `catch _, _` — so only the `call` and `whereis` paths needed changing.)

**Stop receiving traffic before you stop being able to serve it.** `Sagents.ready?/0` exposes the signal for a readiness check, and `docs/deployment.md` documents the ordering that has to hold on SIGTERM: mark unready → LB stops routing → in-flight drains → tree stops. Previously only the last step happened.

**Close the orphan/duplicate defect.** `Sagents.Supervisor` is now `:rest_for_one` — the registry genuinely *is* a dependency of the dynamic supervisors after it, and `:one_for_one` asserted an independence that does not hold.

That change alone was not sufficient, which the tests caught. `Horde.Registry.start_link/3` starts a *supervisor*, and the process registered as `Sagents.Registry` is its child:

```
Sagents.Supervisor
└── Sagents.Horde.RegistryImpl   <- the child Sagents.Supervisor sees (a supervisor)
    ├── Horde.RegistryImpl       <- the process registered as Sagents.Registry
    └── Sagents.Registry.Crdt
```

When the registered process crashes, Horde restarts it internally with fresh empty ETS tables and `Sagents.Supervisor` never observes a failed child, so the restart chain never fires. Elixir's `Registry` is shaped identically. `Sagents.RegistryWatcher` closes that gap: listed immediately after the registry, it monitors the registered process directly and stops when it dies, which *is* a child failure `:rest_for_one` acts on. Verified directly — after a kill, the agents supervisor moves and `count_agents/0` is `0` rather than `2`.

The trade is explicit: a registry crash now costs running agents instead of leaving invisible duplicates. Agent state is durable, so a restart is recoverable; a silent duplicate is not.

## Changes

**Core**

- `lib/sagents/process_registry.ex` — Added `available?/0`, `fetch/1`, `ensure_available!/1`; routed `lookup/1`, `select/1`, `count/0`, `keys/1` through a `guarded/2` helper that raises rather than returning a plausible default.
- `lib/sagents/registry_unavailable_error.ex` — **New.** Named exception carrying `:operation` and `:registry`, with a message that explains the lifecycle cause and points at the readiness fix.
- `lib/sagents/registry_watcher.ex` — **New.** Monitors the registered registry process and stops when it dies, so a backend-internal restart reaches `:rest_for_one`. Polls (100ms) when the name is unclaimed so a mid-restart backend cannot become a restart storm. Stops with `{:shutdown, {:registry_down, reason}}` so it restarts without being reported as a crash.
- `lib/sagents/supervisor.ex` — Strategy changed `:one_for_one` → `:rest_for_one`; `RegistryWatcher` inserted between the registry and its dependents.
- `lib/sagents.ex` — Added `Sagents.ready?/0`.

**Call sites threaded through the new API**

- `lib/sagents/agent_server.ex` — Added `fetch_pid/1`; `get_pid/1` now raises instead of answering `nil`; `safe_call/3` resolves via `fetch_pid/1`; added `call!/3` for calls with no room for an error tuple; `queue_message` folds the condition into its existing `:no_server` fallback, since raising out of a tool body is what that guard exists to prevent.
- `lib/sagents/session.ex` — `start/3`, `stop/2` and `session_info/2` use `fetch_pid/1` and propagate `{:error, :registry_unavailable}`; `running?/2` raises, since a boolean has no room for "cannot tell".
- `lib/sagents/agent_supervisor.ex` — `get_pid/1` distinguishes `:not_found` from `:registry_unavailable`; `do_wait_for_agent_ready/4` fails fast rather than burning its timeout on a node that cannot recover.
- `lib/sagents/agents_dynamic_supervisor.ex` — `stop_agent/2` error union widened; start-wait fails fast on `:registry_unavailable`.

**Documentation**

- `docs/deployment.md` — **New guide (261 lines).** The failure explained concretely, the required shutdown sequence, readiness vs liveness (a draining node is not unhealthy — restarting it is the wrong response), supervision tree ordering, Fly.io and Kubernetes examples, mapping the error to a retryable 503, and how to verify it.
- `docs/clustering.md` — Added a "Taking a node out of the cluster" section and `Sagents.ready?/0` to the inspection snippets, cross-linking the new guide. It previously had no shutdown or drain guidance at all.
- `lib/sagents/supervisor.ex` (@moduledoc) — Now states explicitly that `Sagents.Supervisor` must precede the Endpoint and why (reverse shutdown order), plus a section documenting the `:rest_for_one` rationale.
- `lib/sagents/process_registry.ex` (@moduledoc) — New "Availability" section covering why neither backend reports the condition and why `:registry_unavailable` must never be collapsed into "not registered".
- `mix.exs` — `docs/deployment.md` added to the docs extras.

## Testing

- `test/sagents/horde/rolling_deploy_test.exs` — **New, 7 tests**, tagged `:cluster` and `:slow`, using `LocalCluster` with real Erlang nodes and `members: :participation`. Runs in ~24s and passed 4 of 4 repeat runs at varying seeds. Covers:
  - **Exact reproduction** — stop `Sagents.Supervisor` (what OTP does on SIGTERM) while leaving the node up, and assert the raise carries the reported message and the reported frames in order.
  - **The window is the whole drain period** — a probe spawned *outside* the supervision tree (the position an Endpoint occupies) polls continuously; the tail of the result sequence contains nothing but raises. This is what proves retry cannot recover.
  - **Blast radius is one node** — 3 nodes, agent placed and replicated, probes on all three; node1 raises on every request while node2 and node3 never raise once. This is the framing that makes readiness (not clustering) the fix.
  - **Guarded API on a draining node** — `ready?/0` reports false and the API returns `:registry_unavailable` instead of raising, and an agent that *is* running is never reported as merely not running.
  - **CRDT self-healing is real** — a surviving peer repairs both membership and registrations after a registry crash, pointing at the same still-running process. Kept as a passing test deliberately: it documents the property and stops a disproven theory being re-litigated.
  - **Single node takes the agent down rather than orphaning it** — the regression test for the `:rest_for_one` + watcher fix.
- `test/sagents/process_registry_availability_test.exs` — **New, 15 tests.** Asserts the ETS table `available?/0` checks is the one the backend actually reads, that `fetch/1` keeps the two error cases distinct, and case-by-case that each raising function raises rather than answering `nil`, `[]` or `0`.
- `test/sagents/registry_watcher_test.exs` — **New, 5 tests.** Stays up while the watched process lives, stops when it dies, waits rather than failing when the name is unclaimed, ignores unrelated DOWN messages, and asserts `Sagents.Supervisor` actually wires the chain `:rest_for_one`.
- `test/support/sagents/cluster_test_helper.ex` — Reusable pieces: `stop_supervisor/1`, `kill_registry/0`, `probe_once/1` (captures a raise instead of propagating it), `start_probe/2` (out-of-tree caller that keeps polling while the tree comes down), `registry_table_present?/0`, `ready?/0`, `classify/1`, `member_nodes/1`, `start_agent/1`.
- `test/sagents/session_test.exs` — Updated Mimic stubs from `get_pid/1` to `fetch_pid/1`.

`mix precommit` already runs `test --include cluster --include slow`, so the deploy path stays covered.

## Migration

No config, schema, or data changes. Existing code compiles unchanged.

- Two error unions were widened (`AgentSupervisor.get_pid/1`, `AgentsDynamicSupervisor.stop_agent/2`) — a `case` that matched them exhaustively needs a catch-all clause.
- `AgentServer.get_pid/1` and `Session.running?/2` now raise a *Sagents* exception where they previously raised an `:ets` one, so nothing that handled the old behaviour correctly changes meaning.
- Behavioural change worth calling out: a registry crash now restarts running agents rather than leaving them orphaned.

The real upgrade work is not in the code — it is wiring `Sagents.ready?/0` into your readiness check per `docs/deployment.md`. Without that, the guarded API turns 500s into 503s but the requests still land on a node that cannot serve them.

## Known gaps, deliberately out of scope

- The FileSystem lookups (`FileSystemServer.whereis/1`, `FileSystemSupervisor.get_filesystem/1`, `SubAgentServer.whereis/1`, `SubAgentsDynamicSupervisor.whereis/1`) were **not** converted to `fetch/1`. They now raise `Sagents.RegistryUnavailableError` instead of an `:ets` `ArgumentError` — already an improvement, and never a silent lie — but their error unions were left alone. Widening them touches more call sites than this bug justifies. Worth a follow-up for consistency.
- `list_agents/0` derives ids from `ProcessRegistry.keys/1` and silently drops unregistered children while `count_agents/0` counts them. With `:rest_for_one` + the watcher in place the orphan cannot arise through this path, so surfacing them was not implemented, but the inconsistency is still there and worth a separate cleanup.
- `test/sagents/horde/node_transfer_test.exs:166` ("agent process is redistributed on graceful shutdown") fails 100% of the time on this machine, in isolation and in a full run. This is **pre-existing** — the only shared code touched here is additive functions on `ClusterTestHelper`. An independent probe of the same scenario showed redistribution working correctly (both keys resolve on the surviving node within 1s, `count_agents/0` goes to 1), so the discrepancy looks like the test's own wait/teardown logic. It needs its own investigation, since graceful shutdown *is* the rolling-deploy path and this test is the only coverage of it.
- `:local` backend: killing `Sagents.Registry` under `config :sagents, :distribution, :local` brought the whole tree down and left it down (no peer, no parent supervisor in the test). The precise mechanism was not isolated and is recorded as an observation only; the follow-up should be done against the `:rest_for_one` change rather than before it.