### PR TITLE
Close registry-unavailable gaps found in downstream migrations

### DIFF
--- a/MIGRATION_PROMPT_v0.11.x_TO_v0.12.0.md
+++ b/MIGRATION_PROMPT_v0.11.x_TO_v0.12.0.md
@@ -1,0 +1,644 @@
+# Migration Guide: v0.11.x → v0.12.0
+
+## What changed and why
+
+A node stops being able to serve agent requests **the moment
+`Sagents.Supervisor` shuts down**, and it keeps accepting TCP connections for
+the rest of the platform's grace period, commonly 30 to 60 seconds. That is
+every rolling deploy, every scale-down, every machine migration.
+
+`Sagents.Registry` lives in ETS tables owned by a process on the local node.
+When that process stops, the tables go with it. So during the drain window:
+
+- the node still holds open connections and still accepts new ones,
+- no agent lookup on it can succeed,
+- and no retry helps, because the registry is not coming back on this node.
+
+It is not a race with a small window. It is a stable condition for the whole
+drain, and it is **local**: every other node in the cluster serves the same
+request perfectly well. That makes it a routing problem, not an outage.
+
+Before v0.12.0 that condition had no name. Neither backend reports it:
+`Horde.Registry.lookup/2` derives its ETS table name arithmetically and reads it
+unguarded, and Elixir's `Registry` does the same through `Registry.key_info!/1`,
+so both raise `ArgumentError` from inside `:ets`. Where Sagents caught that or
+never triggered it, the answer came back as `nil`, `[]`, `false`, or `0`, which
+a caller reads as **"nothing is running"** and responds to by starting an agent.
+On a draining node that silently produces a second AgentServer for a
+conversation that already has one elsewhere, with both holding and persisting
+its state.
+
+v0.12.0 makes the condition a first-class answer:
+
+- `Sagents.ready?/0`: a boolean for your **readiness** check.
+- `{:error, :registry_unavailable}`: from every API whose return shape can
+  carry it. Deliberately distinct from `{:error, :not_running}`.
+- `Sagents.RegistryUnavailableError`: raised by the APIs whose shape cannot,
+  rather than answering with a plausible-looking default.
+
+The release also hardens the case where the registry process itself fails.
+`Sagents.Supervisor` now supervises `:rest_for_one` with the registry first, so
+a registry failure restarts the dynamic supervisors under it. Agents register
+their `:via` names once, at start, and nothing re-registers them, so a registry
+that comes back empty would otherwise leave them running but invisible to every
+lookup. That is the same silent-duplicate outcome by a different route.
+
+And separately: `Sagents.Middleware.Summarization` no longer picks a cutoff that
+orphans a tool result.
+
+## Read this before you start
+
+**This release changes library code, not the modules `mix sagents.setup`
+generated into your app.** That is the opposite of the v0.11.0 migration. The
+behaviour changes underneath you on `mix deps.get`, whether or not you edit a
+line. Two consequences:
+
+1. **Functions you use today can now raise.** They raise only on a node whose
+   Sagents tree is down, so your tests pass and local development never sees it.
+   Production sees it on every deploy.
+2. **A registry crash now restarts your agents** instead of leaving them
+   running-but-unfindable. Costed and deliberate; see step 6.
+
+**The compiler will not help you, and dialyzer only barely will.** Every changed
+return type is *additive*: a new `{:error, :registry_unavailable}` member in a
+union. A `case` that already handles `{:error, :not_found}` still compiles; it
+raises `CaseClauseError` at runtime on a draining node. If you run dialyzer, do
+it now and read anything it says about the call sites in step 4; it is the only
+automatic signal in this migration, and it is partial.
+
+So this is **search-driven**. Work the steps in order and run the greps.
+
+Nothing here is required to keep working: upgrade, change nothing, and your app
+behaves as v0.11.1 did except that the failures during a drain are now named
+instead of anonymous. Everything below is what turns that naming into a fix.
+
+---
+
+## Prerequisites
+
+1. Start from a clean, committed workspace.
+2. Update the dependency to `~> 0.12.0` and run `mix deps.get`.
+3. Run `mix compile`. **It will be clean.** That is expected.
+4. Note which distribution backend you run, because the drain window exists on
+   both and this guide applies to both:
+
+   ```
+   grep -rn "config :sagents, :distribution" config/
+   ```
+
+---
+
+## Migration Steps
+
+### 1. Add a readiness endpoint, and keep liveness separate
+
+This is the step that actually fixes anything. Everything else narrows windows
+or reports failures well.
+
+```elixir
+# lib/my_app_web/controllers/health_controller.ex
+defmodule MyAppWeb.HealthController do
+  use MyAppWeb, :controller
+
+  # Liveness: is the BEAM up at all? Never consults Sagents.
+  def alive(conn, _params), do: send_resp(conn, 200, "ok")
+
+  # Readiness: should this node receive traffic?
+  def ready(conn, _params) do
+    if Sagents.ready?() do
+      send_resp(conn, 200, "ok")
+    else
+      send_resp(conn, 503, "draining")
+    end
+  end
+end
+```
+
+```elixir
+# lib/my_app_web/router.ex
+scope "/health", MyAppWeb do
+  get "/alive", HealthController, :alive
+  get "/ready", HealthController, :ready
+end
+```
+
+Three things about that snippet are load-bearing:
+
+- **`ready` and `alive` must not share a source.** A draining node is not
+  unhealthy, and the platform's response to a failed *liveness* probe is a
+  restart, which is exactly the wrong move. If you have one `/health` route
+  today doing both jobs, split it.
+- **The scope has no `pipe_through`.** Not the browser pipeline (a probe has no
+  session and no CSRF token), and not an `:api` pipeline either: `plug :accepts,
+  ["json"]` makes the route content-negotiate, and probes frequently send no
+  `Accept` header at all. The probe then gets a 406 and reads the node as
+  unhealthy for a reason that has nothing to do with Sagents. A bare `send_resp`
+  cannot fail that way.
+- **Keep it out of any authentication pipeline**, and out of any plug that
+  itself touches Sagents.
+
+If you already have a readiness endpoint, add `Sagents.ready?/0` to it rather
+than adding a second one. The platform polls one URL.
+
+---
+
+### 2. Put `Sagents.Supervisor` before your Endpoint
+
+```
+grep -n "Sagents.Supervisor" lib/*/application.ex
+```
+
+```elixir
+children = [
+  MyApp.Repo,
+  {Phoenix.PubSub, name: MyApp.PubSub},
+  MyAppWeb.Presence,
+  Sagents.Supervisor,
+  MyAppWeb.Endpoint      # after, so OTP stops it FIRST
+]
+```
+
+OTP stops children in reverse order. Listed this way the Endpoint stops
+accepting requests first and the registry is still alive to serve what is in
+flight. Listed the other way round, the Endpoint outlives the registry and
+serves the entire drain with a dead one underneath it.
+
+This is a one-line change and most apps already have it right, because
+`Sagents.Supervisor` also has to come *after* Repo and PubSub so agents can
+persist state and broadcast on the way down. Both constraints point at the same
+slot. Confirm it rather than assuming it.
+
+Correct ordering narrows the window; it does not remove it. The node stays
+reachable until the platform stops routing to it, which is what steps 1 and 3
+are for. Do all three.
+
+---
+
+### 3. Give the platform time to notice
+
+A readiness check that flips to `false` at the same instant the tree comes down
+buys you nothing. The platform has to poll it, observe the change, and update
+its routing table *before* shutdown proceeds.
+
+The sequence you are building:
+
+```
+1. platform signals shutdown
+2. node reports NOT ready          <-- Sagents.ready?() goes false
+3. load balancer stops routing to it
+4. in-flight requests finish
+5. supervision tree stops           <-- registry goes away here
+6. BEAM exits
+```
+
+Out of the box only 5 and 6 happen. Steps 2 through 4 are yours.
+
+The general principle, whatever the platform: intercept the shutdown signal,
+make readiness report false, wait longer than
+`(readiness poll interval × unhealthy threshold)` plus your longest ordinary
+request, and only then let the tree stop.
+
+**Fly.io.** Fly sends `SIGINT` first, then `SIGTERM` after `kill_timeout`.
+
+```toml
+# fly.toml
+kill_signal = "SIGINT"
+kill_timeout = "45s"
+
+[[services.http_checks]]
+  path = "/health/ready"
+  interval = "5s"
+  timeout = "2s"
+  grace_period = "10s"
+```
+
+**Kubernetes.**
+
+```yaml
+readinessProbe:
+  httpGet: { path: /health/ready, port: 4000 }
+  periodSeconds: 5
+  failureThreshold: 2
+
+lifecycle:
+  preStop:
+    exec:
+      command: ["sleep", "20"]
+
+terminationGracePeriodSeconds: 60
+```
+
+`preStop` runs before `SIGTERM` is delivered and endpoint removal happens
+concurrently with it, so the sleep is what gives the mesh time to stop routing.
+
+**On the BEAM side**, if you want the delay inside the release rather than in a
+`preStop` hook, trap the signal in a small process listed **before**
+`Sagents.Supervisor` in your tree. Listed there, OTP stops it last, so its
+`terminate/2` runs after the Endpoint has stopped accepting and before anything
+else comes down.
+
+```elixir
+defmodule MyApp.Drain do
+  @moduledoc """
+  Holds the shutdown open long enough for the load balancer to observe
+  readiness going false and stop routing here.
+
+  Listed before Sagents.Supervisor in the application tree, so OTP stops it
+  last and this wait happens while the registry is still alive.
+  """
+  use GenServer
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    {:ok, Keyword.get(opts, :delay, 0)}
+  end
+
+  @impl true
+  def terminate(_reason, delay) do
+    Process.sleep(delay)
+    :ok
+  end
+end
+```
+
+Configure `delay` to `0` in dev and test. A drain delay that fires on every
+`Ctrl-C` is a delay you will disable in week two, and then it is not there in
+production either. Also give the child a `shutdown:` timeout longer than the
+delay, or the supervisor will kill it before `terminate/2` returns.
+
+Whichever mechanism you pick, the readiness signal has to be **live** during the
+wait. That is why the delay goes on this side of `Sagents.Supervisor` and not
+after it.
+
+---
+
+### 4. Audit every call site that reads the registry
+
+```
+grep -rn "AgentServer\.\|Session\.\|AgentSupervisor\.\|ProcessRegistry\." lib/ --include="*.ex" --include="*.heex"
+```
+
+Sort what you find into the two tables below.
+
+#### 4a. These now **raise** `Sagents.RegistryUnavailableError`
+
+Their return shapes have no room for "cannot answer", and answering with a
+plausible default is what produces the duplicate agent.
+
+| function | used to answer on a dead registry |
+| --- | --- |
+| `Sagents.AgentServer.get_pid/1` | `nil` |
+| `Sagents.AgentServer.get_status/1` | `:not_running` |
+| `Sagents.AgentServer.get_info/1` | an `:ets` `ArgumentError` |
+| `Sagents.AgentServer.get_state/1` | an `:ets` `ArgumentError` |
+| `Sagents.AgentServer.get_metadata/1` | `{:error, :not_found}` |
+| `Sagents.AgentServer.get_agent/1` | `{:error, :not_found}` |
+| `Sagents.AgentServer.get_inactivity_status/1` | an `:ets` `ArgumentError` |
+| `Sagents.AgentServer.export_state/1` | an `:ets` `ArgumentError` |
+| `Sagents.AgentServer.restore_state/2` | an `:ets` `ArgumentError` |
+| `Sagents.AgentServer.update_agent_and_state/3` | an `:ets` `ArgumentError` |
+| `Sagents.AgentServer.running?/1` | `false` |
+| `Sagents.AgentServer.agent_info/1` | `nil` |
+| `Sagents.AgentServer.stop/1` | an `:ets` `ArgumentError` |
+| `Sagents.Session.running?/2` | `false` |
+| `Sagents.ProcessRegistry.lookup/1` | `[]` |
+| `Sagents.ProcessRegistry.select/1` | `[]` |
+| `Sagents.ProcessRegistry.count/0` | `0` |
+| `Sagents.ProcessRegistry.keys/1` | `[]` |
+
+> #### The `get_status/1` trap {: .warning}
+>
+> `AgentServer.get_status/1` reads as total. It wraps its call in
+> `try/catch :exit -> :not_running`, so every call site treats it as a function
+> that cannot fail. It now raises **before** reaching the call it guards, and a
+> `catch :exit` clause does not catch a `raise`.
+>
+> This matters because `get_status/1` is the natural thing to call on a mount
+> path, to seed `agent_status` and `agent_alive?`. If yours is inside a
+> `try/rescue` for something else, `Ecto.NoResultsError` say, that will not
+> catch it either. The symptom is a crashed mount for the whole drain window,
+> from a line that looks defensive.
+>
+> ```
+> grep -rn "get_status\|get_info(" lib/ --include="*.ex"
+> ```
+
+#### 4b. These gained `{:error, :registry_unavailable}`
+
+| function | note |
+| --- | --- |
+| `Sagents.AgentServer.fetch_pid/1` | **new**; the non-raising `get_pid/1` |
+| `Sagents.ProcessRegistry.fetch/1` | **new**; the non-raising `lookup/1` |
+| `Sagents.AgentServer.execute/1`, `cancel/1`, `resume/2`, `add_message/3`, `reset/1`, `dismiss_interrupt/1` | |
+| `Sagents.Session.start/3`, `ensure_running/3`, `resume/4`, `dismiss/3`, `stop/2` | |
+| `Sagents.AgentSupervisor.get_pid/1` | alongside `{:error, :not_found}` |
+| `Sagents.AgentsDynamicSupervisor.stop_agent/2` | alongside `{:error, :not_found}` |
+
+One deliberate exception: `AgentServer.queue_message_from_tool/3` folds the
+condition into its existing `{:error, :no_server}`. It runs inside tool code, which has no
+better move than its fallback path, and raising out of a tool body is what that
+guard exists to prevent.
+
+#### What to change
+
+**Anything a web request or a LiveView mount can reach** should move from the
+first table to the second:
+
+```elixir
+# Before. Raises on a draining node
+case AgentServer.get_pid(agent_id) do
+  nil -> start_it()
+  pid -> use_it(pid)
+end
+
+# After
+case AgentServer.fetch_pid(agent_id) do
+  {:ok, pid} -> use_it(pid)
+  {:error, :not_running} -> start_it()
+  {:error, :registry_unavailable} -> draining()
+end
+```
+
+**Where the read is incidental to a bigger operation**, such as a mount that
+loads a conversation and happens to want the agent's status, guard the whole
+thing on `Sagents.ready?/0` instead of rewriting each call:
+
+```elixir
+def load_conversation(socket, conversation_id, opts) do
+  if Sagents.ready?() do
+    do_load_conversation(socket, conversation_id, opts)
+  else
+    {:error, put_flash(socket, :error, @draining_message)}
+  end
+end
+```
+
+That is the better shape when everything downstream needs the registry anyway.
+There is nothing worth half-rendering on a node that is going away.
+
+**Leave the raising forms in place** in tests, mix tasks, IEx helpers, and
+anywhere else that runs with the supervision tree definitively up. The raise is
+a diagnostic, and converting a test to `fetch_pid/1` demonstrates nothing.
+
+---
+
+### 5. Answer `:registry_unavailable` as its own thing
+
+Two rules, and the first one is the whole point of the release.
+
+**Never collapse it into "not running".**
+
+| answer | meaning | correct response |
+| --- | --- | --- |
+| `{:error, :not_running}` | the registry answered; nothing is running | start an agent |
+| `{:error, :registry_unavailable}` | the registry could not answer | retry elsewhere |
+
+A catch-all that starts an agent is the failure this release exists to prevent:
+
+```elixir
+# WRONG. The catch-all swallows :registry_unavailable and starts a duplicate
+case Session.ensure_running(config, assigns, request_opts: opts) do
+  {:ok, changes} -> assign(socket, changes)
+  {:error, _reason} -> start_a_fresh_one(socket)
+end
+```
+
+**Answer 503, not 500.** A 500 says the request cannot be served. A 503 says it
+cannot be served *here*, which is true, and it is the status clients and load
+balancers already know how to retry.
+
+```elixir
+case Sagents.Session.ensure_running(config, assigns, request_opts: opts) do
+  {:ok, changes} -> assign(socket, changes)
+  {:error, :registry_unavailable} -> {:error, message: "Service is restarting, please retry", code: 503}
+  {:error, reason} -> {:error, message: "Could not start session: #{inspect(reason)}"}
+end
+```
+
+In a LiveView there is no status code to send, so the equivalent is separate
+product copy and a separate log level. Route every session failure through one
+funnel rather than adding a clause per call site:
+
+```elixir
+@draining_message "This server is restarting. Please try that again in a moment."
+
+def flash_session_error(socket, reason, copy) do
+  label = Keyword.fetch!(copy, :log_label)
+
+  case reason do
+    :registry_unavailable ->
+      Logger.warning("#{label}: this node is draining, its Sagents registry is unavailable")
+      put_flash(socket, :error, @draining_message)
+
+    other ->
+      Logger.error("#{label}: #{inspect(other)}")
+      put_flash(socket, :error, Keyword.fetch!(copy, :user_message))
+  end
+end
+```
+
+Two details worth keeping:
+
+- **`:warning`, not `:error`.** A routine deploy should not fill the log with
+  alarms. An error level here trains people to ignore the one time it means
+  something.
+- **"Please try again" is literally accurate**, not a euphemism. Every other
+  node serves the request fine, and the client's reconnect after a deploy lands
+  on one of them. Telling the user something failed would be the inaccurate
+  version.
+
+Keep the log term and the user copy **separate**, for the same reason the
+v0.11.0 guide gave: interpolating the reason puts internal vocabulary in front
+of a person.
+
+---
+
+### 6. Know what a registry crash now costs
+
+You do not wire anything up for this, but you should know it happened, because
+the behaviour changed and it is visible.
+
+`Sagents.Supervisor` supervises `:rest_for_one` with the registry first, and a
+new `Sagents.RegistryWatcher` sits between the registry and its dependents. A
+registry failure now restarts the agent and filesystem dynamic supervisors:
+running agents on that node stop and are re-created from persisted state on the
+next request.
+
+That is heavy-handed on purpose. An `AgentSupervisor` and an `AgentServer`
+register their `:via` names once, at start, and nothing re-registers them. A
+registry that comes back empty underneath them leaves them running but invisible
+to every lookup, so the next request reads "nothing is running" and starts a
+*second* AgentServer, with both persisting the same conversation. Restarting is
+recoverable; a silent duplicate is not.
+
+On a healthy multi-node `:horde` cluster a peer would have repaired the
+registry within a few hundred milliseconds, so this over-reacts. It does so
+knowingly: nothing on the affected node can tell in time whether repair is
+coming. A single-node deployment has no peer, and a partitioned or lagging
+cluster looks identical from the inside until the window has passed.
+
+**What to check in your app:** anything that assumed an agent stays alive
+because nothing asked it to stop. A registry crash now costs the in-flight LLM
+turns on that node, the same as a deploy does.
+
+None of this touches draining. The watcher is listed after the registry, so OTP
+stops it first on a normal shutdown; a draining node never looks like a registry
+failure.
+
+---
+
+### 7. Stop treating Horde redistribution as a guarantee
+
+**Skip this step if you run `:local`.**
+
+Not a code change in this release, but a documented limit that is easy to have
+designed against without noticing.
+
+Horde hands a departed node's processes to a survivor only once that survivor
+has converged on the departure and marked the member dead. A node that leaves
+*before* convergence completes takes its agents with it. An agent running for a
+couple of seconds or more is redistributed reliably; one placed immediately
+before the node departs is dropped in roughly one departure in four. Graceful
+(`:init.stop`) and abrupt departures behave identically.
+
+A dropped agent is dropped **cleanly**. The registry and Horde's process CRDT
+are both left empty for it, so there is no orphan and no duplicate, and the next
+`Sagents.Session.ensure_running/3` starts it from persisted state.
+
+So:
+
+```
+grep -rn "node_transferring\|node_transferred" lib/ --include="*.ex" --include="*.heex"
+```
+
+Anything that must happen has to be driven by a request, a job, or a supervisor
+you control, never by an agent you assume Horde kept alive somewhere. A
+background loop inside an agent, a timer that fires "later", a piece of work
+handed to an agent and then forgotten: all of those need a driver that survives
+the node.
+
+Steps 1 through 3 are also what protect you here, since they stop new agents
+being placed on a node that is about to leave, which is exactly the case that
+loses them.
+
+---
+
+### 8. Summarization: nothing to change, something to re-check
+
+`Sagents.Middleware.Summarization` picked cutoffs that could orphan a tool
+result: keeping a `:tool` message whose originating assistant tool call was
+summarized away. Providers reject that outright, OpenAI with "No tool call
+found for function call output", so a long conversation could start failing
+every turn after its first compaction. Cuts landing between consecutive results
+from parallel tool calls hit the same way.
+
+The cutoff search now rejects a point where the first kept message is a tool
+result, as well as the previously-handled case of summarizing away an assistant
+whose results remain on the kept side.
+
+**Skip this if `Summarization` is not in your middleware stack.** If it is,
+there is no code change, but the effect is worth knowing: the middleware is now
+slightly *more* willing to summarize nothing rather than produce an invalid
+transcript. If you tuned `messages_to_keep` against the old behaviour, check
+that compaction still triggers where you expect.
+
+---
+
+### 9. Fix the tests that now fail, and add the ones that catch this
+
+Existing tests are unlikely to fail: the registry is up in the test
+environment, which is exactly why this migration has no automatic signal. Two
+things that can break:
+
+- A test asserting `Session.stop/2` returns only `{:ok, :stopped | :not_running}`,
+  or `AgentSupervisor.get_pid/1` only `{:ok, pid} | {:error, :not_found}`, if
+  you assert on the spec rather than the value.
+- A Mimic stub of `Sagents.AgentServer` or `Sagents.ProcessRegistry` that no
+  longer covers the functions the code now calls: `fetch_pid/1` in place of
+  `get_pid/1`, `fetch/1` in place of `lookup/1`.
+
+Worth adding, because they are cheap and nothing else covers the drain path:
+
+- **The readiness endpoint answers 503 when the node cannot host agents.** Stub
+  `Sagents.ready?/0` rather than stopping the real supervision tree, which would
+  take every other test's agents with it.
+- **The liveness endpoint answers 200 anyway.** This is the assertion that stops
+  someone helpfully "fixing" the duplication by pointing both at the same
+  source.
+- **The readiness route needs no session and no `Accept` header.** Guards the
+  pipeline decision in step 1, which is otherwise invisible until a real probe
+  gets a 406.
+- **Your guarded load path returns without touching the registry while
+  draining.** Write it with *no* stubs for the registry-reading modules: if the
+  guard regresses, the test fails on an unstubbed call rather than passing
+  quietly.
+- **Your error funnel shows retry copy for `:registry_unavailable`** and never
+  interpolates a raw reason term into user-facing text.
+
+---
+
+## Verifying the migration
+
+The compiler cannot confirm any of this. Check it by hand.
+
+**The registry-gone path**, without deploying anything:
+
+```elixir
+# in IEx, on a running app
+Sagents.ready?()
+# => true
+
+Supervisor.terminate_child(MyApp.Supervisor, Sagents.Supervisor)
+
+Sagents.ready?()
+# => false
+```
+
+With the tree down, hit the app:
+
+1. `GET /health/ready` answers **503**; `GET /health/alive` answers **200**.
+2. Open a conversation. You get your draining copy, not a crashed mount and not
+   a 500.
+3. Send a message. Same: retryable copy, and the log shows a **warning**, not an
+   error.
+
+Then put it back:
+
+```elixir
+Supervisor.restart_child(MyApp.Supervisor, Sagents.Supervisor)
+Sagents.ready?()
+# => true
+```
+
+and confirm the app works normally again.
+
+**The drain sequence**, on your real platform: deploy, and poll `/health/ready`
+throughout. If it is still answering 200 at the moment agent requests start
+failing, steps 1 through 3 are not wired correctly. That gap is the entire bug.
+
+**The registry-crash path**, if you want to see step 6:
+
+```elixir
+Process.exit(Process.whereis(Sagents.Registry), :kill)
+```
+
+The dynamic supervisors restart with it, running agents on that node stop, and
+the next request re-creates them from persisted state. `Sagents.ready?/0` should
+be back to `true` within milliseconds.
+
+---
+
+## Recommended approach for generated files
+
+Unlike v0.11.0, there is nothing to re-generate: `mix sagents.setup` templates
+did not change in this release. Every step above is host code: your
+application module, your router, your controllers, your LiveViews, your
+deployment config.
+
+If you skip everything else, do step 1. A readiness endpoint on its own converts
+the failure from "every request during every deploy fails on this node" to
+"traffic goes somewhere that works". Steps 4 and 5 make the requests that still
+slip through report themselves honestly.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,38 +36,67 @@ rather than an outage.
 
 ```
 1. platform signals shutdown
-2. node reports NOT ready          <-- Sagents.ready?() goes false
+2. node reports NOT ready          <-- your drain flag flips here
 3. load balancer stops routing to it
 4. in-flight requests finish
-5. supervision tree stops           <-- registry goes away here
+5. supervision tree stops           <-- Sagents.ready?() goes false here
 6. BEAM exits
 ```
 
 Out of the box, only steps 5 and 6 happen. Steps 2 through 4 are yours to wire
