### PR TITLE
Fix registry crash recovery and document Horde handoff limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,11 +677,18 @@ config :sagents, :distribution, :horde
 
 When Horde is enabled, `Sagents.ProcessRegistry` and `Sagents.ProcessSupervisor` automatically switch to `Horde.Registry` and `Horde.DynamicSupervisor`, giving you:
 
-- **Automatic agent redistribution** across cluster nodes
+- **Agent redistribution** across cluster nodes when a node leaves
 - **State migration** when nodes join or leave the cluster
 - **Node transfer events** broadcast during redistribution so your UI can react
 
 Agents broadcast `{:agent, {:node_transferring, data}}` and `{:agent, {:node_transferred, data}}` events during Horde redistribution, allowing connected clients to follow their agent to a new node.
+
+> Redistribution is best-effort, not a guarantee: a node that leaves before the
+> cluster has converged on its departure takes its agents with it rather than
+> handing them over. Nothing is corrupted or duplicated, and the next
+> `Sagents.Session.ensure_running/3` re-creates the agent from persisted state —
+> but design against the request, not against an agent you assume is still
+> alive. See [Clustering](docs/clustering.md#taking-a-node-out-of-the-cluster).
 
 #### Controlling membership
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -355,47 +355,134 @@ found; restored state always wins.
 
 ## Registry and Discovery
 
-Agents register with a named `Registry`:
+Every agent process registers itself in `Sagents.Registry` at start, through the
+`Sagents.ProcessRegistry` abstraction. That module hides which backend is in
+play:
+
+- `:local` — Elixir's `Registry` (single node, no extra dependency)
+- `:horde` — `Horde.Registry` (cluster-wide, requires the `:horde` dependency)
 
 ```elixir
-# Registration happens in AgentServer.start_link
-Registry.register(Sagents.Registry, agent_id, %{})
+config :sagents, :distribution, :local   # default
+config :sagents, :distribution, :horde
+```
 
-# Discovery
+Registration is by keyed `:via` tuple rather than by bare agent id, so a
+supervisor and the server inside it are separate entries:
+
+```elixir
+Sagents.ProcessRegistry.via_tuple({:agent_server, "conversation-1"})
+Sagents.ProcessRegistry.via_tuple({:agent_supervisor, "conversation-1"})
+```
+
+Discovery:
+
+```elixir
 AgentServer.list_running_agents()
 # => ["conversation-1", "conversation-2"]
 
-AgentServer.whereis("conversation-1")
-# => #PID<0.1234.0>
+AgentServer.fetch_pid("conversation-1")
+# => {:ok, #PID<0.1234.0>}
 ```
+
+### A lookup has three outcomes
+
+A registry read can only be answered while the registry process on *this* node
+is alive. It is not alive while the node is still starting `Sagents.Supervisor`,
+and it is not alive after that supervisor has shut down while the BEAM drains
+during a rolling deploy — a window that lasts as long as the platform's grace
+period, and during which a load balancer may still be routing requests here.
+
+So the API keeps three answers distinct:
+
+```elixir
+case AgentServer.fetch_pid(agent_id) do
+  {:ok, pid} -> ...                        # running
+  {:error, :not_running} -> ...            # the registry answered: nothing there
+  {:error, :registry_unavailable} -> ...   # this node cannot answer at all
+end
+```
+
+**`:registry_unavailable` must never collapse into "not running".** A caller
+that reads "nothing is running" responds by starting an agent, so collapsing the
+two lets a draining node start a second AgentServer for a conversation that
+already has one elsewhere. Both would hold and persist state for it, with
+nothing reporting the conflict.
+
+Functions whose return shape cannot carry the condition raise
+`Sagents.RegistryUnavailableError` instead of answering `nil`, `false`, `[]` or
+`0` — `AgentServer.get_pid/1`, `AgentServer.list_running_agents/0` and
+`Sagents.Session.running?/2` among them. Prefer the tuple-returning forms
+(`AgentServer.fetch_pid/1`, `Sagents.Session.ensure_running/3`) anywhere a web
+request can reach, and map `:registry_unavailable` to a retryable 503 rather
+than a 500: the cluster can serve the request, just not on this node.
+
+`Sagents.ready?/0` exposes the same signal for a readiness endpoint. See
+[Deployments, draining, and readiness](deployment.md).
 
 ## Supervision Tree
 
 ```
-Application Supervisor
+Application Supervisor (your app)
 │
+├── MyApp.Repo
 ├── Phoenix.PubSub (:my_pubsub)
 │
-├── Sagents.Registry
+├── Sagents.Supervisor                          # strategy: :rest_for_one
+│   │
+│   ├── Sagents.Registry                        # Registry | Horde.Registry
+│   ├── Sagents.RegistryWatcher
+│   │
+│   ├── Sagents.AgentsDynamicSupervisor
+│   │   ├── AgentSupervisor ("conversation-1")
+│   │   │   ├── AgentServer
+│   │   │   └── SubAgentsDynamicSupervisor
+│   │   │       ├── SubAgentServer
+│   │   │       └── SubAgentServer
+│   │   │
+│   │   └── AgentSupervisor ("conversation-2")
+│   │       └── ...
+│   │
+│   └── Sagents.FileSystem.FileSystemSupervisor
+│       ├── FileSystemServer ({:user, 1})       # Scoped independently
+│       ├── FileSystemServer ({:user, 2})
+│       └── FileSystemServer ({:project, 42})   # Can be shared across agents
 │
-├── Sagents.FileSystemSupervisor (DynamicSupervisor)
-│   ├── FileSystemServer ({:user, 1})      # Scoped independently
-│   ├── FileSystemServer ({:user, 2})
-│   └── FileSystemServer ({:project, 42})  # Can be shared across agents
-│
-└── Sagents.AgentsDynamicSupervisor (DynamicSupervisor)
-    │
-    ├── AgentSupervisor ("conversation-1")
-    │   ├── AgentServer
-    │   └── SubAgentsDynamicSupervisor
-    │       ├── SubAgentServer
-    │       └── SubAgentServer
-    │
-    ├── AgentSupervisor ("conversation-2")
-    │   └── ...
-    │
-    └── ...
+└── MyAppWeb.Endpoint                           # after Sagents.Supervisor, on purpose
 ```
+
+### Why `:rest_for_one`
+
+An AgentSupervisor and an AgentServer register their `:via` names once, at
+start, and nothing re-registers them afterwards. A registry that came back empty
+underneath them would leave them running but invisible to every lookup — so the
+next request reads "nothing is running" and starts a *second* AgentServer for a
+conversation that already has one, with both persisting state.
+
+`:rest_for_one` expresses that dependency: a registry failure takes the dynamic
+supervisors down with it, agents stop, and the next request re-creates them from
+persisted state. That looks heavy-handed and is the point. Agent state is
+durable, so a restart is recoverable; a silent duplicate is not.
+
+`Sagents.RegistryWatcher` is listed immediately after the registry because
+neither backend lets a registry failure reach `Sagents.Supervisor` on its own.
+Both run the registered process under a supervisor of their own and restart it
+internally with fresh, empty tables, so this supervisor never sees a failed
+child. The watcher monitors the registered process directly and stops when it
+dies, which is what puts the restart into the `:rest_for_one` chain.
+
+### Why the Endpoint comes last
+
+OTP shuts children down in reverse start order. Listed **after**
+`Sagents.Supervisor`, the Endpoint stops accepting requests first and the
+registry is still alive to serve whatever is in flight. Listed **before**, it
+keeps serving requests after the registry is gone, and every one of them fails
+until the BEAM exits.
+
+Correct ordering narrows that window but does not close it, because the node
+stays reachable for the platform's whole drain period. Wiring `Sagents.ready?/0`
+into a readiness check is what closes it. See
+[Deployments, draining, and readiness](deployment.md).
 
 **Flexible Scoping**: FileSystemServer lives outside the AgentSupervisor tree, allowing different scoping strategies. For example:
 - User-scoped filesystem: All of a user's conversations share the same files
@@ -424,6 +511,59 @@ AgentServer.start_link(
   ]
 )
 ```
+
+### Registry Failure
+
+A registry process crashing is rare, but it has a defined outcome: the
+`:rest_for_one` chain restarts the dynamic supervisors below it, agents on that
+node stop, and the next request re-creates them from persisted state.
+
+Two internal pieces make that restart land correctly, and you call neither:
+
+- `Sagents.RegistryWatcher` connects the failure to the restart chain, because
+  both backends restart the registered process internally.
+- `Sagents.LocalRegistry` covers the `:local` backend, where the restart races
+  the outgoing registry's partition process. That partition traps exits, because
+  it links to every registered process, so it does not die with the registry: it
+  terminates asynchronously and holds its registered name for a few milliseconds
+  longer. A start landing inside that window fails with
+  `{:already_started, pid}`, and a supervisor does not retry its way out of a
+  failed restart — it would give up and take the whole tree with it.
+  `Sagents.LocalRegistry` monitors the straggler, waits for it to exit, and
+  retries.
+
+### A Draining or Starting Node
+
+The node's registry cannot answer lookups before `Sagents.Supervisor` has
+started and after it has shut down. The second window is every rolling deploy,
+and it lasts for the platform's whole grace period while the node is still
+reachable.
+
+Lookups report this as `{:error, :registry_unavailable}` or raise
+`Sagents.RegistryUnavailableError` rather than answering with a plausible
+default — see [A lookup has three outcomes](#a-lookup-has-three-outcomes-not-two).
+It is not a race to retry through: on the affected node *every* call fails
+identically until the BEAM exits, so recovery has to come from the request
+landing on a different node.
+
+### Node Departure in a Cluster (`:horde`)
+
+Horde hands a departed node's processes to a survivor only once that survivor
+has converged on the departure and marked the node's member entry dead. An agent
+placed immediately before its node leaves is dropped rather than handed over;
+one that has been running for a couple of seconds or more is redistributed
+reliably. Whether the departure is graceful makes no difference.
+
+A dropped agent is dropped **cleanly**: the registry and Horde's process CRDT
+are both left with no entry for it, so there is no orphan and no duplicate, and
+the next `Sagents.Session.ensure_running/3` starts it again from persisted
+state. That is the same recovery path an inactivity shutdown uses.
+
+The rule to design to: **treat redistribution as an optimization and the next
+request as the guarantee.** Work that must happen should be driven by a request,
+a job, or a supervisor you control, never by assuming Horde kept an agent alive
+somewhere. See
+[Taking a node out of the cluster](clustering.md#taking-a-node-out-of-the-cluster).
 
 ### LLM Errors
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -464,12 +464,23 @@ supervisors down with it, agents stop, and the next request re-creates them from
 persisted state. That looks heavy-handed and is the point. Agent state is
 durable, so a restart is recoverable; a silent duplicate is not.
 
-`Sagents.RegistryWatcher` is listed immediately after the registry because
-neither backend lets a registry failure reach `Sagents.Supervisor` on its own.
-Both run the registered process under a supervisor of their own and restart it
-internally with fresh, empty tables, so this supervisor never sees a failed
-child. The watcher monitors the registered process directly and stops when it
-dies, which is what puts the restart into the `:rest_for_one` chain.
+`Sagents.RegistryWatcher` is listed immediately after the registry because on
+both backends the process that owns the registry's ETS tables sits one level
+below the child `Sagents.Supervisor` supervises, and both backends restart that
+process internally with fresh, empty tables. The registry ends up empty while
+this supervisor never sees a failed child.
+
+Which process that is differs by backend. Under `:horde` it is
+`Horde.RegistryImpl`, which is itself registered as `Sagents.Registry`. Under
+`:local` it is a `Registry.Partition`, a child of the `Registry.Supervisor` that
+holds the name, so watching the name would miss the failure entirely.
+`Sagents.ProcessRegistry.watched_name/0` resolves the difference, and the
+watcher monitors whatever it returns, stopping when that process dies. That is
+what puts the restart into the `:rest_for_one` chain.
+
+A `:local` registry has a second failure mode, `Registry.Supervisor` itself
+dying, which *is* a failed child and reaches the chain unaided. Watching the
+partition covers it too, since the partition dies whenever its supervisor does.
 
 ### Why the Endpoint comes last
 
@@ -521,7 +532,8 @@ node stop, and the next request re-creates them from persisted state.
 Two internal pieces make that restart land correctly, and you call neither:
 
 - `Sagents.RegistryWatcher` connects the failure to the restart chain, because
-  both backends restart the registered process internally.
+  both backends restart the process that owns the registry's tables internally,
+  leaving the registry empty without failing a child of `Sagents.Supervisor`.
 - `Sagents.LocalRegistry` covers the `:local` backend, where the restart races
   the outgoing registry's partition process. That partition traps exits, because
   it links to every registered process, so it does not die with the registry: it
@@ -531,6 +543,19 @@ Two internal pieces make that restart land correctly, and you call neither:
   failed restart — it would give up and take the whole tree with it.
   `Sagents.LocalRegistry` monitors the straggler, waits for it to exit, and
   retries.
+
+Under `:horde` this deliberately over-reacts. A surviving peer repairs a
+restarted registry from the CRDT within a few hundred milliseconds, pointing at
+the processes that were still running, so on a healthy cluster a registry crash
+would have cost nothing. The agents are restarted anyway, because no node can
+tell in time whether that repair is coming: a single-node deployment has no
+peer, and a partitioned cluster is indistinguishable from a healthy one from the
+inside. Over-reacting costs a restart from durable state. Under-reacting leaves
+agents running but unregistered, which is the silent duplicate above.
+
+A registry failure is not part of draining. The watcher sits after the registry
+and OTP stops children in reverse order, so it is gone before the registry is on
+an orderly shutdown.
 
 ### A Draining or Starting Node
 

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -196,11 +196,47 @@ Sagents.ready?()
 
 ## Taking a node out of the cluster
 
-Membership handles a node *leaving*. It does not handle the window where the
-node has stopped its Sagents supervision tree but is still receiving HTTP
-traffic, which is every rolling deploy. Requests arriving in that window cannot
-be served on that node no matter how healthy the rest of the cluster is.
+Membership prunes a departed node automatically. Two things it does **not** do
+are worth being explicit about, because both are easy to assume.
+
+### It does not stop traffic reaching a draining node
+
+Membership says nothing about the window where a node has stopped its Sagents
+supervision tree but is still receiving HTTP traffic, which is every rolling
+deploy. Requests arriving in that window cannot be served on that node no matter
+how healthy the rest of the cluster is.
 
 See [Deployments, draining, and readiness](deployment.md) for the readiness
 signal (`Sagents.ready?/0`), the required shutdown sequence, and platform
 examples.
+
+### It does not guarantee the departed node's agents are handed over
+
+Pruning membership and handing over processes are separate mechanisms. Horde
+takes over a departed node's processes only after the surviving node has
+converged on the departure and marked that member dead. A node that leaves
+before that convergence completes takes its agents with it.
+
+In practice this affects agents placed shortly before the departure. An agent
+that has been running for a couple of seconds or more is redistributed
+reliably; one placed immediately before the node leaves is dropped in roughly
+one departure in four. Whether the node leaves gracefully (`:init.stop`) or
+abruptly makes no difference.
+
+A dropped agent is dropped **cleanly**. Both the registry and the supervisor's
+process CRDT are left with no entry for it, so there is no orphan and no
+duplicate, and the next `Sagents.Session.ensure_running/3` starts it again from
+persisted state. This is the same recovery path an inactivity shutdown uses,
+which is why it is a bounded cost rather than data loss.
+
+The rule to design to: **treat redistribution as an optimization and the next
+request as the guarantee.** Work that must happen should be driven by a request,
+a job, or a supervisor you control — never by assuming Horde kept an agent alive
+somewhere on your behalf.
+
+If you want to observe this directly, the coverage is in
+`test/sagents/horde/node_transfer_test.exs`:
+
+```bash
+mix test test/sagents/horde/node_transfer_test.exs --include cluster
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -286,15 +286,42 @@ them is recoverable; a silent duplicate is not.
 Two internal pieces make that restart reach the right processes, and you do not
 interact with either:
 