-up, and they are the whole fix. The library gives you the signal for step 2 and
+up, and they are the whole fix. The library gives you the signal for step 5 and
 a clean error if a request slips through anyway.
+
+**Note where the two signals sit.** `Sagents.ready?/0` first answers false at
+step 5, which is after the load balancer needed it at step 2. So a readiness
+endpoint wired to `Sagents.ready?/0` **alone** answers 200 for the entire drain
+and then starts failing requests at the same instant it starts reporting
+unhealthy. That is worse than nothing, because it looks finished.
+
+Readiness needs two sources: a flag you set at step 2 (step 3 below), and
+`Sagents.ready?/0` for every other way the tree can be down (still booting,
+crashed, restarting).
 
 ## Step 1: readiness, not liveness
 
 `Sagents.ready?/0` answers whether this node can host and route agent sessions.
-Wire it into your **readiness** check. Do not wire it into a liveness check: a
-draining node is not unhealthy, and restarting it is the wrong response.
+Wire it into your **readiness** check, together with the drain flag from step 3.
+
+Keep it out of your liveness check. A draining node is not an unhealthy one, and
+what that costs depends on the platform: Kubernetes restarts a pod that fails
+liveness, which is exactly the wrong move, while Fly never acts on a check
+result at all. The reason to have `alive/2` on either platform is that it is the
+signal that **stays green while readiness goes red**, the only way to read your
+platform's check list and tell a node draining normally (alive 200, ready 503)
+from one that is wedged (both failing). Readiness alone cannot express that
+difference, and during a rolling deploy it is the difference an operator is
+looking at.
 
 ```elixir
 # lib/my_app_web/controllers/health_controller.ex
 defmodule MyAppWeb.HealthController do
   use MyAppWeb, :controller
 
-  # Liveness: is the BEAM up at all? Never consults Sagents.
-  def alive(conn, _params), do: send_resp(conn, 200, "ok")
+  # Liveness: is the BEAM up at all? Never consults Sagents or the drain flag.
+  def alive(conn, _params) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, "ok")
+  end
 
-  # Readiness: should this node receive traffic?
+  # Readiness: should this node receive traffic? The drain flag flips first,
+  # at step 2; Sagents.ready?/0 covers every other way the tree can be down.
   def ready(conn, _params) do
-    if Sagents.ready?() do
-      send_resp(conn, 200, "ok")
-    else
-      send_resp(conn, 503, "draining")
-    end
+    {status, body} =
+      if MyApp.Drain.draining?() or not Sagents.ready?() do
+        {503, "draining"}
+      else
+        {200, "ok"}
+      end
+
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(status, body)
   end
 end
 ```
@@ -80,8 +109,30 @@ scope "/health", MyAppWeb do
 end
 ```
 
-Keep these routes outside any authentication pipeline, and outside any plug that
-itself touches Sagents.
+**The scope has no `pipe_through`** on purpose. Not the browser pipeline, since
+a probe has no session and no CSRF token, and not an `:api` pipeline either:
+`plug :accepts, ["json"]` makes the route content-negotiate, and probes
+frequently send no `Accept` header at all. The probe then takes a 406 and reads
+the node as unhealthy for a reason that has nothing to do with Sagents.
+
+Check `endpoint.ex` for anything above the router that can halt or redirect,
+too. `force_ssl` is the common one: probes reach the machine over plain HTTP on
+the internal network with no `x-forwarded-proto` to rewrite on, so `Plug.SSL`
+answers 301 and the readiness endpoint never runs. Exclude both full paths, and
+repeat the host defaults, because passing any `:exclude` value replaces
+`Plug.SSL`'s defaults entirely:
+
+```elixir
+force_ssl: [
+  rewrite_on: [:x_forwarded_proto],
+  exclude: [
+    hosts: ["localhost", "127.0.0.1"],
+    # Exact full-path matches, not prefixes. `paths: ["/health"]` does NOT
+    # cover "/health/ready": Plug.SSL compares conn.path_info for equality.
+    paths: ["/health/alive", "/health/ready"]
+  ]
+]
+```
 
 ## Step 2: supervision tree order
 
@@ -92,15 +143,25 @@ children = [
   MyApp.Repo,
   {Phoenix.PubSub, name: MyApp.PubSub},
   MyAppWeb.Presence,
-  Sagents.Supervisor,
-  MyAppWeb.Endpoint      # after, so OTP stops it FIRST
+  Sagents.Supervisor,     # after Repo/PubSub, so agents can persist on the way down
+  MyAppWeb.Endpoint,      # after Sagents, so OTP stops the listener FIRST
+  {MyApp.Drain, delay: drain_delay()}   # LAST, so it stops FIRST
 ]
 ```
 
-OTP shuts children down in reverse order. Listed this way, the Endpoint stops
-accepting requests first and the registry is still alive to serve whatever is
-already in flight. Listed the other way around, the Endpoint outlives the
-registry and serves the entire drain period with a dead registry underneath it.
+OTP shuts children down in reverse order, and that single rule is what makes all
+three positions correct at once. Trace it: `Drain` → `Endpoint` →
+`Sagents.Supervisor` → `PubSub` → `Repo`. The drain sleeps while the listener is
+still up and can still answer the probe, then the listener stops, then the
+registry, then the things agents needed in order to persist themselves.
+
+The Endpoint's position matters on its own: listed the other way around, it
+outlives the registry and serves the entire drain period with a dead registry
+underneath it.
+
+The drain process must be **last**, which is the placement that is easy to get
+backwards. Listed anywhere earlier, its wait happens behind an already-stopped
+listener, where no probe can observe the readiness change it exists to publish.
 
 Correct ordering narrows the window. It does not remove it: the node is still
 reachable by the load balancer until the platform stops sending traffic, which
@@ -110,8 +171,7 @@ is what step 1 is for. Do both.
 
 A readiness check that flips to `false` at the same instant the tree comes down
 buys you nothing. The platform needs to poll it, observe the change, and update
-its routing table before shutdown proceeds. That is what a pre-stop hook or a
-drain delay is for.
+its routing table before shutdown proceeds. That is what the drain delay is for.
 
 The general principle, whatever the platform:
 
@@ -121,29 +181,172 @@ The general principle, whatever the platform:
    time your longest ordinary request takes.
 4. Only then let the supervision tree stop.
 
+A small process at the end of your tree does all four:
+
+```elixir
+defmodule MyApp.Drain do
+  @moduledoc """
+  Holds shutdown open long enough for the load balancer to observe readiness
+  going false and stop routing here.
+
+  Listed LAST in the application tree. OTP stops children in reverse order, so
+  last means `terminate/2` runs first, while the Endpoint is still serving and
+  can still answer the readiness probe.
+  """
+  use GenServer
+
+  require Logger
+
+  @flag {__MODULE__, :draining?}
+
+  @doc "Whether this node has begun shutting down. Safe to call from a request."
+  def draining?, do: :persistent_term.get(@flag, false)
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  def child_spec(opts) do
+    delay = Keyword.get(opts, :delay, 0)
+
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [[delay: delay]]},
+      # Must exceed the delay, or the supervisor brutal-kills this process
+      # partway through terminate/2 and the drain silently does not happen.
+      shutdown: delay + :timer.seconds(5)
+    }
+  end
+
+  @impl true
+  def init(opts) do
+    # Without this, terminate/2 is not called on supervisor shutdown at all.
+    Process.flag(:trap_exit, true)
+    :persistent_term.put(@flag, false)
+    {:ok, Keyword.get(opts, :delay, 0)}
+  end
+
+  @impl true
+  def terminate(_reason, delay) do
+    :persistent_term.put(@flag, true)
+    Logger.info("draining: readiness is now false, waiting #{delay}ms before shutdown")
+    Process.sleep(delay)
+    :ok
+  end
+end
+```
+
+Two details that are easy to get wrong and hard to notice:
+
+- **The flag must be readable without talking to this process.** During
+  `terminate/2` the GenServer is out of its receive loop, so a
+  `GenServer.call(MyApp.Drain, :draining?)` from the readiness endpoint blocks
+  for the whole sleep and then exits when the process dies. `:persistent_term`
+  is read directly by the caller.
+- **Configure `delay: 0` in dev and test.** A drain delay that fires on every
+  `Ctrl-C` is a delay you will disable in week two, and then it is not there in
+  production either. Take the value from config, so `drain_delay/0` in your
+  application module reads `Application.get_env(:my_app, :drain_delay_ms, 0)`
+  and only `config/runtime.exs` sets it to something like `20_000`.
+
+> #### The signal that reaches the BEAM must be SIGTERM {: .warning}
+>
+> Everything above, and every `terminate/2` in your tree including the one in
+> `Sagents.AgentServer` that persists agent state, hangs off OTP calling
+> `init:stop()`. Only **SIGTERM** produces that. OTP's default
+> `erl_signal_handler` maps `sigterm` to `init:stop()`; `sigquit` and `sigusr1`
+> map to `erlang:halt/0,1`, which is immediate and graceless; and **`sigint`
+> matches none of its clauses**, falling through to a no-op. What SIGINT
+> actually reaches is the BEAM's break handler.
+>
+> | signal | `terminate/2` runs? | result |
+> | --- | --- | --- |
+> | `SIGTERM` | yes, with `reason: :shutdown` | drain waits, state persists, agents broadcast shutdown |
+> | `SIGINT` | **no** | break handler; the node either sits until SIGKILL or halts outright |
+>
+> So under SIGINT there is no drain, no readiness flip, and **no agent state
+> persisted**: every deploy silently loses the in-flight turn on every
+> conversation. Where this goes wrong in practice is a hand-written platform
+> config, a `CMD` that puts a shell at PID 1, and process managers that send
+> something other than SIGTERM.
+>
+> A shell-form `CMD /app/bin/server` makes `/bin/sh` PID 1, and it does not
+> forward SIGTERM to its child, so the BEAM never sees the signal and is
+> SIGKILLed at the deadline with nothing having run. Use the exec form, which is
+> what the generated Phoenix Dockerfile ships: `CMD ["/app/bin/server"]`.
+
 ### Fly.io
 
-Fly sends `SIGINT` first (then `SIGTERM` after `kill_timeout`). Set a
-`kill_timeout` that covers your drain, and make sure your health check interval
-is short enough that the proxy notices within it.
+Fly sends the configured `kill_signal`, waits `kill_timeout`, then sends
+**`SIGKILL`**. Nothing happens in between, so `kill_timeout` is not a stage in a
+graceful sequence: it is the hard deadline before the machine dies mid-drain,
+and it must exceed your drain delay.
+
+`fly launch` detects an Elixir project and generates `kill_signal = "SIGTERM"`,
+so this is normally already right. Confirm the line rather than assuming it,
+since everything above depends on it.
 
 ```toml
-# fly.toml
-kill_signal = "SIGINT"
-kill_timeout = "45s"
+# fly.toml. Use this form if your file has [http_service], which is what
+# `fly launch` has generated for years.
+kill_signal = "SIGTERM"   # confirm this is present and says SIGTERM
+kill_timeout = "45s"      # hard deadline before SIGKILL; must exceed the drain
 
-[[services.http_checks]]
+# Readiness. This is the check that changes routing, so this is the one that
+# makes the drain do anything at all.
+[[http_service.checks]]
   path = "/health/ready"
   interval = "5s"
   timeout = "2s"
   grace_period = "10s"
 ```
 
-With a 5 second interval, the proxy notices within a few seconds of readiness
-flipping, so a 45 second `kill_timeout` leaves plenty of room. Handle the signal
-so the wait happens before the tree stops, for example by trapping it in a small
-process started *before* `Sagents.Supervisor` in your tree, or by using a
-release `pre_stop` hook.
+With a 5 second interval the proxy notices within a few seconds of readiness
+flipping, so a 45 second `kill_timeout` leaves room for a 20 second drain.
+
+> #### `checks` and `http_checks` are not interchangeable {: .warning}
+>
+> There are **two** independent axes here and they do not vary together. The
+> *format* (`[http_service]` and `[[services]]`, which are mutually exclusive)
+> and the *sub-key*, which is spelled differently under each. `flyctl` decodes
+> the two from separate struct fields, so only two of the four combinations
+> exist:
+>
+> | table | result |
+> | --- | --- |
+> | `[[http_service.checks]]` | correct for the `[http_service]` format |
+> | `[[http_service.http_checks]]` | **decoded into nothing** |
+> | `[[services.http_checks]]` | correct for the older `[[services]]` format |
+> | `[[services.checks]]` | **decoded into nothing** |
+>
+> A wrong sub-key does not give you a degraded check, it gives you **no check at
+> all**, and readiness is the entire mechanism by which the drain does anything.
+> Fly Proxy is never told to stop routing, so the node keeps taking new requests
+> for the whole delay and the endpoint still closes underneath whatever is in
+> flight: the exact failure this guide exists to prevent, now with the drain
+> delay added to every machine stop. Confirm it with `fly checks list`.
+
+**Wire the liveness endpoint too.** On Fly this is not the readiness block with
+a different path: a liveness check belongs in the **top-level `[checks]`
+section**, a different shape that needs a unique name, an explicit `port`, and
+an explicit `type`.
+
+```toml
+# Top-level checks do NOT affect routing, and Fly never restarts or stops a
+# machine over a failed check. This exists so `fly status` / `fly checks list`
+# can separate a node draining normally from one that is wedged.
+[checks]
+  [checks.alive]
+    type = 'http'
+    port = 8080          # your internal_port; must be bound on 0.0.0.0
+    path = '/health/alive'
+    method = 'get'
+    interval = '15s'
+    timeout = '5s'
+    grace_period = '30s' # must cover boot
+```
+
+Do not put `/health/alive` in `[[http_service.checks]]` instead. That section
+governs routing, and an endpoint that always answers 200 tells the proxy nothing
+while adding a check every deploy has to wait on.
 
 If you run agents in more than one region, read the partition section of
 [Clustering](clustering.md) as well: `fly-replay` routing a request to the wrong
@@ -151,24 +354,36 @@ region has a different and worse failure mode than draining does.
 
 ### Kubernetes
 
+Kubernetes sends `SIGTERM` already, so there is no signal to change.
+
 ```yaml
 readinessProbe:
   httpGet: { path: /health/ready, port: 4000 }
   periodSeconds: 5
   failureThreshold: 2
 
-lifecycle:
-  preStop:
-    exec:
-      command: ["sleep", "20"]
+# Both endpoints, or the liveness half of step 1 is wired to nothing. Unlike
+# Fly, Kubernetes does act on this one: keep the drain flag out of it, or the
+# kubelet restarts the pod you are trying to drain.
+livenessProbe:
+  httpGet: { path: /health/alive, port: 4000 }
+  periodSeconds: 15
+  failureThreshold: 3
 
 terminationGracePeriodSeconds: 60
 ```
 
-`preStop` runs before `SIGTERM` is delivered, and endpoint removal happens
-concurrently with it, so the sleep is what gives the service mesh time to stop
-routing. `terminationGracePeriodSeconds` must exceed the `preStop` sleep plus
-your longest request.
+With `MyApp.Drain` in the tree you do not also need a `preStop` sleep;
+`terminationGracePeriodSeconds` must exceed the drain delay plus your longest
+request.
+
+If you would rather keep the wait outside the BEAM, drop `MyApp.Drain` and use
+`lifecycle.preStop.exec.command: ["sleep", "20"]` instead. `preStop` runs before
+`SIGTERM` is delivered and endpoint removal happens concurrently with it, so the
+sleep does give the service mesh time to stop routing. The cost is that
+readiness then has only `Sagents.ready?/0` to report, which goes false at step 5
+rather than step 2, which is too late to be the signal the mesh acted on. Prefer the
+in-BEAM flag.
 
 ## Step 4: handle the error if one slips through
 
@@ -193,10 +408,68 @@ end
 cannot be served *here*, which is true, and it is the answer clients and load
 balancers know how to retry.
 