-- `Sagents.RegistryWatcher`. Under `:horde` the registry is restarted by Horde's
-  own supervisor, so `Sagents.Supervisor` never sees a failed child of its own.
-  The watcher monitors the registered process and fails in its place.
+- `Sagents.RegistryWatcher`. On both backends the process owning the registry's
+  ETS tables runs under a supervisor of the backend's own, which restarts it
+  with empty tables without failing a child of `Sagents.Supervisor`. Under
+  `:horde` that process is the one registered as `Sagents.Registry`; under
+  `:local` it is a `Registry.Partition` one level below the name. The watcher
+  monitors it and fails in its place.
 - `Sagents.LocalRegistry`. Under `:local` the restart races the outgoing
   registry's partition process, which traps exits and holds its registered name
   for a few milliseconds after the registry is gone. A start landing inside that
   window fails with `{:already_started, pid}`, and a supervisor does not recover
   from a failed restart. `Sagents.LocalRegistry` waits for the straggler to exit
   and retries.
+
+None of this is part of draining. The watcher is listed after the registry, and
+OTP stops children in reverse order, so it is already gone by the time the
+registry stops on a normal shutdown. A draining node never looks like a registry
+failure.
+
+> #### On a cluster this deliberately over-reacts {: .info}
+>
+> Under `:horde`, registrations replicate through the same CRDT as membership,
+> so a surviving peer repairs a restarted registry within a few hundred
+> milliseconds, pointing at the very processes that were still running. Left
+> alone, a registry crash on a healthy multi-node cluster would cost nothing.
+>
+> Sagents restarts the node's agents anyway. Nothing on the affected node can
+> tell in time whether a repair is coming: a single-node deployment has no peer,
+> and a partitioned or lagging cluster looks identical from the inside until the
+> window has passed. Guessing wrong leaves agents running but unregistered,
+> which is what produces two AgentServers persisting one conversation with
+> nothing reporting it.
+>
+> So the failure is bounded to a restart from durable state rather than left to
+> become silent corruption. What it means for you: a registry crash costs the
+> in-flight LLM turns on that node, the same as a deploy does, and conversations
+> resume on the next request.
 
 ## Verifying it
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -226,10 +226,10 @@ default. On request paths, prefer the tuple-returning forms
 Agent state is durable, which is what makes all of this recoverable.
 
 - **Graceful shutdown.** Agents terminate, persist their state, and broadcast a
-  shutdown event. Under `:horde`, surviving members pick up the work when a
-  request next asks for it.
-- **A node vanishing abruptly.** Horde detects the departure and redistributes.
-  The new process starts from persisted state.
+  shutdown event.
+- **A node vanishing abruptly.** Under `:horde`, surviving members usually
+  restart the departed node's agents on their own. Treat this as an
+  optimization, not a guarantee — see the warning below.
 - **The next request either way.** `Sagents.Session.ensure_running/3` starts the
   agent from persisted state on whichever node handles it. A conversation that
   was mid-run resumes as a fresh run rather than continuing the interrupted one.
@@ -237,6 +237,64 @@ Agent state is durable, which is what makes all of this recoverable.
 So a deploy costs you in-flight LLM turns, not conversations. Sizing your drain
 window is a question of how long you are willing to wait for those turns, not of
 whether state survives.
+
+> #### Redistribution is best-effort; the next request is the guarantee {: .warning}
+>
+> Horde only hands a departed node's processes to a survivor once that survivor
+> has converged on the departure — its member entry for the node has to be
+> marked dead before the takeover clause fires. A node that leaves *before* that
+> convergence completes takes its agents with it instead of handing them over.
+>
+> An agent that has been running for a couple of seconds or more is
+> redistributed reliably. One placed immediately before the node departs is
+> dropped in roughly one departure in four. Both `:init.stop` and an abrupt node
+> loss behave identically here — being graceful does not help.
+>
+> When an agent is dropped it is **dropped cleanly, not corrupted**: the
+> registry and Horde's process CRDT are both left empty for that agent, so
+> nothing is left behind and no duplicate is possible. The next
+> `Sagents.Session.ensure_running/3` starts it again from persisted state,
+> exactly as it would after an inactivity shutdown.
+>
+> The practical consequences:
+>
+> - **Do not treat redistribution as a correctness property.** Anything that
+>   must happen must be driven by a request, a job, or a supervisor you control,
+>   not by an agent that you assume Horde kept alive somewhere.
+> - **The drain sequence above is what protects you.** Steps 1 to 4 stop new
+>   agents being placed on a node that is about to leave, which is exactly the
+>   case that loses them.
+
+### If the registry itself fails
+
+A node's registry process crashing is rare, but it has a defined outcome on both
+backends, and it is deliberately a noisy one.
+
+`Sagents.Supervisor` supervises its children `:rest_for_one` with the registry
+first, so a registry failure restarts the agent and filesystem supervisors too.
+Running agents on that node stop and are re-created from persisted state on the
+next request.
+
+That looks heavy-handed and is the point. An `AgentSupervisor` and an
+`AgentServer` register their `:via` names once, at start, and nothing
+re-registers them. A registry that comes back empty underneath them leaves them
+running but invisible to every lookup — so the next request reads "nothing is
+running" and starts a *second* AgentServer for a conversation that already has
+one, with both persisting state and nothing reporting the conflict. Restarting
+them is recoverable; a silent duplicate is not.
+
+Two internal pieces make that restart reach the right processes, and you do not
+interact with either:
+
+- `Sagents.RegistryWatcher`. Under `:horde` the registry is restarted by Horde's
+  own supervisor, so `Sagents.Supervisor` never sees a failed child of its own.
+  The watcher monitors the registered process and fails in its place.
+- `Sagents.LocalRegistry`. Under `:local` the restart races the outgoing
+  registry's partition process, which traps exits and holds its registered name
+  for a few milliseconds after the registry is gone. A start landing inside that
+  window fails with `{:already_started, pid}`, and a supervisor does not recover
+  from a failed restart. `Sagents.LocalRegistry` waits for the straggler to exit
+  and retries.
 
 ## Verifying it
 

--- a/lib/sagents/local_registry.ex
+++ b/lib/sagents/local_registry.ex
@@ -28,17 +28,32 @@ defmodule Sagents.LocalRegistry do
   sleep, so it costs exactly as long as the collision lasts.
 
   Only the `:local` backend needs this. Under `:horde` the name
-  `Sagents.Registry` belongs to `Horde.RegistryImpl`, a child of Horde's own
-  supervisor, which restarts it internally — `Sagents.Supervisor` never sees a
-  failed child there, which is why `Sagents.RegistryWatcher` exists.
+  `Sagents.Registry` belongs to `Horde.RegistryImpl`, which Horde's own
+  supervisor restarts internally, so there is no name for a restart to collide
+  with.
+
+  This covers the case where `Registry.Supervisor` itself dies. The other
+  `:local` failure mode, where the supervisor survives and its partition is
+  replaced with empty tables, produces no failed child at all and is handled by
+  `Sagents.RegistryWatcher`.
   """
 
   @retries 5
-  @exit_timeout 5_000
+
+  # The collision is measured in single-digit milliseconds, so this is three
+  # orders of magnitude of headroom. It is a bound on the pathological case, not
+  # a duration anything is expected to wait: past it, the name is held by
+  # something that is not going away and retrying cannot help.
+  @exit_timeout 1_000
 
   @doc """
   Start `Registry` with `opts`, retrying past a name still held by the previous
   registry's terminating partition.
+
+  Every retry is gated on observing the straggler actually exit, so the retry
+  count bounds how many distinct collisions are tolerated rather than how long
+  this blocks. If a straggler does not exit within #{@exit_timeout}ms, the
+  underlying error is returned instead of retrying against it.
   """
   @spec start_link(keyword()) :: Supervisor.on_start()
   def start_link(opts) do
@@ -47,20 +62,24 @@ defmodule Sagents.LocalRegistry do
 
   defp start_link(opts, retries_left) do
     case Registry.start_link(opts) do
-      {:error, {:shutdown, {:failed_to_start_child, _id, {:already_started, pid}}}}
+      {:error, {:shutdown, {:failed_to_start_child, _id, {:already_started, pid}}}} = error
       when retries_left > 0 ->
-        await_exit(pid)
-        start_link(opts, retries_left - 1)
+        case await_exit(pid) do
+          :ok -> start_link(opts, retries_left - 1)
+          :timeout -> error
+        end
 
       other ->
         other
     end
   end
 
-  # The collision is a process that is already terminating, so waiting on its
-  # exit is precise. The timeout only guards against the name being held by
-  # something that is not going away, in which case retrying is pointless and
-  # the caller should see the real error.
+  # Runs in the caller, which is the supervisor starting this child, so it
+  # blocks that supervisor for as long as it waits. The collision is a process
+  # that is already terminating, which is why waiting on its exit is both
+  # precise and short. A timeout means the assumption does not hold, and the
+  # caller is told rather than made to wait again.
+  @spec await_exit(pid()) :: :ok | :timeout
   defp await_exit(pid) do
     ref = Process.monitor(pid)
 
@@ -69,7 +88,7 @@ defmodule Sagents.LocalRegistry do
     after
       @exit_timeout ->
         Process.demonitor(ref, [:flush])
-        :ok
+        :timeout
     end
   end
 end

--- a/lib/sagents/local_registry.ex
+++ b/lib/sagents/local_registry.ex
@@ -1,0 +1,75 @@
+defmodule Sagents.LocalRegistry do
+  @moduledoc """
+  Starts Elixir's `Registry` for the `:local` backend, tolerating a restart that
+  races the previous registry's own shutdown.
+
+  ## Why this exists
+
+  `Registry.start_link/1` starts a `Registry.Supervisor` registered under the
+  given name, and that supervisor's children are `Registry.Partition` processes
+  registered under derived names such as `Sagents.Registry.PIDPartition0`.
+
+  `Registry.Partition` traps exits, because it links to every registered
+  process. So when `Sagents.Registry` dies abnormally, the partition does *not*
+  die with it: it receives the exit signal as a message and terminates
+  asynchronously, holding its registered name for a few milliseconds longer.
+
+  `Sagents.Supervisor` restarts its failed child immediately, well inside that
+  window. `Registry.Supervisor.init/1` then tries to start a partition under a
+  name the outgoing one still holds and gets `{:already_started, pid}`. The
+  restart fails, and because a failed restart is not something a supervisor
+  retries its way out of, `Sagents.Supervisor` gives up and exits `:shutdown` —
+  taking the registry, both dynamic supervisors and every running agent with it,
+  permanently. Nothing below it comes back until the host application's own
+  supervisor restarts the whole subtree.
+
+  This module closes that window: on an `:already_started` collision it waits
+  for the straggler to actually exit, then retries. The wait is a monitor, not a
+  sleep, so it costs exactly as long as the collision lasts.
+
+  Only the `:local` backend needs this. Under `:horde` the name
+  `Sagents.Registry` belongs to `Horde.RegistryImpl`, a child of Horde's own
+  supervisor, which restarts it internally — `Sagents.Supervisor` never sees a
+  failed child there, which is why `Sagents.RegistryWatcher` exists.
+  """
+
+  @retries 5
+  @exit_timeout 5_000
+
+  @doc """
+  Start `Registry` with `opts`, retrying past a name still held by the previous
+  registry's terminating partition.
+  """
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    start_link(opts, @retries)
+  end
+
+  defp start_link(opts, retries_left) do
+    case Registry.start_link(opts) do
+      {:error, {:shutdown, {:failed_to_start_child, _id, {:already_started, pid}}}}
+      when retries_left > 0 ->
+        await_exit(pid)
+        start_link(opts, retries_left - 1)
+
+      other ->
+        other
+    end
+  end
+
+  # The collision is a process that is already terminating, so waiting on its
+  # exit is precise. The timeout only guards against the name being held by
+  # something that is not going away, in which case retrying is pointless and
+  # the caller should see the real error.
+  defp await_exit(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      @exit_timeout ->
+        Process.demonitor(ref, [:flush])
+        :ok
+    end
+  end
+end

--- a/lib/sagents/process_registry.ex
+++ b/lib/sagents/process_registry.ex
@@ -66,7 +66,15 @@ defmodule Sagents.ProcessRegistry do
   def child_spec(_opts) do
     case distribution_type() do
       :local ->
-        {Registry, keys: :unique, name: @registry_name}
+        # Sagents.LocalRegistry wraps Registry.start_link/1 to survive a restart
+        # that races the outgoing registry's partition process, which traps
+        # exits and holds its registered name for a few milliseconds after the
+        # registry itself is gone. See `Sagents.LocalRegistry`.
+        %{
+          id: @registry_name,
+          start: {Sagents.LocalRegistry, :start_link, [[keys: :unique, name: @registry_name]]},
+          type: :supervisor
+        }
 
       :horde ->
         assert_horde_available!()

--- a/lib/sagents/process_registry.ex
+++ b/lib/sagents/process_registry.ex
@@ -257,6 +257,35 @@ defmodule Sagents.ProcessRegistry do
   """
   def registry_name, do: @registry_name
 
+  @doc """
+  The name of the process whose death empties this node's registry.
+
+  This is not always `registry_name/0`, and the difference is what
+  `Sagents.RegistryWatcher` has to monitor.
+
+  Under `:horde` the two are the same: `Horde.RegistryImpl` is registered as
+  `Sagents.Registry` and owns its own ETS tables.
+
+  Under `:local` they differ. `Registry.start_link/1` registers a
+  `Registry.Supervisor` under the given name, but the tables that hold
+  registrations belong to its `Registry.Partition` child. That partition can be
+  restarted with empty tables while the supervisor keeps running and keeps its
+  registered name, so watching the name would miss the failure entirely.
+  Watching the partition catches both: it also dies whenever its supervisor
+  does.
+
+  The single-partition name is safe because `child_spec/1` starts the registry
+  without a `:partitions` option. Changing that would need this to return every
+  partition.
+  """
+  @spec watched_name() :: atom()
+  def watched_name do
+    case distribution_type() do
+      :local -> Module.concat(@registry_name, "PIDPartition0")
+      :horde -> @registry_name
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Internal
   # ---------------------------------------------------------------------------