-The same `{:error, :registry_unavailable}` is returned by `Sagents.Session.start/3`,
-`resume/4`, `dismiss/3` and `stop/2`, by `Sagents.AgentServer.fetch_pid/1`, and
-by the `Sagents.AgentServer` lifecycle calls (`execute/1`, `cancel/1`,
-`resume/2`, `add_message/3`, `reset/1`, `dismiss_interrupt/1`).
+### Which functions report it, and which raise
+
+Classify by **how a call reaches the registry**, not by which module it lives in.
+That rule is short, checkable against the source, and it covers functions this
+page does not name:
+
+| how it reaches the registry | behaviour when the registry is gone |
+| --- | --- |
+| `GenServer.cast` on a `:via` tuple | **safe.** Elixir wraps `cast` in `try … catch _, _ -> :ok`, so it silently no-ops |
+| `GenServer.call` on a `:via` tuple | **raises.** A `catch :exit` clause does not catch a raise |
+| `get_pid/1`, `whereis/1`, `lookup/1`, `select/1`, `count/0`, `keys/1` | **raises** `Sagents.RegistryUnavailableError` |
+| `fetch_pid/1`, `fetch/1`, `fetch_running/2`, `fetch_filesystem_running/1` | `{:error, :registry_unavailable}` |
+
+The `cast` and `call` asymmetry is why a function's signature tells you nothing
+on its own. Same via tuple, same dead registry, opposite outcome.
+
+The tuple-returning forms, by layer:
+
+- `Sagents.Session`: `start/3`, `ensure_running/3`, `resume/4`, `dismiss/3`,
+  `stop/2`, `fetch_running/2`
+- `Sagents.AgentServer`: `fetch_pid/1`, `execute/1`, `cancel/1`, `resume/2`,
+  `add_message/3`, `reset/1`, `dismiss_interrupt/1`, `subscribe/3`
+- `Sagents.FileSystem`: `ensure_filesystem/3`, `stop_filesystem/2`,
+  `get_filesystem_pid/1`, `fetch_filesystem_running/1`
+- `Sagents.AgentSupervisor`: `get_pid/1`, `stop/2`
+- `Sagents.ProcessRegistry`: `fetch/1`, and `Sagents.FileSystemServer.fetch_pid/1`
+
+The raising ones you are most likely to meet by accident are the two
+`?`-predicates, `Sagents.Session.running?/2` and
+`Sagents.FileSystem.filesystem_running?/1`, because a name ending in `?` is the
+last thing a reader suspects of raising. Both have non-raising siblings in the
+list above. `Sagents.FileSystem.list_filesystems/0` and
+`Sagents.AgentServer.get_status/1` are the next two: `get_status/1` wraps its
+call in `try/catch :exit`, so every call site reads as though it cannot fail,
+while the raise happens *before* reaching the call that `catch` guards.
+
+**Do not skip the filesystem layer because it looks incidental.**
+`Sagents.FileSystem` gets read as one function when it is a module of them, and
+its calls sit in the least suspicious place: best-effort cleanup, where the
+return is usually discarded. Discarding it there is fine and stays fine. Two
+other shapes are worth checking:
+
+- **A catch-all that logs.** `{:error, :registry_unavailable}` reaching an
+  `{:error, reason} -> Logger.error(...)` clause turns every deploy into an
+  alarm for a condition that is not a fault.
+- **`ensure_filesystem/3` returning the error.** It deliberately does not start
+  a filesystem it could not first check for, because this node cannot see
+  whether one already exists elsewhere. A caller that reads any error as "start
+  failed, carry on degraded" is making a different decision than the one that
+  was reported.
+
+> #### The not-found atom differs by layer {: .warning}
+>
+> Only `:registry_unavailable` is spelled the same everywhere.
+> `Sagents.AgentServer.fetch_pid/1` and `Sagents.FileSystemServer.fetch_pid/1`
+> answer `{:error, :not_running}`; `Sagents.ProcessRegistry.fetch/1` answers
+> `{:error, :not_registered}`; the supervisor layer
+> (`Sagents.AgentSupervisor.get_pid/1`,
+> `Sagents.FileSystem.get_filesystem_pid/1`) answers `{:error, :not_found}`.
+>
+> Copying a `case` shape from one layer to another gives you a `CaseClauseError`
+> on the drain path, which is the one path with no test coverage.
 
 ### Why it is not just `nil`
 
@@ -213,13 +486,12 @@ start a *new* agent for a conversation that already has one somewhere else. Two
 processes would then hold and persist state for the same conversation, silently.
 That is why the distinction is load-bearing rather than cosmetic.
 
-A handful of functions cannot express the condition in their return value:
-`Sagents.AgentServer.get_pid/1` returns `pid() | nil`,
-`Sagents.Session.running?/2` returns a boolean, and
-`Sagents.ProcessRegistry.select/1` returns a list. Those **raise**
-`Sagents.RegistryUnavailableError` rather than answering with a plausible
-default. On request paths, prefer the tuple-returning forms
-(`fetch_pid/1`, `ensure_running/3`, `Sagents.ProcessRegistry.fetch/1`).
+It is also why the raising functions raise rather than answering. A shape like
+`pid() | nil`, a boolean, or a list has no room for a third answer, and every
+plausible default is the dangerous one: `nil`, `false` and `[]` all read as
+"nothing is running". A loud, named error is the safer answer, even at the cost
+of a `?`-predicate that can raise. On request paths, prefer the tuple-returning
+forms listed above.
 
 ## What happens to running agents
 
@@ -337,6 +609,32 @@ To check your own application, hit `/health/ready` while a deploy is in flight
 and confirm it reports 503 before the node stops answering agent requests. If
 readiness is still reporting 200 at the moment lookups start failing, steps 1
 through 3 are not wired correctly.