--- a/lib/sagents/registry_watcher.ex
+++ b/lib/sagents/registry_watcher.ex
@@ -26,7 +26,7 @@ defmodule Sagents.RegistryWatcher do
   `Horde.Registry.start_link/3` starts a supervisor, and the process registered
   under the name is its child. When that child crashes, Horde's own supervisor
   restarts it with fresh, empty ETS tables, so `Sagents.Supervisor` sees no
-  failed child of its own. Elixir's `Registry` is shaped the same way.
+  failed child of its own.
 
   This watcher monitors the process registered as `Sagents.Registry` directly
   and stops when it dies. Listed immediately after the registry in
@@ -34,6 +34,18 @@ defmodule Sagents.RegistryWatcher do
   does act on, taking the agent and filesystem supervisors down with it. Agents
   stop, and the next request re-creates them from persisted state with fresh
   registrations.
+
+  ## The `:local` backend is shaped differently
+
+  Elixir's `Registry` is *not* shaped like Horde's. `Registry.start_link/1`
+  registers its `Registry.Supervisor` under the given name, so `Sagents.Registry`
+  is a direct child of `Sagents.Supervisor` there and its death is already a
+  child failure the `:rest_for_one` strategy sees. The watcher is redundant in
+  that mode rather than load-bearing; it stops as well, which costs one extra
+  restart and changes nothing else.
+
+  What the `:local` backend needs instead is `Sagents.LocalRegistry`, because
+  its restart races the outgoing registry's partition process.
 
   ## The trade being made
 

--- a/lib/sagents/registry_watcher.ex
+++ b/lib/sagents/registry_watcher.ex
@@ -15,49 +15,87 @@ defmodule Sagents.RegistryWatcher do
 
   `Sagents.Supervisor` uses `:rest_for_one` so a registry failure restarts
   everything listed after it, which re-establishes those registrations. The
-  watcher is what connects a registry failure to that chain, because the failure
-  happens one level below where the strategy can see it:
+  watcher is what connects a registry failure to that chain, because on both
+  backends the process that holds the registrations sits one level below where
+  the strategy can see it.
+
+  ## What each backend actually looks like
+
+  Under `:horde`, `Horde.Registry.start_link/3` starts a supervisor, and the
+  process registered under the name is its child:
 
       Sagents.Supervisor
       └── Sagents.Horde.RegistryImpl   <- the child Sagents.Supervisor supervises (a supervisor)
-          ├── Horde.RegistryImpl       <- the process registered as Sagents.Registry
+          ├── Horde.RegistryImpl       <- registered as Sagents.Registry, owns the ETS tables
           └── Sagents.Registry.Crdt
 
-  `Horde.Registry.start_link/3` starts a supervisor, and the process registered
-  under the name is its child. When that child crashes, Horde's own supervisor
-  restarts it with fresh, empty ETS tables, so `Sagents.Supervisor` sees no
-  failed child of its own.
+  Under `:local`, `Registry.start_link/1` registers its `Registry.Supervisor`
+  under the given name, and the ETS tables belong to a `Registry.Partition`
+  child:
 
-  This watcher monitors the process registered as `Sagents.Registry` directly
-  and stops when it dies. Listed immediately after the registry in
+      Sagents.Supervisor
+      └── Sagents.Registry                    <- the child Sagents.Supervisor supervises
+          └── Sagents.Registry.PIDPartition0  <- owns the ETS tables
+
+  The shapes differ, and so does which process `Sagents.Supervisor` can see fail
+  on its own. What does not differ is that in both cases a backend supervisor
+  can replace the table-owning process with a fresh, empty one without ever
+  failing a child of `Sagents.Supervisor`:
+
+  - `:horde` restarts `Horde.RegistryImpl` under `Sagents.Horde.RegistryImpl`.
+  - `:local` restarts `Registry.Partition` under `Sagents.Registry`.
+
+  A `:local` registry has a second failure mode, `Registry.Supervisor` itself
+  dying, which *is* a failed child and does reach `:rest_for_one` unaided. That
+  one is already handled, and `Sagents.LocalRegistry` is what makes its restart
+  survivable. It is the partition case that needs watching.
+
+  ## What is watched
+
+  This watcher monitors `Sagents.ProcessRegistry.watched_name/0`, the process
+  that owns the tables rather than the process that holds the registry's name.
+  On `:horde` those are the same process; on `:local` they are not.
+
+  It stops when that process dies. Listed immediately after the registry in
   `Sagents.Supervisor`, its stop is a child failure the `:rest_for_one` strategy
   does act on, taking the agent and filesystem supervisors down with it. Agents
   stop, and the next request re-creates them from persisted state with fresh
   registrations.
 
-  ## The `:local` backend is shaped differently
+  Watching the partition covers the `Registry.Supervisor` case too, since the
+  partition dies whenever its supervisor does.
 
-  Elixir's `Registry` is *not* shaped like Horde's. `Registry.start_link/1`
-  registers its `Registry.Supervisor` under the given name, so `Sagents.Registry`
-  is a direct child of `Sagents.Supervisor` there and its death is already a
-  child failure the `:rest_for_one` strategy sees. The watcher is redundant in
-  that mode rather than load-bearing; it stops as well, which costs one extra
-  restart and changes nothing else.
+  ## When it fires, and when it does not
 
-  What the `:local` backend needs instead is `Sagents.LocalRegistry`, because
-  its restart races the outgoing registry's partition process.
+  Only the death of the table-owning process fires it. In particular it does
+  **not** fire on an orderly shutdown. The watcher is listed after the registry
+  so that it can monitor it, and OTP terminates children in reverse order, so
+  that same placement means the watcher is already gone by the time the registry
+  stops. A draining node therefore never looks like a registry failure. Draining
+  is handled by `Sagents.ready?/0` and the guarded lookups instead, not here.
 
   ## The trade being made
 
   A registry crash costs running agents rather than leaving duplicates behind.
-  That is deliberate. Agent state is durable, so a restart is recoverable and
-  mostly invisible to a user. A silent duplicate is neither: it corrupts the
-  conversation, and nothing reports it.
+  Agent state is durable, so a restart is recoverable and mostly invisible to a
+  user. A silent duplicate is neither: two AgentServers hold and persist state
+  for one conversation, and nothing reports the conflict.
 
-  This is a rare event. It does not fire on a normal shutdown, when the whole
-  tree is coming down anyway, and it does not fire when Horde repairs a
-  restarted registry from a peer's CRDT without the registered process ever
-  dying.
+  On a healthy multi-node cluster this is more disruptive than doing nothing
+  would have been. Horde replicates registrations through the same CRDT as
+  membership, so a peer repairs a restarted registry within a few hundred
+  milliseconds, pointing at the very processes this watcher just took down.
+
+  It fires anyway, because nothing on this node can tell in time whether a
+  repair is coming. A single-node deployment has no peer at all. A partitioned
+  or lagging cluster is indistinguishable from a healthy one from here, right up
+  until the window where guessing wrong leaves agents alive and unregistered.
+  The cost of over-reacting is a restart from durable state; the cost of
+  under-reacting is silent corruption. The asymmetry is the whole argument.
+
+  Both halves are pinned in `test/sagents/horde/rolling_deploy_test.exs`: a peer
+  repairing a crashed node's registry, and an agent on the crashed node coming
+  down regardless.
 
   Started automatically by `Sagents.Supervisor`. You do not start it yourself.
   """
@@ -78,7 +116,7 @@ defmodule Sagents.RegistryWatcher do
   - `:name` - registered name, defaults to this module. `nil` starts it
     unnamed, which tests use to run more than one at a time.
   - `:registry_name` - the process name to watch, defaults to
-    `Sagents.ProcessRegistry.registry_name/0`. Overridden only in tests.
+    `Sagents.ProcessRegistry.watched_name/0`. Overridden only in tests.
   """
   def start_link(opts \\ []) do
     case Keyword.get(opts, :name, __MODULE__) do
@@ -90,7 +128,7 @@ defmodule Sagents.RegistryWatcher do
   @impl true
   def init(opts) do
     registry_name =
-      Keyword.get(opts, :registry_name, Sagents.ProcessRegistry.registry_name())
+      Keyword.get(opts, :registry_name, Sagents.ProcessRegistry.watched_name())
 
     {:ok, %{ref: nil, pid: nil, registry_name: registry_name}, {:continue, :monitor}}
   end
@@ -107,9 +145,10 @@ defmodule Sagents.RegistryWatcher do
 
   def handle_info({:DOWN, ref, :process, pid, reason}, %{ref: ref, pid: pid} = state) do
     Logger.warning(
-      "#{inspect(state.registry_name)} went down (#{inspect(reason)}). " <>
-        "Restarting agent and filesystem supervisors so their registrations are " <>
-        "re-established. Running agents will restart from persisted state."
+      "#{inspect(state.registry_name)}, which holds this node's registry contents, " <>
+        "went down (#{inspect(reason)}). Restarting agent and filesystem supervisors " <>
+        "so their registrations are re-established. Running agents will restart from " <>
+        "persisted state."
     )
 
     # A `{:shutdown, _}` reason still restarts a :permanent child, and unlike a

--- a/lib/sagents/session.ex
+++ b/lib/sagents/session.ex
@@ -503,7 +503,7 @@ defmodule Sagents.Session do
                       # ...
                     end
 
-                See PLAN-RefactoringTheAgentAPI-FactoriesAndConfig.md.
+                See `Sagents.Factory` for the full contract.
                 """,
                 __STACKTRACE__
       else

--- a/lib/sagents/supervisor.ex
+++ b/lib/sagents/supervisor.ex
@@ -76,10 +76,12 @@ defmodule Sagents.Supervisor do
   not.
 
   `Sagents.RegistryWatcher` sits between the registry and its dependents to
-  connect a registry failure to that chain. Both backends run the registered
-  process under a supervisor of their own and restart it internally, so the
-  failure is never a failed child of *this* supervisor. The watcher monitors the
-  registered process directly and fails in its place.
+  connect a registry failure to that chain. On both backends the process that
+  owns the registry's ETS tables runs under a supervisor of the backend's own,
+  which can replace it with a fresh, empty one without ever failing a child of
+  *this* supervisor. The watcher monitors that table-owning process and fails in
+  its place. See `Sagents.ProcessRegistry.watched_name/0` for why it is not
+  always the process registered as `Sagents.Registry`.
   """
 
   use Supervisor