+
+Check the probe is not being redirected on the way in, which `force_ssl` will do
+silently:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://<internal-address>/health/ready
+```
+
+A `301` means the exclusion in step 1 is missing, and no amount of correct
+readiness logic will help.
+
+**Then confirm the platform is actually asking.** Both checks above talk to your
+app, and the app can be perfectly healthy while the platform has been told to
+poll nothing, which is what a misspelled check sub-key produces:
+
+```bash
+fly checks list -a <app>     # must list your checks. An empty table means the
+                             # key decoded into nothing
+kubectl describe pod <pod>   # the Liveness:/Readiness: lines, same question
+```
+
+Do not substitute `fly config validate` for this. It reports
+`Configuration is valid` for a file containing sections and keys `flyctl` does
+not recognize: it confirms well-formed TOML, not that Fly understood any
+particular line. The curl proves your app answers; `fly checks list` proves the
+platform is asking. They are independent failures and you need both.
 
 ## Related
 

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -614,7 +614,12 @@ defmodule Sagents.AgentServer do
 
   ## Returns
 
-  - `:ok` — always returns `:ok`, even if the AgentServer is not running
+  `:ok` in every case, including the two where the message is not delivered:
+  no AgentServer is running for `agent_id`, and this node's registry cannot
+  answer (it is draining during a rolling deploy). Delivery is fire-and-forget
+  by design, so there is no queue to fall back to and no retry that helps on
+  this node. The undelivered cases are logged rather than returned, because a
+  caller cannot act on them and a silently dropped push is invisible.
 
   ## Examples
 
@@ -627,16 +632,21 @@ defmodule Sagents.AgentServer do
   """
   @spec notify_middleware(String.t(), term(), term()) :: :ok
   def notify_middleware(agent_id, middleware_id, message) do
-    agent_id
-    |> get_pid()
-    |> case do
-      pid when is_pid(pid) ->
+    case fetch_pid(agent_id) do
+      {:ok, pid} ->
         send(pid, {:middleware_message, middleware_id, message})
+
+      {:error, :not_running} ->
         :ok
 
-      _other ->
-        :ok
+      {:error, :registry_unavailable} ->
+        Logger.warning(
+          "notify_middleware(#{agent_id}, #{inspect(middleware_id)}): " <>
+            "registry unavailable on this node, message dropped"
+        )
     end
+
+    :ok
   end
 
   @doc """
@@ -658,8 +668,12 @@ defmodule Sagents.AgentServer do
   - `subscriber_pid` — the pid to receive events. Defaults to `self()` when
     `nil`.
 
-  Returns `{:ok, server_pid, monitor_ref}` on success, or
-  `{:error, :process_not_found}` if no AgentServer is running for `agent_id`.
+  Returns `{:ok, server_pid, monitor_ref}` on success,
+  `{:error, :process_not_found}` if no AgentServer is running for `agent_id`,
+  or `{:error, :registry_unavailable}` if this node's registry cannot answer.
+
+  The third answer is distinct because it is not a statement about the agent.
+  See `docs/deployment.md`.
 
   ## Examples
 
@@ -673,10 +687,20 @@ defmodule Sagents.AgentServer do
       {:ok, _pid, _ref} = AgentServer.subscribe("my-agent-1", :main, bridge_pid)
   """
   @spec subscribe(String.t(), :main | :debug, pid() | nil) ::
-          {:ok, pid(), reference()} | {:error, :process_not_found}
+          {:ok, pid(), reference()} | {:error, :process_not_found | :registry_unavailable}
   def subscribe(agent_id, channel \\ :main, subscriber_pid \\ nil)
       when is_binary(agent_id) and channel in [:main, :debug] do
-    Publisher.subscribe(get_name(agent_id), channel, subscriber_pid)
+    # Resolves the pid rather than handing Publisher a `:via` tuple.
+    # `Publisher.subscribe/3` is a `GenServer.call`, which resolves a via name
+    # itself, and that resolution raises `ArgumentError` from inside `:ets`
+    # while this node's registry is unavailable. Publisher's `catch :exit`
+    # guard does not catch a raise, so the error would escape a function whose
+    # whole visible structure claims to have handled it.
+    case fetch_pid(agent_id) do
+      {:ok, pid} -> Publisher.subscribe(pid, channel, subscriber_pid)
+      {:error, :not_running} -> {:error, :process_not_found}
+      {:error, :registry_unavailable} = error -> error
+    end
   end
 
   @doc """
@@ -684,11 +708,19 @@ defmodule Sagents.AgentServer do
 
   Mirrors `subscribe/3`. Defaults `channel` to `:main` and `subscriber_pid`
   to `self()` (when `nil`). Always returns `:ok`.
+
+  An unavailable registry is `:ok` rather than an error: the subscription lives
+  on a process this node cannot reach, the producer's own monitor cleans up the
+  entry when the subscriber goes away, and there is nothing for a caller to do
+  with the distinction.
   """
   @spec unsubscribe(String.t(), :main | :debug, pid() | nil) :: :ok
   def unsubscribe(agent_id, channel \\ :main, subscriber_pid \\ nil)
       when is_binary(agent_id) and channel in [:main, :debug] do
-    Publisher.unsubscribe(get_name(agent_id), channel, subscriber_pid)
+    case fetch_pid(agent_id) do
+      {:ok, pid} -> Publisher.unsubscribe(pid, channel, subscriber_pid)
+      {:error, _reason} -> :ok
+    end
   end
 
   @doc """
@@ -1340,6 +1372,15 @@ defmodule Sagents.AgentServer do
 
   @doc """
   Check if an agent is running.
+
+  **Raises `Sagents.RegistryUnavailableError`** when this node's registry
+  cannot answer, which covers the drain window of a rolling deploy. A boolean
+  has no room for "cannot tell", and `false` reads as "nothing is running",
+  which a caller responds to by starting a duplicate agent for an agent that
+  already has a process elsewhere.
+
+  Use `fetch_pid/1` anywhere a web request can reach: it reports the condition
+  as `{:error, :registry_unavailable}` instead.
   """
   def running?(agent_id) do
     case get_pid(agent_id) do
@@ -3170,12 +3211,23 @@ defmodule Sagents.AgentServer do
     :ok
   end
 
+  # Best-effort: the caller only broadcasts a cancellation event when this
+  # answers, so `nil` is an acceptable outcome and a raise is not. This runs
+  # during sub-agent teardown, where an escaping error would take the
+  # AgentServer down mid-cleanup.
+  #
+  # The two handlers do not cover each other: `keys/1` raises rather than
+  # exiting when this node's registry is gone, and a `catch :exit` clause does
+  # not catch a raise. Only the registry-unavailable raise is swallowed, so a
+  # genuine ArgumentError against a live registry still escapes.
   defp lookup_sub_agent_id(child_pid) do
     Sagents.ProcessRegistry.keys(child_pid)
     |> Enum.find_value(fn
       {:sub_agent, id} -> id
       _other -> nil
     end)
+  rescue
+    Sagents.RegistryUnavailableError -> nil
   catch
     :exit, _reason -> nil
   end

--- a/lib/sagents/agent_supervisor.ex
+++ b/lib/sagents/agent_supervisor.ex
@@ -119,19 +119,24 @@ defmodule Sagents.AgentSupervisor do
   @doc """
   Stop the AgentSupervisor.
 
+  `{:error, :registry_unavailable}` means this node's registry could not answer,
+  so nothing was stopped and nothing is known about whether anything was
+  running. It is distinct from `:not_found` for the same reason it is in
+  `get_pid/1`.
+
   ## Examples
 
       AgentSupervisor.stop("my-agent-1")
       AgentSupervisor.stop("my-agent-1", 10_000) # 10 second timeout
 
   """
-  @spec stop(String.t(), timeout()) :: :ok | {:error, :not_found}
+  @spec stop(String.t(), timeout()) :: :ok | {:error, :not_found | :registry_unavailable}
   def stop(agent_id, timeout \\ 5_000) do
     case get_pid(agent_id) do
       {:ok, pid} ->
         Supervisor.stop(pid, :normal, timeout)
 
-      {:error, :not_found} = error ->
+      {:error, _reason} = error ->
         error
     end
   end

--- a/lib/sagents/agents_dynamic_supervisor.ex
+++ b/lib/sagents/agents_dynamic_supervisor.ex
@@ -280,7 +280,9 @@ defmodule Sagents.AgentsDynamicSupervisor do
   def list_agents(supervisor \\ __MODULE__) do
     Sagents.ProcessSupervisor.which_children(supervisor)
     |> Enum.map(fn {_id, pid, _type, _modules} ->
-      # Get agent_id from the AgentSupervisor's registered name via Registry
+      # Get agent_id from the AgentSupervisor's registered name via Registry.
+      # keys/1 raises on a node whose registry is gone, which is the right
+      # answer for a listing: an empty or short list reads as a real result.
       case Sagents.ProcessRegistry.keys(pid) do
         [{:agent_supervisor, agent_id}] -> agent_id
         _other -> nil

--- a/lib/sagents/file_system.ex
+++ b/lib/sagents/file_system.ex
@@ -68,6 +68,9 @@ defmodule Sagents.FileSystem do
   ## Returns
 
   - `{:ok, pid}` - Filesystem PID (existing or newly started)
+  - `{:error, :registry_unavailable}` - this node's registry could not answer,
+    so it cannot tell whether one is already running and deliberately does not
+    start one
   - `{:error, reason}` - Error starting filesystem
 
   ## Examples
@@ -111,6 +114,12 @@ defmodule Sagents.FileSystem do
           {:error, {:already_started, pid}} -> {:ok, pid}
           {:error, reason} -> {:error, reason}
         end
+
+      {:error, :registry_unavailable} = error ->
+        # This node cannot see whether a filesystem already exists for the
+        # scope, so it must not start one. Starting anyway is how a scope ends
+        # up with two servers holding the same files.
+        error
     end
   end
 
@@ -158,12 +167,19 @@ defmodule Sagents.FileSystem do
 
   - `:ok` - Successfully stopped
   - `{:error, :not_found}` - Filesystem not running
+  - `{:error, :registry_unavailable}` - this node's registry could not answer
+
+  The last one matters more than it looks. This is often a best-effort cleanup
+  called before real work, so it reports rather than raises: a raise here takes
+  the caller's whole operation down with it, turning "the scratch filesystem
+  survived" into "the record was never deleted".
 
   ## Examples
 
       :ok = stop_filesystem({:user, 123})
   """
-  @spec stop_filesystem(tuple(), keyword()) :: :ok | {:error, :not_found}
+  @spec stop_filesystem(tuple(), keyword()) ::
+          :ok | {:error, :not_found | :registry_unavailable}
 
   def stop_filesystem(scope_key, opts \\ []) do
     FileSystemSupervisor.stop_filesystem(scope_key, opts)
@@ -171,6 +187,14 @@ defmodule Sagents.FileSystem do
 
   @doc """
   Check if a filesystem is running for the given scope.
+  **Raises on a node whose registry is unavailable.**
+
+  `Sagents.RegistryUnavailableError` comes out of this whenever this node's
+  registry cannot answer, which covers the drain window of every rolling
+  deploy. A boolean has no room for "cannot tell", and `false` reads as
+  "nothing is running", which a caller responds to by starting a second
+  filesystem for a scope that already has one elsewhere. Use
+  `fetch_filesystem_running/1` anywhere a web request can reach.
 
   ## Parameters
 
@@ -187,9 +211,39 @@ defmodule Sagents.FileSystem do
   """
   @spec filesystem_running?(tuple()) :: boolean()
   def filesystem_running?(scope_key) when is_tuple(scope_key) do
+    case fetch_filesystem_running(scope_key) do
+      {:ok, running?} ->
+        running?
+
+      {:error, :registry_unavailable} ->
+        raise Sagents.RegistryUnavailableError,
+          operation: :"FileSystem.filesystem_running?/1"
+    end
+  end
+
+  @doc """
+  Whether a filesystem is running for `scope_key`, without raising.
+
+  The non-raising sibling of `filesystem_running?/1`, in the same relationship
+  as `Sagents.Session.fetch_running/2` to `running?/2`:
+
+  - `{:ok, true}` / `{:ok, false}` - the registry answered
+  - `{:error, :registry_unavailable}` - this node's registry could not answer
+
+  Prefer this anywhere a web request can reach. `{:ok, false}` means "start
+  one"; the error means this node cannot know, so it must not guess.
+
+  ## Examples
+
+      {:ok, true} = fetch_filesystem_running({:user, 123})
+      {:ok, false} = fetch_filesystem_running({:user, 999})
+  """
+  @spec fetch_filesystem_running(tuple()) :: {:ok, boolean()} | {:error, :registry_unavailable}
+  def fetch_filesystem_running(scope_key) when is_tuple(scope_key) do
     case FileSystemSupervisor.get_filesystem(scope_key) do
-      {:ok, _pid} -> true
-      {:error, :not_found} -> false
+      {:ok, _pid} -> {:ok, true}
+      {:error, :not_found} -> {:ok, false}
+      {:error, :registry_unavailable} = error -> error
     end
   end
 
@@ -204,12 +258,14 @@ defmodule Sagents.FileSystem do
 
   - `{:ok, pid}` - Filesystem found
   - `{:error, :not_found}` - Filesystem not running
+  - `{:error, :registry_unavailable}` - this node's registry could not answer
 
   ## Examples
 
       {:ok, pid} = get_filesystem_pid({:user, 123})
   """
-  @spec get_filesystem_pid(tuple()) :: {:ok, pid()} | {:error, :not_found}
+  @spec get_filesystem_pid(tuple()) ::
+          {:ok, pid()} | {:error, :not_found | :registry_unavailable}
   def get_filesystem_pid(scope_key) do
     FileSystemSupervisor.get_filesystem(scope_key)
   end
@@ -240,6 +296,9 @@ defmodule Sagents.FileSystem do
   ## Returns
 
   List of `{scope_key, pid}` tuples.
+
+  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
+  answer, rather than reporting an empty list as though it were a real result.
 
   ## Examples
 

--- a/lib/sagents/file_system/file_system_supervisor.ex
+++ b/lib/sagents/file_system/file_system_supervisor.ex
@@ -239,8 +239,8 @@ defmodule Sagents.FileSystem.FileSystemSupervisor do
             {:error, :not_found}
         end
 
-      {:error, :not_found} ->
-        {:error, :not_found}
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -255,16 +255,27 @@ defmodule Sagents.FileSystem.FileSystemSupervisor do
 
   - `{:ok, pid}` - Filesystem found
   - `{:error, :not_found}` - Filesystem not running for this scope
+  - `{:error, :registry_unavailable}` - this node's registry could not answer
+
+  The third answer is deliberately distinct from `:not_found` for the same
+  reason it is in `Sagents.AgentSupervisor.get_pid/1`: a caller reads "not
+  found" as "start one", and on a draining node that produces a second
+  filesystem for a scope that already has one elsewhere. See
+  `docs/deployment.md`.
 
   ## Examples
 
       {:ok, pid} = get_filesystem({:user, 123})
   """
-  @spec get_filesystem(tuple()) :: {:ok, pid()} | {:error, :not_found}
+  @spec get_filesystem(tuple()) :: {:ok, pid()} | {:error, :not_found | :registry_unavailable}
   def get_filesystem(scope_key) when is_tuple(scope_key) do
-    case ProcessRegistry.lookup({:filesystem_server, scope_key}) do
-      [{pid, _value}] -> {:ok, pid}
-      [] -> {:error, :not_found}
+    # Delegates rather than reading the registry itself. This key had two
+    # independent readers, and only one of them was guarded, so the whole
+    # public Sagents.FileSystem API kept raising after the other was fixed.
+    case FileSystemServer.fetch_pid(scope_key) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, :not_running} -> {:error, :not_found}
+      {:error, :registry_unavailable} = error -> error
     end
   end
 
@@ -274,6 +285,10 @@ defmodule Sagents.FileSystem.FileSystemSupervisor do
   ## Returns
 
   List of `{scope_key, pid}` tuples.
+
+  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
+  answer, rather than reporting an empty list as though it were a real result.
+  Same reasoning as `Sagents.ProcessRegistry.select/1`, which it uses.
 
   ## Examples
 
@@ -309,8 +324,20 @@ defmodule Sagents.FileSystem.FileSystemSupervisor do
   # before the process is visible via lookup. With local Registry, this
   # succeeds immediately on the first check.
   defp await_registry_propagation(registry_key, expected_pid, attempts \\ 50) do
-    case ProcessRegistry.lookup(registry_key) do
-      [{^expected_pid, _value}] ->
+    # `fetch/1` rather than `lookup/1`: the node can begin shutting down between
+    # the successful start_child and this wait, and polling a registry that is
+    # gone cannot succeed. Raising here would take down a start that already
+    # produced a live pid.
+    case ProcessRegistry.fetch(registry_key) do
+      {:ok, ^expected_pid} ->
+        :ok
+
+      {:error, :registry_unavailable} ->
+        Logger.warning(
+          "Registry unavailable while waiting for #{inspect(registry_key)} to propagate; " <>
+            "this node is shutting down"
+        )
+
         :ok
 
       _other when attempts > 0 ->

--- a/lib/sagents/file_system_server.ex
+++ b/lib/sagents/file_system_server.ex
@@ -133,12 +133,47 @@ defmodule Sagents.FileSystemServer do
   The scope_key can be any term that uniquely identifies the filesystem scope.
   Common patterns include tuples like `{:user, 123}`, UUIDs like
   `"550e8400-e29b-41d4-a716-446655440000"`, or database IDs like `12345`.
+
+  Returns `nil` when no FileSystemServer is registered for `scope_key`.
+
+  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
+  answer at all, which happens while the node is starting and while it drains
+  during a rolling deploy. `nil` there would be indistinguishable from "not
+  running", and callers act on that by starting a server. Use `fetch_pid/1` on
+  request paths, where the condition is a value rather than a raise.
   """
   @spec whereis(term()) :: pid() | nil
   def whereis(scope_key) do
-    case ProcessRegistry.lookup({:filesystem_server, scope_key}) do
-      [{pid, _value}] -> pid
-      [] -> nil
+    case fetch_pid(scope_key) do
+      {:ok, pid} ->
+        pid
+
+      {:error, :not_running} ->
+        nil
+
+      {:error, :registry_unavailable} ->
+        raise Sagents.RegistryUnavailableError, operation: :"FileSystemServer.whereis/1"
+    end
+  end
+
+  @doc """
+  Get the FileSystemServer pid for `scope_key`, without raising.
+
+  The three outcomes are kept distinct on purpose:
+
+  - `{:ok, pid}` - a FileSystemServer is running
+  - `{:error, :not_running}` - the registry answered, nothing is registered
+  - `{:error, :registry_unavailable}` - this node's registry could not answer
+
+  Prefer this over `whereis/1` anywhere a web request can reach. See
+  `docs/deployment.md`.
+  """
+  @spec fetch_pid(term()) :: {:ok, pid()} | {:error, :not_running | :registry_unavailable}
+  def fetch_pid(scope_key) do
+    case ProcessRegistry.fetch({:filesystem_server, scope_key}) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, :not_registered} -> {:error, :not_running}
+      {:error, :registry_unavailable} = error -> error
     end
   end
 

--- a/lib/sagents/session.ex
+++ b/lib/sagents/session.ex
@@ -412,26 +412,63 @@ defmodule Sagents.Session do
 
   @doc """
   Whether an agent session is currently running for `conversation_id`.
+  **Raises on a node whose registry is unavailable.**
 
-  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
-  answer. A boolean has no room for "cannot tell", and `false` would be read as
+  A `?`-suffixed predicate is the least likely function in this API to be
+  suspected of raising, so the warning is here in the summary rather than
+  further down: `Sagents.RegistryUnavailableError` comes out of this whenever
+  this node's registry cannot answer, which covers the drain window of every
+  rolling deploy.
+
+  A boolean has no room for "cannot tell", and `false` would be read as
   "nothing is running", which callers respond to by starting a duplicate agent.
-  Guard with `Sagents.ready?/0`, or use `ensure_running/3`, which reports the
-  condition as a value.
+  Use `fetch_running/2` where that matters, or `ensure_running/3`, which reports
+  the condition as a value.
+
+  If you wrap this in your own host predicate, carry the warning into that
+  function's docs too. The wrapper is where the next reader will meet it.
   """
   @spec running?(config(), conversation_id :: term()) :: boolean()
   def running?(config, conversation_id) do
-    agent_id = config.agent_id_fun.(conversation_id)
-
-    case AgentServer.fetch_pid(agent_id) do
-      {:ok, _pid} ->
-        true
-
-      {:error, :not_running} ->
-        false
+    case fetch_running(config, conversation_id) do
+      {:ok, running?} ->
+        running?
 
       {:error, :registry_unavailable} ->
         raise Sagents.RegistryUnavailableError, operation: :"Session.running?/2"
+    end
+  end
+
+  @doc """
+  Whether an agent session is running for `conversation_id`, without raising.
+
+  The non-raising sibling of `running?/2`, in the same relationship as
+  `Sagents.AgentServer.fetch_pid/1` to `get_pid/1` and
+  `Sagents.ProcessRegistry.fetch/1` to `lookup/1`:
+
+  - `{:ok, true}` / `{:ok, false}` - the registry answered
+  - `{:error, :registry_unavailable}` - this node's registry could not answer
+
+  Prefer this anywhere a web request can reach. `{:ok, false}` means "start
+  one"; the error means this node cannot know, so it must not guess.
+
+  ## Examples
+
+      case Session.fetch_running(config, conversation_id) do
+        {:ok, true} -> :already_running
+        {:ok, false} -> start_it()
+        {:error, :registry_unavailable} -> {:error, :draining}
+      end
+  """
+  @spec fetch_running(config(), conversation_id :: term()) ::
+          {:ok, boolean()} | {:error, :registry_unavailable}
+  def fetch_running(config, conversation_id) do
+    agent_id = config.agent_id_fun.(conversation_id)
+
+    case AgentServer.fetch_pid(agent_id) do
+      {:ok, _pid} -> {:ok, true}
+      {:error, :not_running} -> {:ok, false}
+      {:error, :registry_unavailable} = error -> error
     end
   end
 

--- a/lib/sagents/sub_agent_server.ex
+++ b/lib/sagents/sub_agent_server.ex
@@ -144,6 +144,14 @@ defmodule Sagents.SubAgentServer do
   ## Examples
 
       pid = SubAgentServer.whereis("main-agent-sub-1")
+
+  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
+  answer, for the same reason `Sagents.AgentServer.get_pid/1` does: `nil` would
+  be indistinguishable from "not running".
+
+  In practice this is unreachable. Callers run inside an agent turn, and the
+  parent agent is itself registered, so a registry that cannot answer would
+  have taken the caller down first.
   """
   @spec whereis(String.t()) :: pid() | nil
   def whereis(sub_agent_id) when is_binary(sub_agent_id) do

--- a/lib/sagents/sub_agents_dynamic_supervisor.ex
+++ b/lib/sagents/sub_agents_dynamic_supervisor.ex
@@ -65,6 +65,15 @@ defmodule Sagents.SubAgentsDynamicSupervisor do
   ## Examples
 
       pid = SubAgentsDynamicSupervisor.whereis("agent-123")
+
+  Raises `Sagents.RegistryUnavailableError` when this node's registry cannot
+  answer, for the same reason `Sagents.AgentServer.get_pid/1` does: `nil` would
+  be indistinguishable from "not running".
+
+  In practice this is unreachable. Every caller runs inside an agent turn, and
+  the agent itself is registered, so a registry that cannot answer would have
+  taken the caller down first. The raise is the correct answer to a question
+  that should not arise here.
   """
   @spec whereis(String.t()) :: pid() | nil
   def whereis(agent_id) do

--- a/lib/sagents/subscriber.ex
+++ b/lib/sagents/subscriber.ex
@@ -54,6 +54,8 @@ defmodule Sagents.Subscriber do
   until `:DOWN` fires, which it will.
   """
 
+  require Logger
+
   alias Sagents.AgentServer
   alias Sagents.FileSystemServer
   alias Sagents.Publisher
@@ -126,7 +128,15 @@ defmodule Sagents.Subscriber do
     key = {:filesystem, scope_key}
 
     do_subscribe(subs, key, channel, fn ->
-      Publisher.subscribe(FileSystemServer.get_name(scope_key), channel)
+      # Resolve the pid rather than handing Publisher a `:via` tuple, for the
+      # reason given on `Sagents.AgentServer.subscribe/3`: the via resolution
+      # inside `GenServer.call` raises out of `:ets` on a node whose registry
+      # is gone, past Publisher's `catch :exit`.
+      case FileSystemServer.fetch_pid(scope_key) do
+        {:ok, pid} -> Publisher.subscribe(pid, channel)
+        {:error, :not_running} -> {:error, :process_not_found}
+        {:error, :registry_unavailable} = error -> error
+      end
     end)
   end
 
@@ -136,7 +146,7 @@ defmodule Sagents.Subscriber do
   @spec unsubscribe_from_agent(subs(), String.t()) :: subs()
   def unsubscribe_from_agent(subs, agent_id) do
     do_unsubscribe(subs, {:agent, agent_id}, fn channel ->
-      Publisher.unsubscribe(AgentServer.get_name(agent_id), channel)
+      AgentServer.unsubscribe(agent_id, channel)
     end)
   end
 
@@ -146,7 +156,10 @@ defmodule Sagents.Subscriber do
   @spec unsubscribe_from_filesystem(subs(), term()) :: subs()
   def unsubscribe_from_filesystem(subs, scope_key) do
     do_unsubscribe(subs, {:filesystem, scope_key}, fn channel ->
-      Publisher.unsubscribe(FileSystemServer.get_name(scope_key), channel)
+      case FileSystemServer.fetch_pid(scope_key) do
+        {:ok, pid} -> Publisher.unsubscribe(pid, channel)
+        {:error, _reason} -> :ok
+      end
     end)
   end
 
@@ -166,7 +179,15 @@ defmodule Sagents.Subscriber do
           state: :subscribed
         })
 
-      {:error, :process_not_found} ->
+      # No producer to subscribe to, or no registry on this node able to find
+      # one. Both rest at `:pending`, which the next presence arrival revives.
+      #
+      # Folding `:registry_unavailable` in here is safe in a way it is not
+      # elsewhere: nothing starts a producer off the back of a pending entry.
+      # The dangerous conflation is "cannot answer" read as "nothing is
+      # running" by a caller whose response is to start one. A pending
+      # subscription just waits.
+      {:error, reason} when reason in [:process_not_found, :registry_unavailable] ->
         Map.put(subs, key, %{
           channel: channel,
           server_pid: nil,
@@ -226,20 +247,36 @@ defmodule Sagents.Subscriber do
 
   `joins` whose key matches a `:pending` agent subscription triggers a
   re-subscribe. Returns the (possibly updated) subs map.
+
+  Entries that cannot be re-subscribed stay `:pending` rather than being
+  dropped, so a later diff can still revive them. That covers a node whose own
+  registry is unavailable: the presence topic is cluster-wide, so this fires
+  for agents booting anywhere in the cluster, including while this node drains
+  and can resolve nothing.
   """
   @spec handle_presence_diff(subs(), String.t(), map()) :: subs()
   def handle_presence_diff(subs, @presence_topic, %{joins: joins}) when is_map(joins) do
-    Enum.reduce(Map.keys(joins), subs, fn agent_id, acc ->
-      key = {:agent, agent_id}
+    if Sagents.ready?() do
+      Enum.reduce(Map.keys(joins), subs, fn agent_id, acc ->
+        key = {:agent, agent_id}
 
-      case Map.get(acc, key) do
-        %{state: :pending, channel: channel} ->
-          subscribe_to_agent(acc, agent_id, channel)
+        case Map.get(acc, key) do
+          %{state: :pending, channel: channel} ->
+            subscribe_to_agent(acc, agent_id, channel)
 
-        _other ->
-          acc
-      end
-    end)
+          _other ->
+            acc
+        end
+      end)
+    else
+      # Every re-subscribe would resolve to `:pending` anyway, which is what
+      # these entries already are. Skipping the work matters because a host
+      # calls this from `handle_info` for a cluster-wide topic: without the
+      # guard a draining node probes its dead registry once per joining agent,
+      # per broadcast, for the length of the drain.
+      Logger.debug("presence diff ignored: registry unavailable on this node")
+      subs
+    end
   end
 
   def handle_presence_diff(subs, _topic, _payload), do: subs

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Sagents.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/sagents-ai/sagents"
-  @version "0.11.1"
+  @version "0.12.0"
 
   def project do
     [

--- a/priv/templates/agent_live_helpers.ex.eex
+++ b/priv/templates/agent_live_helpers.ex.eex
@@ -53,6 +53,11 @@ defmodule <%= module %> do
 
   require Logger
 
+  # Shown for `:registry_unavailable`, on every path that can hit it. See
+  # `flash_session_error/3` for why this condition gets its own copy. Reword it
+  # for your product; keep it separate from the other failures.
+  @draining_message "This server is restarting. Please try that again in a moment."
+
   # ===========================================================================
   # State init / reset
   # ===========================================================================
@@ -124,9 +129,34 @@ defmodule <%= module %> do
   ## Returns
 
   - `{:ok, socket}` - Socket with conversation loaded and subscribed
-  - `{:error, socket}` - Socket with flash error (when conversation not found)
+  - `{:error, socket}` - Socket with flash error (conversation not found, or
+    this node cannot host agent sessions)
   """
   def load_conversation(socket, conversation_id, opts) do
+    if Sagents.ready?() do
+      do_load_conversation(socket, conversation_id, opts)
+    else
+      # This node's Sagents supervision tree is down: it is draining during a
+      # deploy, or has not finished booting. Reading the agent's status,
+      # subscribing, and waking it for a pending interrupt all need the
+      # registry, so there is nothing worth rendering here.
+      #
+      # The guard is what keeps this from being a crash.
+      # `AgentServer.get_status/1` below reads as total — it catches exits and
+      # answers `:not_running` — but it raises
+      # `Sagents.RegistryUnavailableError` before reaching the call it guards,
+      # and a `catch :exit` clause does not catch a raise. The `rescue` below
+      # does not catch it either.
+      Logger.warning(
+        "Refusing to load conversation #{inspect(conversation_id)}: " <>
+          "this node is draining, its Sagents registry is unavailable"
+      )
+
+      {:error, put_flash(socket, :error, @draining_message)}
+    end
+  end
+
+  defp do_load_conversation(socket, conversation_id, opts) do
     scope = Keyword.fetch!(opts, :scope)
     user_id = Keyword.get(opts, :user_id)
     conversations = Keyword.get(opts, :conversations_module, <%= conversations_alias %>)
@@ -555,8 +585,10 @@ defmodule <%= module %> do
         |> assign(Sagents.AgentUtils.cleared_interrupt_changes())
 
       {:error, reason} ->
-        Logger.error("halt dismissal failed: #{inspect(reason)}")
-        put_flash(socket, :error, "That could not be dismissed. Please try again.")
+        flash_session_error(socket, reason,
+          log_label: "halt dismissal failed",
+          user_message: "That could not be dismissed. Please try again."
+        )
     end
   end
 
@@ -570,14 +602,8 @@ defmodule <%= module %> do
   # the wrong state (someone answered from another tab) returns an error
   # rather than being woken, because there is nothing to wake.
   #
-  # `copy` carries two deliberately separate strings:
-  #
-  #   * `:log_label` - internal vocabulary, paired with the raw reason term.
-  #   * `:user_message` - product copy shown to the person. Never interpolate
-  #     the reason into it. A live-but-wrong-state agent returns "Cannot
-  #     resume, server is not interrupted": an internal string, and one that
-  #     says "agent", a word many products deliberately never put in front of
-  #     a user. This is a slot you are meant to edit and localize.
+  # `copy` is the log label / product copy pair described on
+  # `flash_session_error/3`.
   defp resume_or_flash(socket, resume_data, changes, running_changes, copy) do
     case <%= coordinator_alias %>.resume_agent_session(
            socket.assigns,
@@ -594,7 +620,60 @@ defmodule <%= module %> do
         |> assign(running_changes)
 
       {:error, reason} ->
-        Logger.error("#{Keyword.fetch!(copy, :log_label)}: #{inspect(reason)}")
+        flash_session_error(socket, reason, copy)
+    end
+  end
+
+  # ===========================================================================
+  # Session error reporting
+  # ===========================================================================
+
+  @doc """
+  The copy shown when this node cannot host agent sessions.
+
+  Exposed so tests can assert *which* message a path produced without
+  hardcoding the string. A test that inlines the literal keeps passing after
+  someone rewords the copy, which is the moment it stops testing anything. The
+  assertion worth writing is that the draining copy differs from the ordinary
+  failure copy, and it needs this to be expressible.
+  """
+  def draining_message, do: @draining_message
+
+  @doc """
+  Log a failed session action and flash product copy describing it.
+
+  `copy` carries two deliberately separate strings:
+
+    * `:log_label` - internal vocabulary, paired with the raw reason term.
+    * `:user_message` - product copy shown to the person. Never interpolate the
+      reason into it. A live-but-wrong-state agent returns "Cannot resume,
+      server is not interrupted": an internal string, and one that says "agent",
+      a word many products deliberately never put in front of a user. This is a
+      slot you are meant to edit and localize.
+
+  `:registry_unavailable` is answered separately because it is not a failure of
+  the request. It means this node cannot host or route agent sessions - it is
+  draining during a deploy, or has not finished booting - while another node
+  serves the same request fine. "Try again" is literally the correct
+  instruction, and after a deploy the reconnect lands on a node that works.
+  Reporting it as a generic failure tells the user something is broken when
+  nothing is, and logging it at `:error` fills the log with alarms for a routine
+  deploy.
+
+  Route every session failure through here rather than adding a clause per call
+  site: the drain path is the one failure a healthy production system produces
+  routinely, which is what makes both rules load-bearing rather than tidy.
+  """
+  def flash_session_error(socket, reason, copy) do
+    label = Keyword.fetch!(copy, :log_label)
+
+    case reason do
+      :registry_unavailable ->
+        Logger.warning("#{label}: this node is draining, its Sagents registry is unavailable")
+        put_flash(socket, :error, @draining_message)
+
+      other ->
+        Logger.error("#{label}: #{inspect(other)}")
         put_flash(socket, :error, Keyword.fetch!(copy, :user_message))
     end
   end

--- a/priv/templates/coordinator.ex.eex
+++ b/priv/templates/coordinator.ex.eex
@@ -145,13 +145,38 @@ defmodule <%= module %> do
 
   Note: agents automatically stop after inactivity timeout. Only call this
   for explicit cleanup (e.g., conversation archival).
+
+  Returns `{:ok, :stopped}`, `{:ok, :not_running}`, or
+  `{:error, :registry_unavailable}` when this node cannot answer registry
+  lookups at all.
   """
   def stop_conversation_session(conversation_id),
     do: Sagents.Session.stop(@config, conversation_id)
 
-  @doc "Whether an agent session is currently running for `conversation_id`."
+  @doc """
+  Whether an agent session is currently running for `conversation_id`.
+  **Raises on a node whose registry is unavailable.**
+
+  `Sagents.RegistryUnavailableError` comes out of this whenever this node's
+  registry cannot answer, which covers the drain window of every rolling
+  deploy. A boolean has no room for "cannot tell", and `false` reads as
+  "nothing is running", which a caller responds to by starting a duplicate
+  agent for a conversation that already has one elsewhere.
+
+  Anywhere a web request can reach, use `fetch_session_running/1` or
+  `ensure_agent_session_running/2`, which report the condition as a value.
+  """
   def session_running?(conversation_id),
     do: Sagents.Session.running?(@config, conversation_id)
+
+  @doc """
+  Whether an agent session is running for `conversation_id`, without raising.
+
+  Returns `{:ok, boolean}` or `{:error, :registry_unavailable}`. The
+  non-raising form of `session_running?/1`; see `Sagents.Session.fetch_running/2`.
+  """
+  def fetch_session_running(conversation_id),
+    do: Sagents.Session.fetch_running(@config, conversation_id)
 
   # ===========================================================================
   # Customization slots (edit after generation as needed)

--- a/test/sagents/agent_cancel_subagent_test.exs
+++ b/test/sagents/agent_cancel_subagent_test.exs
@@ -1,20 +1,25 @@
 defmodule Sagents.AgentCancelSubAgentTest do
   @moduledoc """
-  Integration test for the main-agent-cancel → sub-agent-cancel contract.
+  Integration coverage for the main-agent-cancel → sub-agent-cancel contract.
 
   When the main agent is cancelled, every running SubAgentServer must die too
   (the parent won't consume the sub-agent's result) AND the debugger must see
   a terminal :subagent_cancelled event before the sub-agent vanishes.
 
-  Tagged :slow because it mocks a sub-agent that sleeps 5 seconds; the test
-  asserts the sub-agent dies well before that. Without the fix the sub-agent
-  runs to completion and the assertion times out.
+  A sub-agent blocked in an LLM call cannot broadcast that event for itself, so
+  the parent broadcasts a minimal one on its behalf. Resolving the sub-agent's
+  id for that broadcast reads this node's registry, which is why one test here
+  drives the same path with the registry refusing to answer.
+
+  Tagged :slow because the mocked sub-agent sleeps 5 seconds; the tests assert
+  it dies well before that.
   """
 
   use Sagents.BaseCase, async: false
   use Mimic
 
-  alias Sagents.{Agent, AgentServer, State, SubAgent}
+  alias Sagents.{Agent, AgentServer, ProcessRegistry, State, SubAgent}
+  alias Sagents.RegistryUnavailableError
   alias Sagents.SubAgentsDynamicSupervisor
   alias LangChain.ChatModels.ChatAnthropic
   alias LangChain.Function
@@ -44,36 +49,26 @@ defmodule Sagents.AgentCancelSubAgentTest do
     )
   end
 
-  @tag :slow
-  test "cancelling main agent kills running sub-agent and broadcasts :subagent_cancelled" do
-    agent_id = "parent-cancel-#{System.unique_integer([:positive])}"
+  defp slow_researcher_config do
+    SubAgent.Config.new!(%{
+      name: "slow-researcher",
+      description: "Performs slow research",
+      system_prompt: "You research things slowly.",
+      tools: [
+        Function.new!(%{
+          name: "noop",
+          description: "Placeholder tool; never actually called in this test.",
+          function: fn _args, _ctx -> {:ok, "noop"} end
+        })
+      ]
+    })
+  end
 
-    subagent_config =
-      SubAgent.Config.new!(%{
-        name: "slow-researcher",
-        description: "Performs slow research",
-        system_prompt: "You research things slowly.",
-        tools: [
-          Function.new!(%{
-            name: "noop",
-            description: "Placeholder tool; never actually called in this test.",
-            function: fn _args, _ctx -> {:ok, "noop"} end
-          })
-        ]
-      })
-
-    agent = make_parent_agent(agent_id, [subagent_config])
-
-    # Start the SubAgentsDynamicSupervisor that the SubAgent middleware needs.
-    {:ok, _sup} = SubAgentsDynamicSupervisor.start_link(agent_id: agent_id)
-
-    # Subscribe later (after AgentServer starts) via the new direct transport.
-
-    test_pid = self()
-
-    # Mock LLM: parent's first call returns a task tool call; the sub-agent's
-    # first call sleeps 5s to simulate being stuck mid-LLM-call. If cancel
-    # doesn't kill the sub-agent, the full sleep elapses and the test times out.
+  # Mock LLM: the parent's first call returns a task tool call; the sub-agent's
+  # first call sleeps 5s to simulate being stuck mid-LLM-call. A cancel that
+  # fails to kill the sub-agent lets the full sleep elapse and the assertions
+  # time out.
+  defp stub_blocked_subagent_llm(test_pid) do
     ChatAnthropic
     |> stub(:call, fn _model, messages, _tools ->
       is_subagent_call =
@@ -115,10 +110,22 @@ defmodule Sagents.AgentCancelSubAgentTest do
         {:ok, [msg]}
       end
     end)
+  end
+
+  # Leaves the parent running with one sub-agent blocked inside its LLM call,
+  # which is the state that routes cancellation through the parent's fallback
+  # broadcast rather than the sub-agent's own.
+  defp start_parent_with_blocked_subagent(agent_id) do
+    agent = make_parent_agent(agent_id, [slow_researcher_config()])
+
+    # Start the SubAgentsDynamicSupervisor that the SubAgent middleware needs.
+    {:ok, _sup} = SubAgentsDynamicSupervisor.start_link(agent_id: agent_id)
+
+    stub_blocked_subagent_llm(self())
 
     initial_state = State.new!(%{messages: [Message.new_user!("Research")]})
 
-    {:ok, _pid} =
+    {:ok, server_pid} =
       AgentServer.start_link(
         agent: agent,
         initial_state: initial_state,
@@ -141,6 +148,15 @@ defmodule Sagents.AgentCancelSubAgentTest do
     [{_id, sub_pid, :worker, _modules}] = DynamicSupervisor.which_children(sup_pid)
     assert is_pid(sub_pid)
 
+    %{server_pid: server_pid, sub_pid: sub_pid}
+  end
+
+  @tag :slow
+  test "cancelling main agent kills running sub-agent and broadcasts :subagent_cancelled" do
+    agent_id = "parent-cancel-#{System.unique_integer([:positive])}"
+
+    %{sub_pid: sub_pid} = start_parent_with_blocked_subagent(agent_id)
+
     ref = Process.monitor(sub_pid)
 
     # Cancel the main agent.
@@ -150,7 +166,7 @@ defmodule Sagents.AgentCancelSubAgentTest do
     # have completed naturally.
     assert_receive {:DOWN, ^ref, :process, ^sub_pid, _reason}, 2_000
 
-    # Assert 2: observability — the terminal :subagent_cancelled event fired.
+    # Assert 2: observability. The terminal :subagent_cancelled event fired.
     # Context is empty in this test because the sub-agent was blocked in an
     # LLM call and the parent fallback-broadcasts without state -- the
     # debugger already has the per-turn messages from its own stream.
@@ -175,5 +191,36 @@ defmodule Sagents.AgentCancelSubAgentTest do
     assert_receive {:agent,
                     {:tool_execution_update, :cancelled, %{call_id: "parent_tc_1", name: "task"}}},
                    1_000
+  end
+
+  @tag :slow
+  test "cancel completes when the registry cannot resolve the sub-agent id" do
+    agent_id = "parent-cancel-drain-#{System.unique_integer([:positive])}"
+
+    %{sub_pid: sub_pid} = start_parent_with_blocked_subagent(agent_id)
+
+    # The drain window, narrowed to the single call the fallback broadcast
+    # makes. keys/1 raises rather than exiting, and it runs inside the :cancel
+    # handle_call, so an error escaping it takes the AgentServer down partway
+    # through cancelling.
+    stub(ProcessRegistry, :keys, fn _pid ->
+      raise RegistryUnavailableError, operation: :keys
+    end)
+
+    ref = Process.monitor(sub_pid)
+
+    # A crashed handle_call would exit the caller here rather than answering.
+    assert :ok = AgentServer.cancel(agent_id)
+
+    # Teardown still completes: the sub-agent dies and the parent survives to
+    # record the cancellation. get_status/1 is the synchronous proof of both.
+    assert_receive {:DOWN, ^ref, :process, ^sub_pid, _reason}, 2_000
+    assert AgentServer.get_status(agent_id) == :cancelled
+
+    # What is lost is the best-effort observability event, because the
+    # sub-agent's id cannot be resolved without the registry. Losing the event
+    # is the acceptable outcome; losing the AgentServer is not.
+    refute_receive {:agent, {:debug, {:subagent, _sub_id, {:subagent_cancelled, _ctx}}}},
+                   300
   end
 end

--- a/test/sagents/drain_paths_test.exs
+++ b/test/sagents/drain_paths_test.exs
@@ -1,0 +1,170 @@
+defmodule Sagents.DrainPathsTest do
+  @moduledoc """
+  Coverage for the paths a host reaches while this node's registry cannot
+  answer: the drain window of a rolling deploy.
+
+  The distinction these guard is that a `GenServer.call` on a `:via` tuple
+  raises `ArgumentError` from inside `:ets` when the registry's table is gone,
+  and a `catch :exit` clause does not catch a raise. Every function here sits
+  behind such a `catch` and reads as though it already handled the condition.
+
+  Uses the same unavailable-registry construction as
+  `Sagents.ProcessRegistryAvailabilityTest`: pointing the backend at a registry
+  name that owns no table is observably identical to a shut-down registry.
+  """
+  use ExUnit.Case, async: false
+
+  alias Sagents.AgentServer
+  alias Sagents.FileSystemServer
+  alias Sagents.Subscriber
+
+  setup do
+    original = Application.get_env(:sagents, :distribution, :local)
+    Application.put_env(:sagents, :distribution, :horde)
+    on_exit(fn -> Application.put_env(:sagents, :distribution, original) end)
+
+    refute Sagents.ready?()
+    :ok
+  end
+
+  describe "AgentServer.notify_middleware/3" do
+    test "drops the message and returns :ok rather than raising" do
+      assert :ok = AgentServer.notify_middleware("anything", :some_middleware, :ping)
+    end
+  end
+
+  describe "AgentServer.subscribe/3 and unsubscribe/3" do
+    test "subscribe/3 reports the condition instead of raising" do
+      assert {:error, :registry_unavailable} = AgentServer.subscribe("anything")
+    end
+
+    test "unsubscribe/3 is a no-op instead of raising" do
+      assert :ok = AgentServer.unsubscribe("anything")
+    end
+  end
+
+  describe "Subscriber.subscribe_to_agent/3" do
+    test "records the entry as :pending rather than raising" do
+      # :pending is the correct resting state. Nothing starts an agent off the
+      # back of a pending entry, so this is not the not_running conflation the
+      # release exists to prevent, and the next presence diff revives it.
+      subs = Subscriber.subscribe_to_agent(%{}, "anything")
+
+      assert %{state: :pending, server_pid: nil} = subs[{:agent, "anything"}]
+    end
+
+    test "unsubscribe_from_agent/2 drops the entry rather than raising" do
+      subs = Subscriber.subscribe_to_agent(%{}, "anything")
+
+      assert Subscriber.unsubscribe_from_agent(subs, "anything") == %{}
+    end
+  end
+
+  describe "Subscriber.subscribe_to_filesystem/3" do
+    test "records the entry as :pending rather than raising" do
+      subs = Subscriber.subscribe_to_filesystem(%{}, {:user, 1})
+
+      assert %{state: :pending, server_pid: nil} = subs[{:filesystem, {:user, 1}}]
+    end
+
+    test "unsubscribe_from_filesystem/2 drops the entry rather than raising" do
+      subs = Subscriber.subscribe_to_filesystem(%{}, {:user, 1})
+
+      assert Subscriber.unsubscribe_from_filesystem(subs, {:user, 1}) == %{}
+    end
+  end
+
+  describe "Subscriber.handle_presence_diff/3" do
+    test "leaves pending entries pending rather than raising" do
+      # The host never makes this call. The generated helper routes
+      # presence_diff broadcasts into it from handle_info, and the presence
+      # topic is cluster-wide, so an agent booting on any node would otherwise
+      # crash every open LiveView on a draining node.
+      subs = Subscriber.subscribe_to_agent(%{}, "anything")
+
+      result =
+        Subscriber.handle_presence_diff(
+          subs,
+          Subscriber.presence_topic(),
+          %{joins: %{"anything" => %{}}, leaves: %{}}
+        )
+
+      assert %{state: :pending} = result[{:agent, "anything"}]
+    end
+
+    test "keeps entries it cannot resubscribe rather than dropping them" do
+      subs = Subscriber.subscribe_to_agent(%{}, "anything")
+
+      result =
+        Subscriber.handle_presence_diff(
+          subs,
+          Subscriber.presence_topic(),
+          %{joins: %{"anything" => %{}}, leaves: %{}}
+        )
+
+      assert Map.keys(result) == Map.keys(subs)
+    end
+  end
+
+  describe "the Sagents.FileSystem public API" do
+    test "stop_filesystem/2 reports the condition rather than raising" do
+      # A best-effort cleanup that raises takes its caller's whole operation
+      # down with it. The host case that found this ran stop_filesystem/2
+      # before a Repo.transaction, so the raise meant the record was never
+      # deleted, not merely that scratch space survived.
+      assert {:error, :registry_unavailable} = Sagents.FileSystem.stop_filesystem({:user, 1})
+    end
+
+    test "get_filesystem_pid/1 reports the condition rather than raising" do
+      assert {:error, :registry_unavailable} = Sagents.FileSystem.get_filesystem_pid({:user, 1})
+    end
+
+    test "ensure_filesystem/3 refuses to start rather than guessing" do
+      # Starting one here is the duplicate-creation hazard the release exists
+      # to prevent: this node cannot see whether a filesystem already exists.
+      assert {:error, :registry_unavailable} =
+               Sagents.FileSystem.ensure_filesystem({:user, 1}, [])
+    end
+
+    test "fetch_filesystem_running/1 reports the condition as a value" do
+      assert {:error, :registry_unavailable} =
+               Sagents.FileSystem.fetch_filesystem_running({:user, 1})
+    end
+
+    test "filesystem_running?/1 raises rather than answering false" do
+      # false reads as "nothing is running", which a caller responds to by
+      # starting one. Same reasoning as Session.running?/2.
+      assert_raise Sagents.RegistryUnavailableError, fn ->
+        Sagents.FileSystem.filesystem_running?({:user, 1})
+      end
+    end
+
+    test "list_filesystems/0 raises rather than answering []" do
+      assert_raise Sagents.RegistryUnavailableError, fn ->
+        Sagents.FileSystem.list_filesystems()
+      end
+    end
+  end
+
+  describe "AgentSupervisor.stop/2" do
+    test "reports the condition rather than raising CaseClauseError" do
+      # get_pid/1 gained a third answer in v0.12.0; a case matching only the
+      # two it had before turns a drain into an unrelated-looking crash.
+      assert {:error, :registry_unavailable} = Sagents.AgentSupervisor.stop("anything")
+    end
+  end
+
+  describe "FileSystemServer.whereis/1" do
+    test "raises a named error rather than answering nil" do
+      # nil reads as "no filesystem server is running", which a caller responds
+      # to by starting one.
+      assert_raise Sagents.RegistryUnavailableError, fn ->
+        FileSystemServer.whereis({:user, 1})
+      end
+    end
+
+    test "fetch_pid/1 reports the condition as a value" do
+      assert {:error, :registry_unavailable} = FileSystemServer.fetch_pid({:user, 1})
+    end
+  end
+end

--- a/test/sagents/session_test.exs
+++ b/test/sagents/session_test.exs
@@ -462,6 +462,35 @@ defmodule Sagents.SessionTest do
       stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
       assert Session.running?(base_config(), 1)
     end
+
+    test "raises rather than answering false when the registry cannot answer" do
+      # false would be read as "nothing is running", and a caller responds to
+      # that by starting a duplicate agent for a conversation that already has
+      # one on another node.
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :registry_unavailable} end)
+
+      assert_raise Sagents.RegistryUnavailableError, fn ->
+        Session.running?(base_config(), 1)
+      end
+    end
+  end
+
+  describe "fetch_running/2" do
+    test "{:ok, false} when no agent is registered" do
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :not_running} end)
+      assert {:ok, false} = Session.fetch_running(base_config(), 1)
+    end
+
+    test "{:ok, true} when an agent is registered" do
+      fake_pid = :erlang.list_to_pid(~c"<0.99999.0>")
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:ok, fake_pid} end)
+      assert {:ok, true} = Session.fetch_running(base_config(), 1)
+    end
+
+    test "keeps 'cannot answer' distinct from 'not running'" do
+      stub(AgentServer, :fetch_pid, fn _agent_id -> {:error, :registry_unavailable} end)
+      assert {:error, :registry_unavailable} = Session.fetch_running(base_config(), 1)
+    end
   end
 
   # ===========================================================================

--- a/test/sagents/templates_test.exs
+++ b/test/sagents/templates_test.exs
@@ -1,0 +1,86 @@
+defmodule Sagents.TemplatesTest do
+  @moduledoc """
+  Coverage for what `mix sagents.setup` generates.
+
+  Generated modules are copies: a dependency bump never touches them, so a
+  defect shipped in a template stays in every application that ran the
+  generator, and only a migration guide can reach it. These assertions pin the
+  properties that are expensive to notice are missing.
+
+  The templates are EEx, so they are not compiled by this suite. These render
+  them and assert on the source text.
+  """
+  use ExUnit.Case, async: true
+
+  @bindings [
+    module: MyAppWeb.AgentLiveHelpers,
+    conversations_module: MyApp.Conversations,
+    conversations_alias: "Conversations",
+    coordinator_module: MyApp.Agents.Coordinator,
+    coordinator_alias: "Coordinator",
+    subscriber_session_module: MyApp.Agents.AgentSubscriberSession,
+    subscriber_session_alias: "AgentSubscriberSession",
+    app: :my_app,
+    app_module: MyApp
+  ]
+
+  defp render(name) do
+    EEx.eval_file(Path.join([__DIR__, "..", "..", "priv", "templates", name]), @bindings)
+  end
+
+  describe "agent_live_helpers.ex.eex" do
+    setup do
+      %{source: render("agent_live_helpers.ex.eex")}
+    end
+
+    test "renders to syntactically valid Elixir", %{source: source} do
+      # The template is EEx, so nothing else in this suite would catch an edit
+      # that breaks it. The generator's users would.
+      assert {:ok, _ast} = Code.string_to_quoted(source)
+    end
+
+    test "guards the conversation-load path on registry availability", %{source: source} do
+      # AgentServer.get_status/1 raises Sagents.RegistryUnavailableError on a
+      # draining node, past both its own `catch :exit` and this function's
+      # `rescue Ecto.NoResultsError`. Without the guard, every generated app
+      # crashes its LiveView mount for the length of every deploy.
+      guard = index_of(source, "if Sagents.ready?() do")
+      status_read = index_of(source, "AgentServer.get_status(agent_id)")
+
+      assert guard, "load_conversation/3 has no Sagents.ready?/0 guard"
+      assert status_read, "expected the template to still read the agent status"
+
+      assert guard < status_read,
+             "the Sagents.ready?/0 guard must come before the get_status/1 call"
+    end
+
+    test "reports a draining node with its own copy, not the generic failure" do
+      source = render("agent_live_helpers.ex.eex")
+
+      assert source =~ "@draining_message"
+      assert source =~ "def flash_session_error(socket, reason, copy)"
+      assert source =~ ":registry_unavailable ->"
+
+      # Without an accessor a host test has to hardcode the copy, and then it
+      # passes unchanged through the rewording the template invites.
+      assert source =~ "def draining_message, do: @draining_message"
+    end
+
+    test "routes every session failure through the one funnel", %{source: source} do
+      # A per-call-site clause is how the drain case gets missed on the paths
+      # nobody thought about.
+      refute source =~ ~r/Logger\.error\("halt dismissal failed/,
+             "halt dismissal still formats its own error"
+
+      refute source =~ ~r/Logger\.error\("#\{Keyword\.fetch!\(copy, :log_label\)\}/,
+             "the resume funnel still formats its own error"
+    end
+  end
+
+  defp index_of(source, needle) do
+    case :binary.match(source, needle) do
+      {start, _length} -> start
+      :nomatch -> nil
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,6 +9,7 @@ Mimic.copy(LangChain.ChatModels.ChatOpenAI)
 Mimic.copy(Sagents.SubAgentServer)
 Mimic.copy(Sagents.FileSystem.FileSystemSupervisor)
 Mimic.copy(Sagents.ProcessSupervisor)
+Mimic.copy(Sagents.ProcessRegistry)
 Mimic.copy(Sagents.AgentSupervisor)
 Mimic.copy(Horde.Cluster)
 


### PR DESCRIPTION
## Problem

The registry-unavailable work for v0.12.0 landed in [#168](https://github.com/sagents-ai/sagents/pull/168) and [#169](https://github.com/sagents-ai/sagents/pull/169). Migrating downstream applications onto it found that the release did not hold up in practice:

- **The guarantee had holes.** Several public functions still raised on a draining node despite sitting behind a `catch :exit` that reads as though the condition were handled. `Publisher.subscribe/3` is a `GenServer.call`, so handing it a `:via` tuple raises `ArgumentError` out of `:ets` when the registry's table is gone, and a `catch :exit` clause does not catch a raise. `Sagents.FileSystem`'s registry key had two independent readers and only one was guarded, so the whole public filesystem API kept raising.
- **`AgentSupervisor.stop/2` matched only the two answers `get_pid/1` used to give**, turning a drain into a `CaseClauseError` that looks unrelated to deploying.
- **Every generated application shipped the release's own headline trap.** `load_conversation/3` in the `AgentLiveHelpers` template calls `AgentServer.get_status/1` inside a `rescue Ecto.NoResultsError`, which does not catch `RegistryUnavailableError`. The symptom is a crashed LiveView mount for the entire drain window of every deploy, in code the host did not write and a `mix deps.get` cannot reach.
- **The deployment guide's wiring did not actually produce a drain.** It told hosts to wire readiness to `Sagents.ready?/0` alone, but that signal first answers false when the supervision tree stops, which is *after* the load balancer needed it. A node would answer 200 for the whole drain and then start failing requests at the same instant it reported unhealthy.

## Solution

Extend the tri-state (`{:ok, _}` / `{:error, :not_running}` / `{:error, :registry_unavailable}`) across the surfaces the migrations actually touched, and give every raising function a non-raising sibling so request paths have something to call.

Where a `:via` tuple reached a `GenServer.call`, the pid is now resolved first (`AgentServer.subscribe/3`, `Subscriber.subscribe_to_filesystem/3`) so the raise never happens. `FileSystemSupervisor.get_filesystem/1` delegates to the single guarded reader rather than reading the registry a second time itself.

The raise-vs-return split follows return shape, not module: functions whose shape can carry a third answer report it, while `pid() | nil`, boolean, and list shapes raise `Sagents.RegistryUnavailableError` rather than answering with `nil`, `false`, or `[]`, each of which reads as "nothing is running" and is answered by starting a duplicate. Both `?`-predicates now carry that warning in their doc summary, since a name ending in `?` is the last thing a reader suspects of raising.

Two places take the opposite decision on purpose. `Subscriber` folds `:registry_unavailable` in with `:process_not_found` and rests at `:pending`, because nothing starts a producer off the back of a pending entry, and `handle_presence_diff/3` short-circuits on `Sagents.ready?/0` so a draining node does not probe its dead registry once per joining agent for the length of the drain. In `AgentServer`, sub-agent id resolution during teardown rescues the error to `nil`, because an escaping error there takes the AgentServer down mid-cleanup and the only thing lost is a best-effort observability event.

## Changes

**Library**

- [`lib/sagents/file_system.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/file_system.ex) - added `fetch_filesystem_running/1`; `filesystem_running?/1` now raises rather than answering `false`; `ensure_filesystem/3` refuses to start a filesystem it could not first check for
- [`lib/sagents/file_system/file_system_supervisor.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/file_system/file_system_supervisor.ex) - `get_filesystem/1` delegates to `FileSystemServer.fetch_pid/1`; propagation polling uses `ProcessRegistry.fetch/1` and logs instead of raising when the node goes away mid-start
- [`lib/sagents/file_system_server.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/file_system_server.ex) - added `fetch_pid/1`; `whereis/1` raises rather than answering `nil`
- [`lib/sagents/session.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/session.ex) - added `fetch_running/2`, with `running?/2` now implemented on top of it
- [`lib/sagents/agent_server.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/agent_server.ex) - `subscribe/3` and `unsubscribe/3` resolve the pid instead of passing a `:via` tuple; `notify_middleware/3` logs the dropped message; sub-agent id lookup rescues the error during teardown
- [`lib/sagents/agent_supervisor.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/agent_supervisor.ex) - `stop/2` propagates `:registry_unavailable` instead of raising `CaseClauseError`
- [`lib/sagents/subscriber.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/subscriber.ex) - filesystem subscribe/unsubscribe resolve the pid; unreachable subscriptions rest at `:pending` rather than crashing or being dropped; `handle_presence_diff/3` guards on `Sagents.ready?/0`
- [`lib/sagents/sub_agent_server.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/sub_agent_server.ex), [`lib/sagents/sub_agents_dynamic_supervisor.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/sub_agents_dynamic_supervisor.ex), [`lib/sagents/agents_dynamic_supervisor.ex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/lib/sagents/agents_dynamic_supervisor.ex) - documented the raising behaviour and why it is unreachable from inside an agent turn
- [`mix.exs`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/mix.exs) - version bumped to `0.12.0`

**Generator templates** (copies in every host app, so a defect here is only reachable by a migration guide)

- [`priv/templates/agent_live_helpers.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/priv/templates/agent_live_helpers.ex.eex) - `load_conversation/3` guards on `Sagents.ready?/0` and moves its body to `do_load_conversation/3`; new `flash_session_error/3` funnel gives `:registry_unavailable` its own copy and logs it at `:warning` rather than `:error`, so a routine deploy stops filling the log with alarms; `draining_message/0` exists so host tests can assert which message a path produced without hardcoding the string
- [`priv/templates/coordinator.ex.eex`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/priv/templates/coordinator.ex.eex) - added `fetch_session_running/1`; documented the raise on `session_running?/1`