@@ -98,11 +100,12 @@ defmodule Sagents.Supervisor do
       [
         Sagents.ProcessRegistry.child_spec([]),
         # Sits between the registry and its dependents on purpose. Both Horde
-        # and Elixir's Registry run the registered process under their own
-        # supervisor, so a crash there is restarted internally and
-        # Sagents.Supervisor never sees a child fail. The watcher observes the
-        # registered process directly and fails in its place, which is what
-        # puts the restart below into the :rest_for_one chain.
+        # and Elixir's Registry own their ETS tables in a process one level
+        # below the child listed above, and both restart that process
+        # internally with empty tables, so Sagents.Supervisor never sees a
+        # child fail. The watcher observes the table-owning process and fails
+        # in its place, which is what puts the restart below into the
+        # :rest_for_one chain.
         Sagents.RegistryWatcher,
         Sagents.ProcessSupervisor.agents_supervisor_child_spec([]),
         Sagents.ProcessSupervisor.filesystem_supervisor_child_spec([])

--- a/mix.exs
+++ b/mix.exs
@@ -101,6 +101,18 @@ defmodule Sagents.MixProject do
       groups_for_extras: [
         Docs: Path.wildcard("docs/*.md")
       ],
+      # Internals of Elixir's Registry and of Horde that our docs name because
+      # the explanations are not checkable without them. All carry
+      # `@moduledoc false`, so ExDoc cannot link them and warns on every
+      # mention. Listing them here renders the reference as plain code and
+      # drops the warning, rather than making the prose vaguer to stay quiet.
+      skip_code_autolink_to: [
+        "Horde.RegistryImpl",
+        "Registry.Partition",
+        "Registry.Supervisor",
+        "Registry.Supervisor.init/1",
+        "Registry.key_info!/1"
+      ],
       groups_for_modules: [
         "Core Agent": [
           Sagents.Agent,

--- a/test/sagents/horde/node_transfer_test.exs
+++ b/test/sagents/horde/node_transfer_test.exs
@@ -18,6 +18,14 @@ defmodule Sagents.Horde.NodeTransferTest do
   # Timeout for waiting for Horde to redistribute processes after node departure
   @redistribution_timeout 15_000
 
+  # Timeout for waiting for Horde's CRDTs to replicate an agent to another node.
+  # The sync interval is 300ms, so this is generous.
+  @replication_timeout 10_000
+
+  # Additional settle for the part of Horde's convergence that is not observable
+  # from outside. See wait_for_replication/4.
+  @convergence_settle 2_000
+
   setup_all do
     LocalCluster.start()
 
@@ -116,6 +124,77 @@ defmodule Sagents.Horde.NodeTransferTest do
     end
   end
 
+  # An agent can only be handed to a survivor that already knows about it, so
+  # every one of these tests has to let Horde converge before it takes a node
+  # away. Two parts, because one is observable and one is not:
+  #
+  #   1. `replicated?/3` asserts the observable preconditions — the registry
+  #      entry, the child spec, and an `:alive` member entry for the departing
+  #      node — and normally passes within ~100ms.
+  #
+  #   2. `@convergence_settle` covers Horde's remaining internal convergence,
+  #      which is not observable from outside its GenServer state. Removing a
+  #      node before it completes strands the agent instead of moving it: the
+  #      child spec is dropped from the process CRDT and never re-added, and
+  #      nothing restarts it. On the observable preconditions alone, roughly one
+  #      departure in four strands.
+  #
+  # A stranded agent is recoverable, not lost: the registry and the process CRDT
+  # are left clean, so the next `Session.ensure_running/3` starts it again from
+  # persisted state. Redistribution is an optimization, so the settle belongs
+  # here rather than being something the library should guarantee away.
+  defp wait_for_replication(node, departing_node, agent_ids, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    result = do_wait_for_replication(node, departing_node, agent_ids, deadline)
+    if result == :ok, do: Process.sleep(@convergence_settle)
+    result
+  end
+
+  defp do_wait_for_replication(node, departing_node, agent_ids, deadline) do
+    if replicated?(node, departing_node, agent_ids) do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) < deadline do
+        Process.sleep(50)
+        do_wait_for_replication(node, departing_node, agent_ids, deadline)
+      else
+        {:error, :timeout}
+      end
+    end
+  end
+
+  defp replicated?(node, departing_node, agent_ids) do
+    # The registry CRDT: every agent resolves from this node.
+    registrations_replicated? =
+      Enum.all?(agent_ids, fn agent_id ->
+        match?(
+          {:ok, pid} when is_pid(pid),
+          :rpc.call(node, Sagents.AgentSupervisor, :get_pid, [agent_id])
+        )
+      end)
+
+    # The supervisor CRDT: this node knows the child specs it would have to
+    # restart. count_children/1 reports the cluster-wide view, not the local one.
+    specs_replicated? =
+      case :rpc.call(node, Horde.DynamicSupervisor, :count_children, [
+             Sagents.AgentsDynamicSupervisor
+           ]) do
+        %{specs: specs} -> specs >= length(agent_ids)
+        _other -> false
+      end
+
+    # Horde's member bookkeeping: this node must already see the departing node
+    # as an :alive member, because handing its processes over means marking that
+    # entry :dead, and an entry that was never there cannot be marked.
+    member_converged? =
+      :rpc.call(node, Sagents.ClusterTestHelper, :member_alive?, [
+        Sagents.AgentsDynamicSupervisor,
+        departing_node
+      ]) == true
+
+    registrations_replicated? and specs_replicated? and member_converged?
+  end
+
   defp wait_for_node_down(node, timeout) do
     deadline = System.monotonic_time(:millisecond) + timeout
     do_wait_for_node_down(node, deadline)
@@ -146,9 +225,8 @@ defmodule Sagents.Horde.NodeTransferTest do
 
       assert is_pid(original_pid)
 
-      # Wait for CRDT to sync the process entry to the surviving node.
-      # Without this, the surviving node may not know the process exists.
-      Process.sleep(2_000)
+      assert :ok =
+               wait_for_replication(surviving_node, agent_node, [agent_id], @replication_timeout)
 
       # Stop the node that has the agent
       LocalCluster.stop(cluster, agent_node)
@@ -171,6 +249,13 @@ defmodule Sagents.Horde.NodeTransferTest do
 
       agent_node = node(original_pid)
       surviving_node = if agent_node == node1, do: node2, else: node1
+
+      # The surviving node can only take the agent over once Horde has
+      # replicated it there. Without this wait the node departs before the
+      # replica lands and the agent is lost rather than moved — which has
+      # nothing to do with the shutdown being graceful.
+      assert :ok =
+               wait_for_replication(surviving_node, agent_node, [agent_id], @replication_timeout)
 
       # Graceful shutdown: call :init.stop on the node (like System.stop/0)
       :rpc.cast(agent_node, :init, :stop, [])
@@ -207,7 +292,8 @@ defmodule Sagents.Horde.NodeTransferTest do
       agents_on_node2 = Enum.filter(agents, fn {_id, _pid, n} -> n == node2 end)
 
       # Wait for CRDT to sync process entries to both nodes
-      Process.sleep(2_000)
+      all_ids = Enum.map(agents, fn {id, _pid, _node} -> id end)
+      assert :ok = wait_for_replication(node2, node1, all_ids, @replication_timeout)
 
       # Stop node1
       LocalCluster.stop(cluster, node1)

--- a/test/sagents/horde/rolling_deploy_test.exs
+++ b/test/sagents/horde/rolling_deploy_test.exs
@@ -280,7 +280,7 @@ defmodule Sagents.Horde.RollingDeployTest do
   # 3. Registry crash: heals from a peer, restarts without one
   # ===========================================================================
 
-  describe "registry crash under Sagents.Supervisor's :one_for_one strategy" do
+  describe "registry crash under Sagents.Supervisor's :rest_for_one strategy" do
     test "a peer repairs both membership and registrations after a registry crash" do
       {cluster, [node1, node2]} = start_cluster(2)
       start_supervisor_on([node1, node2])
@@ -302,25 +302,92 @@ defmodule Sagents.Horde.RollingDeployTest do
       {:ok, before_pid} = rpc(node1, :probe_once, [agent_id])
       assert is_pid(before_pid)
 
-      assert {:ok, _dead_pid} = rpc(node1, :kill_registry, [])
+      # Horde places an agent by hashing its id, so which node hosts it varies
+      # from run to run. Crash the registry on the node that does *not* host it.
+      # This test is about the CRDT repairing a restarted registry from a peer;
+      # crashing the host's registry also takes the agent down through the
+      # :rest_for_one chain, which is the separate property covered below.
+      agent_node = node(before_pid)
+      crash_node = if agent_node == node1, do: node2, else: node1
 
-      assert wait_until(fn -> rpc(node1, :registered?, [Sagents.Registry]) end),
+      assert {:ok, _dead_pid} = rpc(crash_node, :kill_registry, [])
+
+      assert wait_until(fn -> rpc(crash_node, :registered?, [Sagents.Registry]) end),
              "registry was not restarted by Sagents.Supervisor"
 
       # `ClusterConfig.resolve_members/1` seeds the restarted registry with a
       # self-only member set, and MembershipManager only re-applies members on a
       # :pg join or leave, neither of which happened. Membership is nonetheless
       # restored, because Horde replicates the member set through the same CRDT
-      # as registrations and node2 still lists node1 as a neighbour.
-      assert wait_until(fn -> member_nodes(node1, Sagents.Registry) == both end),
+      # as registrations and the peer still lists this node as a neighbour.
+      assert wait_until(fn -> member_nodes(crash_node, Sagents.Registry) == both end),
              "membership did not heal from the peer: " <>
-               inspect(member_nodes(node1, Sagents.Registry))
+               inspect(member_nodes(crash_node, Sagents.Registry))
 
       # The registration comes back for the same reason, pointing at the same
-      # still-running process. No agent was lost.
-      assert wait_until(fn -> rpc(node1, :probe_once, [agent_id]) == {:ok, before_pid} end),
+      # still-running process on the untouched node.
+      assert wait_until(fn -> rpc(crash_node, :probe_once, [agent_id]) == {:ok, before_pid} end),
              "registration did not heal from the peer: " <>
-               inspect(rpc(node1, :probe_once, [agent_id]))
+               inspect(rpc(crash_node, :probe_once, [agent_id]))
+
+      assert :rpc.call(agent_node, Process, :alive?, [before_pid]),
+             "the agent on the untouched node should not have been disturbed"
+
+      LocalCluster.stop(cluster)
+    end
+
+    test "an agent on the crashed node comes down even though a peer could heal it" do
+      # The deliberate trade, pinned. The previous test shows a peer repairs a
+      # restarted registry within a few hundred milliseconds, pointing at the
+      # still-running processes. For an agent on the node that crashed, the
+      # watcher pre-empts that repair and takes it down anyway.
+      #
+      # That is strictly more disruptive than waiting would have been *when the
+      # heal arrives*. It is chosen regardless, because nothing on this node can
+      # tell in time whether a heal is coming: a single-node deployment has no
+      # peer, and a partitioned or lagging cluster looks identical from here
+      # until it is too late. Guessing wrong leaves agents alive and
+      # unregistered, which is what produces two AgentServers persisting one
+      # conversation. A restart is recoverable from durable state; a duplicate
+      # is not.
+      {cluster, [node1, node2]} = start_cluster(2)
+      start_supervisor_on([node1, node2])
+
+      both = Enum.sort([node1, node2])
+
+      assert wait_until(fn -> member_nodes(node1, Sagents.Registry) == both end),
+             "registry membership did not converge"
+
+      agent_id = "conversation-crash-host-#{System.unique_integer([:positive])}"
+      {:ok, sup_pid} = rpc(node1, :start_agent, [agent_id])
+
+      assert wait_until(fn ->
+               match?({:ok, pid} when is_pid(pid), rpc(node2, :probe_once, [agent_id]))
+             end),
+             "registration did not replicate"
+
+      # Crash the registry on whichever node actually hosts the agent.
+      agent_node = node(sup_pid)
+      other_node = if agent_node == node1, do: node2, else: node1
+
+      assert {:ok, _dead_pid} = rpc(agent_node, :kill_registry, [])
+
+      assert wait_until(fn -> not :rpc.call(agent_node, Process, :alive?, [sup_pid]) end),
+             "the AgentSupervisor should have come down with the :rest_for_one chain"
+
+      assert wait_until(fn -> rpc(agent_node, :registered?, [Sagents.Registry]) end),
+             "registry was not restarted"
+
+      # Settle, then confirm the cluster never holds two AgentSupervisors for
+      # this conversation. Whether it settles at one (Horde re-placed the child
+      # spec from its CRDT) or none (the next request re-creates it) is not the
+      # property being pinned; "never two" is.
+      Process.sleep(3_000)
+
+      count = :rpc.call(other_node, Sagents.AgentsDynamicSupervisor, :count_agents, [])
+
+      assert count in [0, 1],
+             "expected at most one AgentSupervisor for #{agent_id}, found #{inspect(count)}"
 
       LocalCluster.stop(cluster)
     end

--- a/test/sagents/local_registry_test.exs
+++ b/test/sagents/local_registry_test.exs
@@ -12,13 +12,16 @@ defmodule Sagents.LocalRegistryTest do
   """
   use ExUnit.Case, async: false
 
+  # These tests need no cleanup callback. `start_link/1` links the registry to
+  # the test process, so ExUnit's exit already tears it down, and each test uses
+  # a name of its own. An `on_exit` that stops the registry itself races that
+  # teardown: the supervisor is mid-shutdown by the time the callback runs, so
+  # `Process.alive?/1` still says true and `Supervisor.stop/1` exits `:shutdown`.
   describe "start_link/1" do
     test "starts a registry normally" do
       name = unique_name()
       assert {:ok, pid} = Sagents.LocalRegistry.start_link(keys: :unique, name: name)
       assert Process.whereis(name) == pid
-
-      on_exit(fn -> if Process.alive?(pid), do: Supervisor.stop(pid) end)
     end
 
     test "retries past a partition name still held by the previous registry" do
@@ -49,8 +52,6 @@ defmodule Sagents.LocalRegistryTest do
       assert {:ok, _owner} = Registry.register(name, :some_key, :value)
       assert [{self_pid, :value}] = Registry.lookup(name, :some_key)
       assert self_pid == self()
-
-      on_exit(fn -> if Process.alive?(second), do: Supervisor.stop(second) end)
     end
   end
 

--- a/test/sagents/local_registry_test.exs
+++ b/test/sagents/local_registry_test.exs
@@ -1,0 +1,150 @@
+defmodule Sagents.LocalRegistryTest do
+  @moduledoc """
+  Covers the name-reuse race that a `:local` registry restart has to survive.
+
+  `Registry.Partition` traps exits, so it outlives an abnormal exit of the
+  `Registry.Supervisor` registered as `Sagents.Registry` by a few milliseconds
+  while it terminates, still holding its own registered name. A `:rest_for_one`
+  restart lands inside that window, and a plain `Registry.start_link/1` there
+  fails with `{:already_started, pid}`. A supervisor does not recover from a
+  failed restart, so that failure would take the whole `Sagents.Supervisor`
+  tree down and keep it down.
+  """
+  use ExUnit.Case, async: false
+
+  describe "start_link/1" do
+    test "starts a registry normally" do
+      name = unique_name()
+      assert {:ok, pid} = Sagents.LocalRegistry.start_link(keys: :unique, name: name)
+      assert Process.whereis(name) == pid
+
+      on_exit(fn -> if Process.alive?(pid), do: Supervisor.stop(pid) end)
+    end
+
+    test "retries past a partition name still held by the previous registry" do
+      # start_link/1 links the registry here, and we are about to kill it.
+      Process.flag(:trap_exit, true)
+
+      name = unique_name()
+      {:ok, first} = Sagents.LocalRegistry.start_link(keys: :unique, name: name)
+
+      partition = Process.whereis(Module.concat(name, "PIDPartition0"))
+      assert Process.info(partition, :trap_exit) == {:trap_exit, true}
+
+      # Brutally kill the registry and restart it the moment it is gone, which
+      # is exactly what :rest_for_one does. Waiting for the DOWN frees the
+      # registry's own name but not the partition's — the partition traps exits
+      # and is still terminating — so a bare Registry.start_link/1 here fails
+      # with {:already_started, partition}.
+      ref = Process.monitor(first)
+      Process.exit(first, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^first, :killed}, 2_000
+      assert Process.alive?(partition), "the partition should still be terminating"
+
+      assert {:ok, second} = Sagents.LocalRegistry.start_link(keys: :unique, name: name)
+      assert second != first
+      assert Process.whereis(name) == second
+
+      # The new registry is usable, not merely started.
+      assert {:ok, _owner} = Registry.register(name, :some_key, :value)
+      assert [{self_pid, :value}] = Registry.lookup(name, :some_key)
+      assert self_pid == self()
+
+      on_exit(fn -> if Process.alive?(second), do: Supervisor.stop(second) end)
+    end
+  end
+
+  describe "Sagents.Supervisor with the local backend" do
+    @tag :slow
+    test "survives a registry crash and restarts the chain under it" do
+      # This has to drive the real Sagents.Supervisor, because the failure being
+      # covered is that supervisor giving up. The suite-wide one is linked to
+      # the process that started it in test_helper.exs, so its death would abort
+      # the whole run. Retire it with a :normal exit, which does not propagate,
+      # and run a detached replacement that is linked to nothing — the same
+      # trick ClusterTestHelper.start_supervisor/0 uses. on_exit puts an equally
+      # detached tree back, because every later test needs one.
+      :ok = Supervisor.stop(Sagents.Supervisor, :normal)
+      sup = start_detached_supervisor()
+
+      on_exit(fn ->
+        if pid = Process.whereis(Sagents.Supervisor) do
+          Supervisor.stop(pid, :normal)
+        end
+
+        start_detached_supervisor()
+      end)
+
+      before = child_pids()
+
+      registry = Process.whereis(Sagents.Registry)
+      ref = Process.monitor(registry)
+      sup_ref = Process.monitor(sup)
+      Process.exit(registry, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^registry, :killed}, 2_000
+
+      refute_receive {:DOWN, ^sup_ref, :process, ^sup, _reason}, 2_000
+      assert Process.alive?(sup)
+
+      # :rest_for_one: the registry and everything listed after it is replaced.
+      after_ = wait_for_restart(before)
+
+      assert Map.keys(before) == Map.keys(after_)
+
+      for {id, old_pid} <- before do
+        assert after_[id] != old_pid, "#{inspect(id)} should have been restarted"
+      end
+
+      # And the replacement registry actually answers.
+      assert Sagents.ProcessRegistry.available?()
+      assert Sagents.ProcessRegistry.fetch({:agent_server, "nobody"}) == {:error, :not_registered}
+    end
+  end
+
+  # Start Sagents.Supervisor linked to a throwaway process that immediately
+  # unlinks it, so the tree outlives this test and its death takes nothing with
+  # it. That is what lets the test observe a supervisor giving up rather than
+  # being killed by it.
+  defp start_detached_supervisor do
+    parent = self()
+
+    spawn(fn ->
+      {:ok, pid} = Sagents.Supervisor.start_link(name: Sagents.Supervisor)
+      Process.unlink(pid)
+      send(parent, {:detached_supervisor, pid})
+    end)
+
+    receive do
+      {:detached_supervisor, pid} -> pid
+    after
+      5_000 -> flunk("Sagents.Supervisor did not start")
+    end
+  end
+
+  defp child_pids do
+    Sagents.Supervisor
+    |> Supervisor.which_children()
+    |> Map.new(fn {id, pid, _type, _mods} -> {id, pid} end)
+  end
+
+  defp wait_for_restart(before, attempts \\ 50) do
+    current = child_pids()
+
+    cond do
+      attempts == 0 ->
+        current
+
+      map_size(current) == map_size(before) and
+          Enum.all?(current, fn {id, pid} -> is_pid(pid) and before[id] != pid end) ->
+        current
+
+      true ->
+        Process.sleep(50)
+        wait_for_restart(before, attempts - 1)
+    end
+  end
+
+  defp unique_name do
+    Module.concat(__MODULE__, "R#{System.unique_integer([:positive])}")
+  end
+end

--- a/test/sagents/process_registry_test.exs
+++ b/test/sagents/process_registry_test.exs
@@ -55,6 +55,29 @@ defmodule Sagents.ProcessRegistryTest do
     end
   end
 
+  describe "watched_name/0" do
+    test "names the partition rather than the registry under the local backend" do
+      # `Registry.start_link/1` registers a `Registry.Supervisor` under
+      # `Sagents.Registry`, but the ETS tables holding registrations belong to
+      # its partition child. The supervisor can restart that partition with
+      # empty tables and keep its own name and pid, so watching the name would
+      # miss the failure. This is what `Sagents.RegistryWatcher` monitors.
+      assert ProcessRegistry.watched_name() == Sagents.Registry.PIDPartition0
+      refute ProcessRegistry.watched_name() == ProcessRegistry.registry_name()
+    end
+
+    test "the named process exists and owns the registry's tables" do
+      partition = Process.whereis(ProcessRegistry.watched_name())
+
+      assert is_pid(partition), "expected #{inspect(ProcessRegistry.watched_name())} to be alive"
+
+      # It traps exits because it links to every registered process, which is
+      # both why it outlives its supervisor briefly and why registered
+      # processes survive its death rather than dying with it.
+      assert Process.info(partition, :trap_exit) == {:trap_exit, true}
+    end
+  end
+
   describe "child_spec/1" do
     test "returns a valid child spec for default registry" do
       spec = ProcessRegistry.child_spec([])

--- a/test/sagents/process_registry_test.exs
+++ b/test/sagents/process_registry_test.exs
@@ -58,7 +58,16 @@ defmodule Sagents.ProcessRegistryTest do
   describe "child_spec/1" do
     test "returns a valid child spec for default registry" do
       spec = ProcessRegistry.child_spec([])
-      assert {Registry, [keys: :unique, name: Sagents.Registry]} = spec
+
+      # Started through Sagents.LocalRegistry rather than Registry directly, so
+      # a restart that races the outgoing registry's terminating partition
+      # retries instead of taking Sagents.Supervisor down with it.
+      assert %{
+               id: Sagents.Registry,
+               start:
+                 {Sagents.LocalRegistry, :start_link, [[keys: :unique, name: Sagents.Registry]]},
+               type: :supervisor
+             } = spec
     end
   end
 end

--- a/test/sagents/registry_watcher_test.exs
+++ b/test/sagents/registry_watcher_test.exs
@@ -10,6 +10,8 @@ defmodule Sagents.RegistryWatcherTest do
   """
   use ExUnit.Case, async: false
 
+  alias Sagents.AgentsDynamicSupervisor
+  alias Sagents.ClusterTestHelper
   alias Sagents.RegistryWatcher
 
   describe "monitoring" do
@@ -102,9 +104,92 @@ defmodule Sagents.RegistryWatcherTest do
     end
   end
 
+  describe "a registry emptied without any child of Sagents.Supervisor failing" do
+    @tag :slow
+    test "reaches the :rest_for_one chain, so no agent is left orphaned" do
+      # The failure this covers is the one the watcher exists for, driven
+      # against the real tree rather than a stand-in. Under `:local` the process
+      # that owns the registry's ETS tables is a `Registry.Partition` below the
+      # `Registry.Supervisor` that holds the name. Its own supervisor restarts
+      # it with empty tables, so `Sagents.Registry` keeps its pid and
+      # `Sagents.Supervisor` sees nothing fail.
+      #
+      # Every registration is lost regardless. The agents survive it, because
+      # `AgentServer` traps exits and `AgentSupervisor` is a supervisor, so both
+      # ignore the exit signal the dying partition sends down its links. Without
+      # the watcher they keep running with no registration, lookups answer "not
+      # running", and the next request starts a second AgentServer for a
+      # conversation that already has one.
+      Process.flag(:trap_exit, true)
+
+      :ok = Supervisor.stop(Sagents.Supervisor, :normal)
+      {:ok, sup} = ClusterTestHelper.start_supervisor()
+
+      on_exit(fn ->
+        if pid = Process.whereis(Sagents.Supervisor), do: Supervisor.stop(pid, :normal)
+        {:ok, _replacement} = ClusterTestHelper.start_supervisor()
+      end)
+
+      agent_id = "watcher-partition-#{System.unique_integer([:positive])}"
+      {:ok, agent_sup} = ClusterTestHelper.start_agent(agent_id)
+
+      assert AgentsDynamicSupervisor.count_agents() == 1
+      assert {:ok, _pid} = Sagents.AgentServer.fetch_pid(agent_id)
+
+      agent_sup_ref = Process.monitor(agent_sup)
+
+      # Named literally rather than through `ProcessRegistry.watched_name/0`.
+      # Killing whatever the watcher happens to watch would pass no matter what
+      # that function returned, which is the regression being guarded against.
+      partition = Process.whereis(Sagents.Registry.PIDPartition0)
+      assert is_pid(partition), "no partition owns the registry's contents"
+
+      # `Sagents.Registry` itself must survive this, or the test is exercising
+      # the ordinary failed-child path instead of the invisible one.
+      registry = Process.whereis(Sagents.Registry)
+      Process.exit(partition, :kill)
+      assert Process.whereis(Sagents.Registry) == registry
+
+      # The agent comes down with the chain rather than surviving unregistered.
+      assert_receive {:DOWN, ^agent_sup_ref, :process, ^agent_sup, _reason}, 5_000
+
+      # The tree itself survives, and settles with no agent rather than two.
+      assert Process.alive?(sup)
+      assert eventually(fn -> AgentsDynamicSupervisor.count_agents() == 0 end)
+      assert eventually(fn -> Sagents.ProcessRegistry.available?() end)
+
+      # And the registry works again, so the next request can re-create it.
+      assert {:ok, _new_sup} = ClusterTestHelper.start_agent(agent_id)
+      assert AgentsDynamicSupervisor.count_agents() == 1
+      assert AgentsDynamicSupervisor.list_agents() == [agent_id]
+    end
+  end
+
   # ===========================================================================
   # Helpers
   # ===========================================================================
+
+  # Poll a predicate that becomes true once a supervisor restart has settled.
+  # Anything observed here is reached by a chain of restarts rather than by a
+  # message this process can wait on.
+  defp eventually(fun, attempts \\ 100) do
+    cond do
+      safe_predicate(fun) -> true
+      attempts == 0 -> false
+      true -> Process.sleep(50) && eventually(fun, attempts - 1)
+    end
+  end
+
+  # Mid-restart the registry may be briefly absent and the dynamic supervisors
+  # may be shutting down, so a predicate can raise or exit rather than answer.
+  # Either is "not settled yet", not a result.
+  defp safe_predicate(fun) do
+    fun.()
+  rescue
+    _error -> false
+  catch
+    :exit, _reason -> false
+  end
 
   defp start_stand_in_registry do
     name = unique_name()

--- a/test/support/sagents/cluster_test_helper.ex
+++ b/test/support/sagents/cluster_test_helper.ex
@@ -73,6 +73,33 @@ defmodule Sagents.ClusterTestHelper do
   end
 
   @doc """
+  Whether `horde` on this node currently sees `other_node` as an `:alive` member.
+
+  Horde only hands a departed node's processes to a survivor when the survivor's
+  `members_info` entry for that node says `status: :dead`, and `mark_dead/2` can
+  only mark an entry that is already there. A node removed before its member
+  entry has converged on the survivor therefore takes its processes with it
+  instead of handing them over.
+
+  Reads Horde's internal GenServer state, so this is a test-only probe.
+  """
+  def member_alive?(horde, other_node) do
+    case :sys.get_state(horde) do
+      %{members_info: members_info} ->
+        Enum.any?(members_info, fn {{_name, member_node}, member} ->
+          member_node == other_node and member.status == :alive
+        end)
+
+      _other ->
+        false
+    end
+  rescue
+    _error -> false
+  catch
+    _kind, _reason -> false
+  end
+
+  @doc """
   The `node()`s in `horde`'s member set as seen from this node.
   """
   def member_nodes(horde) do


### PR DESCRIPTION
## Problem

Two items were left outside the scope of #168. Both were
observed during that work, neither was caused by it, and neither was part of the
reported bug:

1. `test/sagents/horde/node_transfer_test.exs` ("agent process is redistributed
   on graceful shutdown") failed 100% of the time. Graceful shutdown *is* the
   rolling-deploy path, and that test was its only coverage.
2. Killing `Sagents.Registry` under `config :sagents, :distribution, :local`
   took the entire `Sagents.Supervisor` tree down and kept it down. The
   mechanism was never isolated, so §6 recorded it as an observation with an
   unverified theory attached.

Investigating both turned up a third problem that neither §6 nor #168 had seen:
the `:rest_for_one` and `RegistryWatcher` machinery added in #168 did not
actually cover the `:local` backend, which is the default.

## Solution

### 1. Redistribution: settle time, not gracefulness

§6 claimed an independent probe showed the handoff working, which pointed the
blame at the test's wait and teardown logic. That probe was accepting the
**stale pid** the surviving node's registry still held for the departed node's
process. Adding `node(pid) == surviving_node` removes the false positive, and
with it the apparent difference between the two tests.

An A/B matrix over both departure modes and both settle times:

| departure | settle | outcome |
| --- | --- | --- |
| graceful, `:init.stop` | 0ms | agent stranded |
| abrupt, `LocalCluster.stop/2` | 0ms | agent stranded |
| graceful, `:init.stop` | 2000ms | redistributed |
| abrupt, `LocalCluster.stop/2` | 2000ms | redistributed |

Gracefulness is not the variable. **Settle time is.** The passing test had
`Process.sleep(2_000)` after placing the agent; the failing one had nothing.

CRDT replication of the agent is not the explanation either. It completes before
`start_agent_sync/1` returns: the registry entry, the child spec, and an
`:alive` member entry for the departing node are all on the survivor within a
few milliseconds. Waiting on those three explicitly, with no sleep, still
stranded roughly one departure in four. The rest of the window is inside Horde's
own convergence and is not observable from outside its GenServer state, which is
why the fix is a documented settle rather than a predicate.

A stranded agent is dropped **cleanly**: the registry and the process CRDT are
both left with no entry, so there is no orphan and no duplicate, and the next
`Session.ensure_running/3` re-creates it from persisted state. That is a gap in
Horde's redistribution guarantee under rapid membership change, not a Sagents
defect, so it is fixed in the tests and the docs rather than in the library.

It does mean the docs were promising more than the system delivers. README,
`docs/clustering.md`, `docs/deployment.md` and `docs/architecture.md` now state
the rule directly: **treat redistribution as an optimization and the next
request as the guarantee.**

### 2. The `:local` registry crash: a name-reuse race

Confirmed and root-caused. The ETS-name-collision theory in §6 was close, but it
is a *process* name collision, on the registry's partition rather than the
registry itself.

`Registry.Partition` traps exits, because it links to every registered process.
So it does not die with the registry: it takes the exit as a message and
terminates asynchronously, holding `Sagents.Registry.PIDPartition0` for a few
milliseconds longer. `Sagents.Supervisor` restarts its failed child well inside
that window, `Registry.Supervisor.init/1` tries to start a partition under a
name the outgoing one still holds, and the restart fails with
`{:already_started, pid}`. A supervisor does not retry its way out of a failed
restart, so `Sagents.Supervisor` exits `:shutdown` and takes the registry, both
dynamic supervisors and every running agent with it, permanently.

`Sagents.LocalRegistry` closes the window: on an `:already_started` collision it
monitors the straggler, waits for its actual exit, and retries. A monitor rather
than a sleep, so it costs exactly as long as the collision lasts. Retries are
gated on observing that exit, so the retry count bounds how many distinct
collisions are tolerated rather than how long the call blocks, and a straggler
that does not exit returns the underlying error instead of being retried
against. That matters because the wait runs in the calling supervisor.

### 3. The `:local` backend was still losing agents silently

`Registry.start_link/1` registers a `Registry.Supervisor` under the given name,
but the ETS tables that hold registrations belong to its `Registry.Partition`
child, supervised `:one_for_all`. Kill the partition and the supervisor restarts
it with empty tables while the registered name never changes hands.

Every registration is lost. The registered processes survive it, because
`AgentServer` traps exits and `AgentSupervisor` is a supervisor, so both ignore
the exit signal the dying partition sends down its links. Three layers then miss
the failure independently: `Sagents.Supervisor` sees no failed child,
`RegistryWatcher` was monitoring the process holding the *name* rather than the
one holding the *tables*, and `available?/0` checks a table owned by the
surviving supervisor, so `Sagents.ready?/0` kept the node in rotation.

Reproduced against the real tree, this is the §4 signature exactly:
`count_agents() == 2` with `list_agents() == [agent_id]`. Two AgentSupervisors
for one conversation, both persisting state, one invisible to every Sagents API.

`Sagents.ProcessRegistry.watched_name/0` now resolves the process whose death
empties the registry, and `RegistryWatcher` monitors that instead of the
registry name. Under `:horde` they are the same process. Under `:local` the
partition is watched, which also covers `Registry.Supervisor` dying, since the
partition dies with it.

### On the deliberate over-reaction

Under `:horde`, a surviving peer repairs a restarted registry from the CRDT
within a few hundred milliseconds, pointing at the processes that were still
running, so on a healthy cluster a registry crash would cost nothing. The
watcher fires anyway and restarts the node's agents.

That is intentional, and now documented as such rather than left implicit. No
node can tell in time whether a repair is coming: a single-node deployment has
no peer, and a partitioned or lagging cluster is indistinguishable from a
healthy one from the inside. Over-reacting costs a restart from durable state.
Under-reacting leaves agents running but unregistered, which is the silent
duplicate above.

Both halves are now pinned by tests. The existing peer-repair test was passing
only because Horde usually placed the agent on the *other* node; it failed 3 of
10 runs when instrumented. It now chooses which node to crash based on where the
agent actually landed, and a sibling test covers the case it was accidentally
skipping.

## Changes

**Library**

- [`lib/sagents/local_registry.ex`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/lib/sagents/local_registry.ex)
  (new) - wraps `Registry.start_link/1`, retrying past a partition name the
  outgoing registry still holds, with the retry gated on an observed exit.
- [`lib/sagents/process_registry.ex`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/lib/sagents/process_registry.ex)
  - `child_spec/1` starts the `:local` backend through `Sagents.LocalRegistry`;
  new `watched_name/0` resolves the process that owns the registry's contents.
- [`lib/sagents/registry_watcher.ex`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/lib/sagents/registry_watcher.ex)
  - monitors `watched_name/0` rather than the registry name. Moduledoc rewritten
  with both backends' actual shapes, when it fires and when it does not, and the
  reasoning behind the cluster over-reaction.
- [`lib/sagents/supervisor.ex`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/lib/sagents/supervisor.ex)
  (@moduledoc and inline comment) - corrected the claim that both backends hide
  a registry failure the same way; they do, but not via the process it named.
- [`lib/sagents/session.ex`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/lib/sagents/session.ex)
  - a raised error pointed the reader at a plan document; it now points at
  `Sagents.Factory`.

**Docs**

- [`docs/architecture.md`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/docs/architecture.md)
  - the Registry and Discovery section described a bare `Registry.register/3`
  the code has not used for some time, and the supervision tree diagram showed
  the registry and supervisors as siblings under the application. Both rewritten,
  plus new sections on why `:rest_for_one`, registry failure, a draining node,
  and node departure.
- [`docs/clustering.md`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/docs/clustering.md)
  - separates the two things membership does not do: stop traffic to a draining
  node, and guarantee a departed node's agents are handed over.
- [`docs/deployment.md`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/docs/deployment.md)
  - best-effort redistribution warning, "If the registry itself fails", and the
  cluster over-reaction callout with its operator-facing cost.
- [`README.md`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/README.md)
  - "Automatic agent redistribution" overstated it; now qualified and linked.

**Tests**

- [`test/sagents/local_registry_test.exs`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/test/sagents/local_registry_test.exs)
  (new) - covers the retry directly, and drives the real `Sagents.Supervisor`
  through a registry kill to assert the chain restarts rather than the tree
  giving up.
- [`test/sagents/registry_watcher_test.exs`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/test/sagents/registry_watcher_test.exs)
  - regression test for the partition crash, driving the real tree with a real
  agent. It names `Sagents.Registry.PIDPartition0` literally rather than going
  through `watched_name/0`, so it still fails if that resolution regresses.
- [`test/sagents/horde/rolling_deploy_test.exs`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/test/sagents/horde/rolling_deploy_test.exs)
  - the peer-repair test now crashes the registry on the node that does not host
  the agent, making it deterministic; a new sibling test pins that an agent on
  the crashed node comes down anyway. Stale `:one_for_one` describe title fixed.
- [`test/sagents/horde/node_transfer_test.exs`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/test/sagents/horde/node_transfer_test.exs)
  - `wait_for_replication/4` replaces bare sleeps: it asserts three observable
  preconditions, then applies a documented `@convergence_settle`.
- [`test/support/sagents/cluster_test_helper.ex`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/test/support/sagents/cluster_test_helper.ex)
  - `member_alive?/2`, a test-only probe of Horde's member bookkeeping.
- [`test/sagents/process_registry_test.exs`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/test/sagents/process_registry_test.exs)
  - the new `:local` child spec shape, and `watched_name/0`.

**Build**

- [`mix.exs`](https://github.com/sagents-ai/sagents/blob/me-rolling-deploys-updates/mix.exs)
  - `skip_code_autolink_to` for the `Registry` and Horde internals the docs name.
  They carry `@moduledoc false`, so ExDoc warns on every mention. This drops the
  warnings without making the prose vaguer to stay quiet.

## Testing

```bash
mix test --include cluster --include slow
# 1746 passed, 1 skipped, 2 excluded
```

Both new library behaviours were verified to fail without their fix:

- `local_registry_test.exs` fails 0 of 3 passing without `Sagents.LocalRegistry`.
- The partition regression test fails at its `assert_receive {:DOWN, ...}` when
  `watched_name/0` is reverted to the registry name: the AgentSupervisor survives
  the crash unregistered, which is the orphan signature.

`rolling_deploy_test.exs` now passes 6 of 6 repeat runs, against 7 of 10 before
the placement fix. `node_transfer_test.exs` runs against real Erlang nodes via
`LocalCluster`; the settle narrows Horde's convergence window rather than
closing it, which is why the docs describe redistribution as best-effort.

One pre-existing flake in `ConversationTitleIntegrationTest` appeared in a
`mix precommit` run. It is unrelated to this work, passed 4 of 4 in isolation,
and the full suite was clean on re-run.

## Not included

The v0.12.0 `CHANGELOG.md` entry and the `mix.exs` version bump are staged
locally but deliberately left off this branch, since they cover #168 as well.

Known follow-ups, all flagged during review and none blocking: `child_spec/1` on
`Sagents.LocalRegistry` (it has none, so `{Sagents.LocalRegistry, opts}` in a
tree would raise), `ClusterTestHelper.member_alive?/2`'s catch-all rescue
turning a genuine probe bug into a timeout, and `AgentSupervisor.get_pid/1`
returning a tuple while `AgentServer.get_pid/1` returns `pid | nil`.