**Documentation**

- [`MIGRATION_PROMPT_v0.11.x_TO_v0.12.0.md`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/MIGRATION_PROMPT_v0.11.x_TO_v0.12.0.md) (new) - the eight-step migration, written from what the downstream migrations actually hit: the template patch, a call-site audit whose grep deliberately notes what it misses, the catch-all clause that swallows `:registry_unavailable` into "start a duplicate", and what a registry crash now costs
- [`docs/deployment.md`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/docs/deployment.md) - readiness now needs two sources, since `Sagents.ready?/0` flips at step 5 and the load balancer needed a signal at step 2; adds a complete `MyApp.Drain` process, states that only SIGTERM runs `terminate/2` at all (so under SIGINT no agent state is persisted on any deploy), and documents three silent misconfigurations: `force_ssl` redirecting the probe, `Plug.SSL` comparing paths by equality rather than prefix, and Fly's `checks` / `http_checks` sub-keys decoding into no check at all
- Module docs across the changed files classify behaviour by how a call reaches the registry, including the `cast`-is-safe / `call`-raises asymmetry that makes a function's signature uninformative on its own

**Tests**

- [`test/sagents/drain_paths_test.exs`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/test/sagents/drain_paths_test.exs) (new) - 15 tests covering each path a host reaches on a draining node, asserting both directions of the split: which functions report the condition and which raise
- [`test/sagents/templates_test.exs`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/test/sagents/templates_test.exs) (new) - renders the EEx templates and pins the properties that are expensive to notice missing: valid Elixir, the guard ordered before the `get_status/1` call, separate draining copy, and no per-call-site error formatting left behind
- [`test/sagents/agent_cancel_subagent_test.exs`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/test/sagents/agent_cancel_subagent_test.exs) - extracted the setup into helpers and added a test driving cancellation with `ProcessRegistry.keys/1` raising, asserting the sub-agent still dies and the parent survives
- [`test/sagents/session_test.exs`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/test/sagents/session_test.exs) - coverage for `fetch_running/2` and for `running?/2` raising
- [`test/test_helper.exs`](https://github.com/sagents-ai/sagents/blob/me-prep-for-v0.12.0/test/test_helper.exs) - `Mimic.copy(Sagents.ProcessRegistry)`

## Testing

`mix test` passes at 1756 tests, 1 skipped. The new `:slow` cancel test passes with `mix test --include slow`.

The drain tests construct the unavailable-registry condition the same way `Sagents.ProcessRegistryAvailabilityTest` does, by pointing the backend at a registry name that owns no table, which is observably identical to a shut-down registry. The one exception is the cancel test, which stubs `ProcessRegistry.keys/1` to raise so the drain window narrows to the single call the fallback broadcast makes, with the rest of the agent left live.

The template tests render the EEx and assert on source text, since nothing else in the suite compiles those files.

No `CHANGELOG.md` entry for v0.12.0 is included here, and the `mix.exs` bump is.
