### PR TITLE
Persist dead-stream partials, classify framework transcript rows

### DIFF
--- a/lib/sagents/agent.ex
+++ b/lib/sagents/agent.ex
@@ -765,11 +765,14 @@ defmodule Sagents.Agent do
     end)
   end
 
-  # Fire a Sagents-specific callback key (e.g., :on_after_middleware) from the
-  # callbacks list. This handles keys that are NOT LangChain-native — they won't
-  # be fired by LLMChain.run, so we iterate the list and fire matching handlers
-  # ourselves. LangChain-native keys are handled separately via maybe_add_callbacks
-  # which adds each map to the chain for LLMChain to fire during execution.
+  # Fire a callback key across every handler map, in fan-out.
+  #
+  # Two kinds of key reach this. Sagents-specific keys such as
+  # `:on_after_middleware` are not LangChain-native, so `LLMChain.run/2` will
+  # never fire them and this is the only path they have. LangChain-native keys
+  # are normally fired by the chain itself, having been added to it by
+  # maybe_add_callbacks/2, and are fired from here only for a message the chain
+  # is known not to announce — see notify_partial_message/3.
   defp fire_callback([], _key, _args), do: :ok
 
   defp fire_callback(callbacks, key, args) when is_list(callbacks) do
@@ -787,10 +790,15 @@ defmodule Sagents.Agent do
   defp execute_model(%Agent{} = agent, %State{} = state, callbacks, opts) do
     with {:ok, langchain_messages} <- validate_messages(state.messages),
          {:ok, chain} <- build_chain_impl(agent, langchain_messages, state, callbacks) do
-      chain
-      |> execute_chain(agent.middleware, agent, opts)
+      # The chain result is kept alongside the converted state because
+      # reject_streaming_error/3 announces the partial message a dead stream
+      # leaves behind, and `:on_message_processed` handlers are passed the chain
+      # that produced it.
+      chain_result = execute_chain(chain, agent.middleware, agent, opts)
+
+      chain_result
       |> handle_chain_result(state)
-      |> reject_streaming_error()
+      |> reject_streaming_error(chain_result, callbacks)
     end
   end
 
@@ -834,33 +842,64 @@ defmodule Sagents.Agent do
   # is handed back. Without this the caller receives a silently truncated turn
   # as a success.
   #
+  # The partial message is announced on the way past, so that converting the run
+  # to an error does not also lose the text the model produced. See
+  # notify_partial_message/3.
+  #
   # Applied to the result of `handle_chain_result/2` rather than inside its
   # clauses. The check is cross-cutting and the clauses dispatch on result
   # shape, so attaching it per clause lets the shapes disagree about whether a
   # dead stream counts. A new successful shape needs a clause here.
-  defp reject_streaming_error({:ok, %State{} = state} = success),
-    do: streaming_error_or(state, success)
+  defp reject_streaming_error({:ok, %State{} = state} = success, chain_result, callbacks),
+    do: streaming_error_or(state, success, chain_result, callbacks)
 
-  defp reject_streaming_error({:ok, %State{} = state, _extra} = success),
-    do: streaming_error_or(state, success)
+  defp reject_streaming_error({:ok, %State{} = state, _extra} = success, chain_result, callbacks),
+    do: streaming_error_or(state, success, chain_result, callbacks)
 
   # An interrupt or a pause is the chain stopping deliberately, with the stream
   # intact. Only errors reach the remaining clause, and they are already errors.
-  defp reject_streaming_error(other), do: other
+  defp reject_streaming_error(other, _chain_result, _callbacks), do: other
 
-  defp streaming_error_or(%State{} = state, success) do
-    case check_for_streaming_error(state) do
-      nil -> success
-      error -> {:error, error}
+  defp streaming_error_or(%State{} = state, success, chain_result, callbacks) do
+    with %Message{} = message <- List.last(state.messages),
+         %LangChainError{} = error <- DisplayHelpers.streaming_error(message) do
+      notify_partial_message(callbacks, chain_result, message)
+      {:error, error}
+    else
+      _other -> success
     end
   end
 
-  defp check_for_streaming_error(%State{messages: messages}) do
-    case List.last(messages) do
-      %Message{} = message -> DisplayHelpers.streaming_error(message)
-      _other -> nil
+  # Announce the partial message a dead stream left behind.
+  #
+  # `LLMChain.cancel_delta/3` appends it with `add_message/2`, which fires no
+  # callbacks, so without this the text the model did produce reaches neither the
+  # host's transcript nor the rolling state an AgentServer keeps — it exists only
+  # inside the chain, which the `{:error, _}` return is about to discard.
+  # Firing `:on_message_processed` puts it on the same path every other message
+  # takes. `Sagents.Message.DisplayHelpers.extract_display_items/1` marks it
+  # `stop_reason: "stream_error"`, so a host renders it as a message that stopped
+  # early rather than as ordinary output.
+  #
+  # A partial carrying nothing displayable is not announced. There is no text for
+  # a reader to gain, and an empty assistant message in the transcript and in
+  # persisted agent state is worse than none.
+  #
+  # This cannot double-fire: `add_message/2` is the only way the message was
+  # produced, and it announces nothing.
+  defp notify_partial_message(callbacks, chain_result, %Message{} = message) do
+    if DisplayHelpers.extract_display_items(message) != [] do
+      fire_callback(callbacks, :on_message_processed, [executed_chain(chain_result), message])
     end
+
+    :ok
   end
+
+  # Only the two successful shapes reach notify_partial_message/3, so a chain is
+  # always present by the time this is asked.
+  defp executed_chain({:ok, %LLMChain{} = chain}), do: chain
+  defp executed_chain({:ok, %LLMChain{} = chain, _extra}), do: chain
+  defp executed_chain(_other), do: nil
 
   defp validate_messages(messages) do
     # Messages are already LangChain.Message structs, just validate them

--- a/lib/sagents/agent_server.ex
+++ b/lib/sagents/agent_server.ex
@@ -139,6 +139,15 @@ defmodule Sagents.AgentServer do
     persisted via `display_message_persistence` behaviour.
     The `{:llm_message, ...}` event is also broadcast alongside this event
 
+    Rows the framework originates rather than the model — the cancellation
+    notice, the error notice, and middleware-emitted rows such as a todo
+    snapshot — are the exception: they broadcast only
+    `{:display_message_saved, _}`, because there is no `%Message{}` to carry.
+    Render these from this event. `{:llm_message, _}` is the live channel for
+    model output alone, and it carries the full struct, `status` included, for a
+    host wanting to react to a message that stopped early before the display row
+    lands.
+
   ### Queued Message Events
   - `{:agent, {:message_queued, %Message{}}}` - A message arrived while a run was
     in flight and is being held for delivery at the next run boundary. See
@@ -249,6 +258,7 @@ defmodule Sagents.AgentServer do
   alias Sagents.Agent
   alias Sagents.State
   alias Sagents.AgentSupervisor
+  alias Sagents.Message.DisplayHelpers
   alias Sagents.Middleware
   alias Sagents.MiddlewareEntry
   alias Sagents.Persistence.StateSerializer
@@ -3044,7 +3054,7 @@ defmodule Sagents.AgentServer do
     updated_state = maybe_persist_state(updated_state, :on_error)
 
     # Persist an assistant message describing the error so it survives page reloads
-    persist_error_as_display_message(updated_state, reason)
+    maybe_persist_error_as_display_message(updated_state, reason)
 
     broadcast_event(updated_state, {:status_changed, :error, reason})
     update_presence_status(updated_state, :error)
@@ -3884,22 +3894,114 @@ defmodule Sagents.AgentServer do
     end
   end
 
-  # Create and persist an assistant message for the error so it shows up on page reload.
-  defp persist_error_as_display_message(server_state, reason) do
-    error_text = format_error_for_display(reason)
-    error_message = Message.new_assistant!(error_text)
-    maybe_save_and_broadcast_message(server_state, error_message)
+  # A dead stream puts the partial message the model produced into the
+  # transcript, carrying `content["stop_reason"] = "stream_error"`, so the reader
+  # already sees both the text and the fact that it stopped. Adding a fabricated
+  # row underneath would say the same thing again, less precisely and in prose a
+  # host can neither style nor translate.
+  #
+  # Every other error still writes one. An error that produced no partial — a
+  # request rejected before the stream opened, a tool blowing up, a delta that
+  # would not convert — leaves the reader nothing at all otherwise.
+  defp maybe_persist_error_as_display_message(server_state, reason) do
+    if stream_error_partial_shown?(server_state) do
+      :ok
+    else
+      persist_error_as_display_message(server_state, reason)
+    end
   end
 
-  # Create and persist an assistant message on cancellation so it survives page
-  # reload and reaches every subscribed LiveView via :display_message_saved.
-  # Persisting here (single authoritative writer) avoids duplicate inserts when
-  # multiple LiveViews are subscribed to the same agent.
-  defp persist_cancel_as_display_message(server_state) do
-    cancel_text = "_Agent execution cancelled by user. Partial response discarded._"
-    cancel_message = Message.new_assistant!(cancel_text)
-    maybe_save_and_broadcast_message(server_state, cancel_message)
+  # `Sagents.Agent` announces the partial through `:on_message_processed`, whose
+  # handler both persists the display row and casts `{:turn_state_update, ...}`.
+  # The cast and the task's result are sent by the same process, so the rolling
+  # state has already absorbed the partial by the time the error is handled, and
+  # its presence here is what says the transcript got it.
+  #
+  # A partial that produced nothing displayable is never announced, so it is
+  # absent here too and the error row is written, which is what should happen.
+  defp stream_error_partial_shown?(%ServerState{state: %State{messages: messages}}) do
+    case List.last(messages) do
+      %Message{} = message -> DisplayHelpers.stop_reason(message) == :stream_error
+      _other -> false
+    end
   end
+
+  defp stream_error_partial_shown?(_server_state), do: false
+
+  # Persist a row describing the error so it survives page reload.
+  #
+  # `content_type: "error"` is the classification; a host styles and translates
+  # from that rather than from the prose. `content["error_type"]` carries the
+  # `LangChain.LangChainError` type when there is one, which is the useful
+  # discriminator here — "overloaded" and "exceeded_max_runs" want different
+  # words, and neither is a message that stopped early.
+  #
+  # Deliberately not `content["stop_reason"]`. That vocabulary describes a
+  # message the model began and did not finish, and after the dead-stream partial
+  # is persisted no such case reaches this row. Reusing the key would make a
+  # host's stop-reason branch mean two different things.
+  defp persist_error_as_display_message(server_state, reason) do
+    text = format_error_for_display(reason)
+
+    persist_framework_row(server_state, text, %{
+      message_type: "system",
+      content_type: "error",
+      content: put_error_type(%{"text" => text}, reason)
+    })
+  end
+
+  # Persist a row on cancellation so it survives page reload and reaches every
+  # subscribed LiveView. Persisting here (single authoritative writer) avoids
+  # duplicate inserts when multiple LiveViews are subscribed to the same agent.
+  #
+  # `content["stop_reason"] = "cancelled"` is the same key and the same value
+  # `Sagents.Message.DisplayHelpers` writes for a model message the caller
+  # stopped, so a host renders both from one branch. There is no partial to mark
+  # on this path: cancelling kills the task outright.
+  defp persist_cancel_as_display_message(server_state) do
+    text = "Agent execution cancelled."
+
+    persist_framework_row(server_state, text, %{
+      message_type: "system",
+      content_type: "notification",
+      content: %{"text" => text, "stop_reason" => "cancelled"}
+    })
+  end
+
+  # Write a row the framework originated rather than the model.
+  #
+  # `save_synthetic_message/3` is optional, and a host generated before it
+  # existed does not export it. Routing there unconditionally would delete these
+  # rows outright for those hosts, so the prose message remains the fallback and
+  # every host keeps a transcript entry.
+  #
+  # The two paths do not broadcast alike. `maybe_save_and_broadcast_message/2`
+  # emits both `{:display_message_saved, _}` and `{:llm_message, _}`; the
+  # synthetic path emits only the former, because there is no `%Message{}` to
+  # put in the latter and fabricating one is the misattribution this row exists
+  # to stop making. A host rendering these live from `{:llm_message, _}` reads
+  # `{:display_message_saved, _}` instead, which it already handles if it
+  # implements the callback at all.
+  defp persist_framework_row(server_state, fallback_text, attrs) do
+    if synthetic_message_supported?(server_state) do
+      maybe_save_synthetic_and_broadcast(server_state, attrs)
+    else
+      maybe_save_and_broadcast_message(server_state, Message.new_assistant!(fallback_text))
+    end
+  end
+
+  defp synthetic_message_supported?(%ServerState{display_message_persistence: nil}), do: false
+
+  defp synthetic_message_supported?(%ServerState{display_message_persistence: module}) do
+    Code.ensure_loaded?(module) and function_exported?(module, :save_synthetic_message, 3)
+  end
+
+  # Absent rather than nil when the failure carried no type, matching how the
+  # framework writes every other optional content key.
+  defp put_error_type(content, %LangChain.LangChainError{type: type}) when is_binary(type),
+    do: Map.put(content, "error_type", type)
+
+  defp put_error_type(content, _reason), do: content
 
   defp format_error_for_display(%LangChain.LangChainError{type: "delta_conversion_failed"}) do
     "The assistant returned an invalid response. Please try again."

--- a/lib/sagents/message/display_helpers.ex
+++ b/lib/sagents/message/display_helpers.ex
@@ -55,14 +55,16 @@ defmodule Sagents.Message.DisplayHelpers do
 
   ## Durability
 
-  The classification survives a state round trip, because
-  `Sagents.Persistence.StateSerializer` carries `Message.status`. The error
-  *detail* does not: `Message.metadata` is not serialized, so `streaming_error/1`
-  returns `nil` for a message read back from persisted agent state even though
-  `stop_reason/1` still answers `:stream_error`.
+  The classification survives a state round trip. `Message.status` is
+  serialized, and `Sagents.Persistence.StateSerializer` projects the two metadata
+  keys this module reads, so a message restored from persisted agent state
+  classifies the way it did in the turn that produced it — including where
+  metadata is the only discriminator, which is how LangChain releases below
+  v0.10.0 record a dead stream.
 
-  Where metadata is the only discriminator, the classification is not durable
-  either, and a restored message reports `:cancelled`.
+  The projection is narrower than the live value. `streaming_error/1` returns an
+  error carrying the failure's `type` and `message` but not the `:original` term
+  behind it, which can be any term and does not belong in a persisted state.
 
   ## Examples
 
@@ -92,7 +94,7 @@ defmodule Sagents.Message.DisplayHelpers do
 
   Keyed on the metadata alone rather than on the status, so it answers the same
   way for either shape the supported LangChain range records a dead stream in.
-  Only populated during the turn that produced the message; see the durability
+  Survives a state round trip carrying `type` and `message`; see the durability
   note on `stop_reason/1`.
   """
   @spec streaming_error(Message.t()) :: LangChainError.t() | nil
@@ -108,9 +110,8 @@ defmodule Sagents.Message.DisplayHelpers do
   carry a reason with no detail.
 
   Unlike `streaming_error/1` this is plain JSON rather than a struct, so
-  `extract_display_items/1` carries it into the item's `content` and it survives
-  persistence. It is not durable across an agent-state restore, for the reason
-  given under `stop_reason/1`.
+  `extract_display_items/1` carries it into the item's `content` verbatim and
+  agent state stores it as it stands, with no projection.
   """
   @spec stop_details(Message.t()) :: map() | nil
   def stop_details(%Message{metadata: %{stop_details: details}}) when is_map(details), do: details

--- a/lib/sagents/persistence/state_serializer.ex
+++ b/lib/sagents/persistence/state_serializer.ex
@@ -26,6 +26,17 @@ defmodule Sagents.Persistence.StateSerializer do
   - ❌ Agent configuration: middleware, tools, model
   - ❌ Runtime identifiers: agent_id
 
+  ## Message Metadata
+
+  `LangChain.Message.metadata` is a free-form map that can hold any term,
+  including token usage structs and error causes wrapping HTTP responses. Rather
+  than round-tripping it, the serializer projects the two keys the framework
+  reads from restored history — `:streaming_error` and `:stop_details`, both used
+  by `Sagents.Message.DisplayHelpers` — and drops the rest.
+
+  A restored `:streaming_error` carries the failure's `type` and `message` only.
+  Anything else a caller puts in `metadata` lives for the turn that set it.
+
   Agent capabilities (middleware, tools, model) are code-defined by your
   application. When restoring a conversation, create the agent from your
   application code and restore only the conversation state.
@@ -47,6 +58,7 @@ defmodule Sagents.Persistence.StateSerializer do
   """
 
   alias Sagents.{State, Agent, Todo}
+  alias LangChain.LangChainError
   alias LangChain.Message
   alias LangChain.Message.{ContentPart, ToolCall, ToolResult}
 
@@ -213,8 +225,53 @@ defmodule Sagents.Persistence.StateSerializer do
         base
       end
 
-    base
+    maybe_add_metadata(base, message.metadata)
   end
+
+  # `Message.metadata` holds arbitrary terms — token usage structs, provider
+  # bookkeeping, whatever a caller put there — so it is not round-tripped
+  # wholesale. Two keys are projected into a JSON-safe shape, because the
+  # framework answers questions about them from restored history:
+  # `Sagents.Message.DisplayHelpers.streaming_error/1` and `stop_details/1`.
+  #
+  # The projection is narrower than the in-process value. A
+  # `LangChain.LangChainError` carries `:original`, which can be any term at all
+  # — an exception, an HTTP response, a socket error — so only `type` and
+  # `message` cross the boundary and a restored error has no `:original`.
+  #
+  # Additive and unversioned: history written before this carries no "metadata"
+  # key and restores as it always did, and a reader that does not know the key
+  # ignores it.
+  defp maybe_add_metadata(base, metadata) when is_map(metadata) do
+    case serialize_metadata(metadata) do
+      projected when map_size(projected) == 0 -> base
+      projected -> Map.put(base, "metadata", projected)
+    end
+  end
+
+  defp maybe_add_metadata(base, _metadata), do: base
+
+  defp serialize_metadata(metadata) do
+    %{}
+    |> put_serialized_streaming_error(Map.get(metadata, :streaming_error))
+    |> put_serialized_stop_details(Map.get(metadata, :stop_details))
+  end
+
+  defp put_serialized_streaming_error(projected, %LangChainError{} = error) do
+    Map.put(projected, "streaming_error", %{
+      "type" => error.type,
+      "message" => error.message
+    })
+  end
+
+  defp put_serialized_streaming_error(projected, _error), do: projected
+
+  # Already a string-keyed map decoded from the provider's JSON, so it is stored
+  # as it stands.
+  defp put_serialized_stop_details(projected, details) when is_map(details),
+    do: Map.put(projected, "stop_details", details)
+
+  defp put_serialized_stop_details(projected, _details), do: projected
 
   defp deserialize_message(data) when is_map(data) do
     # Convert string keys to atom keys for Message.new
@@ -244,12 +301,43 @@ defmodule Sagents.Persistence.StateSerializer do
         attrs
       end
 
+    attrs = maybe_add_deserialized_metadata(attrs, data["metadata"])
+
     # Use Message.new! to create the message
     case Message.new(attrs) do
       {:ok, message} -> message
       {:error, _changeset} -> raise "Failed to deserialize message: #{inspect(data)}"
     end
   end
+
+  # Restores the projection written by serialize_metadata/1 under the atom keys
+  # the framework matches on. Keys it did not write stay absent rather than nil,
+  # because presence is what callers test.
+  defp maybe_add_deserialized_metadata(attrs, metadata) when is_map(metadata) do
+    projected =
+      %{}
+      |> put_deserialized_streaming_error(metadata["streaming_error"])
+      |> put_deserialized_stop_details(metadata["stop_details"])
+
+    if map_size(projected) == 0, do: attrs, else: Map.put(attrs, :metadata, projected)
+  end
+
+  defp maybe_add_deserialized_metadata(attrs, _metadata), do: attrs
+
+  defp put_deserialized_streaming_error(projected, error) when is_map(error) do
+    Map.put(
+      projected,
+      :streaming_error,
+      LangChainError.exception(type: error["type"], message: error["message"])
+    )
+  end
+
+  defp put_deserialized_streaming_error(projected, _error), do: projected
+
+  defp put_deserialized_stop_details(projected, details) when is_map(details),
+    do: Map.put(projected, :stop_details, details)
+
+  defp put_deserialized_stop_details(projected, _details), do: projected
 
   defp serialize_content(content) when is_binary(content), do: content
 

--- a/priv/templates/sagents.gen.persistence/display_message.ex.eex
+++ b/priv/templates/sagents.gen.persistence/display_message.ex.eex
@@ -14,8 +14,10 @@ defmodule <%= @context_module %>.DisplayMessage do
   - `"image"` - Image content (URL or base64 data)
   - `"file_reference"` - Reference to a file
   - `"structured_data"` - Structured/formatted data (tables, JSON, etc.)
-  - `"notification"` - System/UI notification
-  - `"error"` - Error message
+  - `"notification"` - System/UI notification. Sagents writes one when a run is
+    cancelled, carrying `content["stop_reason"] = "cancelled"`
+  - `"error"` - Error message. Sagents writes one when a turn fails, carrying
+    `content["error_type"]` when the failure named one
   - `"tool_call"` - Tool invocation request from assistant
   - `"tool_result"` - Tool execution result
   - `"todo_snapshot"` - Point-in-time snapshot of an agent's todo list,
@@ -53,6 +55,17 @@ defmodule <%= @context_module %>.DisplayMessage do
     as optional: most stops carry a reason and no detail.
   - `"display_text"` - on `"tool_call"` content, a human-readable label for the
     tool, taken from the `LangChain.Function` or humanized from its name.
+  - `"error_type"` - on `"error"` content, the `LangChain.LangChainError` type
+    behind the failure, such as `"overloaded"` or `"exceeded_max_runs"`. Absent
+    when the failure named no type. Note that `"error"` rows carry no
+    `"stop_reason"`: that key describes a message the model began and did not
+    finish, which is a different thing from a turn that failed.
+
+  Rows the framework originates rather than the model — `"notification"` and
+  `"error"` — reach `save_synthetic_message/3` rather than `save_message/3`, and
+  are broadcast as `{:display_message_saved, _}` only. A host that does not
+  implement `save_synthetic_message/3` receives them as ordinary assistant text
+  instead, and cannot style or translate them.
 
   ## Metadata Keys
 

--- a/test/sagents/agent_server_framework_rows_test.exs
+++ b/test/sagents/agent_server_framework_rows_test.exs
@@ -1,0 +1,177 @@
+defmodule Sagents.AgentServerFrameworkRowsTest do
+  @moduledoc """
+  The transcript rows the framework writes itself, rather than relaying from the
+  model: the cancellation notice and the error notice.
+
+  A host implementing `save_synthetic_message/3` receives them classified, so it
+  can style and translate them. A host generated before that callback existed
+  receives the prose message instead, which is the only reason the fallback
+  exists.
+  """
+
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.Agent
+  alias Sagents.AgentServer
+  alias Sagents.AgentSupervisor
+  alias Sagents.TestDisplayMessagePersistenceForwarding, as: Synthetic
+  alias Sagents.TestDisplayMessagePersistenceNoSynthetic, as: NoSynthetic
+  alias Sagents.TestingHelpers
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.LangChainError
+  alias LangChain.Message
+  alias LangChain.Message.ContentPart
+
+  # Blocks the run so it can be cancelled, and reports the moment it is in flight
+  # so the test never has to sleep to find out.
+  defmodule BlockingMode do
+    @behaviour LangChain.Chains.LLMChain.Mode
+
+    def register_test_process(pid), do: :persistent_term.put({__MODULE__, :test_pid}, pid)
+
+    @impl true
+    def run(_chain, _opts) do
+      send(:persistent_term.get({__MODULE__, :test_pid}), :mode_running)
+
+      receive do
+        :never -> {:error, :unreachable}
+      end
+    end
+  end
+
+  setup :set_mimic_global
+
+  setup do
+    Synthetic.register_test_process(self())
+    Synthetic.clear_synthetic_response()
+    NoSynthetic.register_test_process(self())
+    BlockingMode.register_test_process(self())
+
+    on_exit(fn -> Synthetic.clear_synthetic_response() end)
+    :ok
+  end
+
+  defp start_agent(persistence, mode) do
+    agent_id = TestingHelpers.generate_test_agent_id()
+    model = ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"})
+
+    agent =
+      Agent.new!(%{
+        agent_id: agent_id,
+        model: model,
+        base_system_prompt: "Test agent",
+        replace_default_middleware: true,
+        middleware: [],
+        mode: mode
+      })
+
+    {:ok, _sup} =
+      AgentSupervisor.start_link_sync(
+        name: AgentSupervisor.get_name(agent_id),
+        agent: agent,
+        pubsub: {Phoenix.PubSub, :test_pubsub},
+        conversation_id: "conv-#{agent_id}",
+        display_message_persistence: persistence
+      )
+
+    # The supervisor is linked to the test process, so it goes down with it.
+    AgentServer.subscribe(agent_id)
+    agent_id
+  end
+
+  defp cancel_a_running_agent(persistence) do
+    agent_id = start_agent(persistence, BlockingMode)
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+    assert_receive :mode_running, 500
+
+    :ok = AgentServer.cancel(agent_id)
+    agent_id
+  end
+
+  describe "cancellation" do
+    test "is classified when the host implements save_synthetic_message/3" do
+      cancel_a_running_agent(Synthetic)
+
+      assert_receive {:saved_synthetic_message, _scope, attrs, _context}, 500
+
+      assert attrs.content_type == "notification"
+      assert attrs.content["stop_reason"] == "cancelled"
+
+      # The row is not attributed to the model, which never said it.
+      assert attrs.message_type == "system"
+
+      # The prose stays as a fallback for a host that renders text before it
+      # learns the content type.
+      assert attrs.content["text"] == "Agent execution cancelled."
+    end
+
+    test "falls back to a message row when the host does not implement it" do
+      # A host generated before save_synthetic_message/3 existed would otherwise
+      # lose the row entirely.
+      cancel_a_running_agent(NoSynthetic)
+
+      assert_receive {:saved_message, %Message{role: :user}, _items}, 500
+      assert_receive {:saved_message, %Message{role: :assistant} = row, _items}, 500
+      assert ContentPart.parts_to_string(row.content) == "Agent execution cancelled."
+    end
+  end
+
+  describe "a failed turn" do
+    setup do
+      stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+        {:error, LangChainError.exception(type: "invalid_request_error", message: "bad request")}
+      end)
+
+      :ok
+    end
+
+    test "is classified when the host implements save_synthetic_message/3" do
+      agent_id = start_agent(Synthetic, nil)
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+      assert_receive {:saved_synthetic_message, _scope, attrs, _context}, 500
+
+      assert attrs.content_type == "error"
+      assert attrs.message_type == "system"
+      assert attrs.content["error_type"] == "invalid_request_error"
+      assert attrs.content["text"] =~ "Sorry, I encountered an error"
+
+      # An error row is not a message that stopped early, so it does not borrow
+      # that vocabulary.
+      refute Map.has_key?(attrs.content, "stop_reason")
+    end
+
+    test "falls back to a message row when the host does not implement it" do
+      agent_id = start_agent(NoSynthetic, nil)
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+      assert_receive {:saved_message, %Message{role: :user}, _items}, 500
+      assert_receive {:saved_message, %Message{role: :assistant} = row, _items}, 500
+      assert ContentPart.parts_to_string(row.content) =~ "Sorry, I encountered an error"
+    end
+
+    test "carries no error_type when the failure named none" do
+      agent_id = start_agent(Synthetic, __MODULE__.UntypedFailureMode)
+
+      :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+      assert_receive {:saved_synthetic_message, _scope, attrs, _context}, 500
+
+      assert attrs.content_type == "error"
+      refute Map.has_key?(attrs.content, "error_type")
+    end
+  end
+
+  defmodule UntypedFailureMode do
+    @behaviour LangChain.Chains.LLMChain.Mode
+
+    @impl true
+    def run(chain, _opts) do
+      {:error, chain, LangChain.LangChainError.exception(message: "something went wrong")}
+    end
+  end
+end

--- a/test/sagents/agent_server_stream_error_test.exs
+++ b/test/sagents/agent_server_stream_error_test.exs
@@ -1,0 +1,138 @@
+defmodule Sagents.AgentServerStreamErrorTest do
+  @moduledoc """
+  What a reader sees when the stream dies mid-response.
+
+  The partial text the model produced reaches the transcript, marked as having
+  stopped early, and takes the place of a fabricated error row. Errors that
+  produced no partial still get the row.
+  """
+
+  use Sagents.BaseCase, async: false
+  use Mimic
+
+  alias Sagents.Agent
+  alias Sagents.AgentServer
+  alias Sagents.AgentSupervisor
+  alias Sagents.TestDisplayMessagePersistenceForwarding
+  alias Sagents.TestingHelpers
+  alias LangChain.ChatModels.ChatAnthropic
+  alias LangChain.LangChainError
+  alias LangChain.Message
+
+  # Reproduces LLMChain.cancel_delta/3: the partial is appended with
+  # add_message/2, which fires no callbacks, and the run still reports success.
+  defmodule DeadStreamMode do
+    @behaviour LangChain.Chains.LLMChain.Mode
+
+    @impl true
+    def run(chain, _opts) do
+      {:ok, LangChain.Chains.LLMChain.add_message(chain, partial())}
+    end
+
+    def partial do
+      %LangChain.Message{
+        role: :assistant,
+        content: "Partial answ",
+        status: :stream_error,
+        metadata: %{
+          streaming_error: LangChain.LangChainError.exception(type: "overloaded", message: "busy")
+        }
+      }
+    end
+  end
+
+  setup :set_mimic_global
+
+  setup do
+    TestDisplayMessagePersistenceForwarding.register_test_process(self())
+    :ok
+  end
+
+  defp start_agent(mode) do
+    agent_id = TestingHelpers.generate_test_agent_id()
+    model = ChatAnthropic.new!(%{model: "claude-sonnet-4-6", api_key: "test_key"})
+
+    agent =
+      Agent.new!(%{
+        agent_id: agent_id,
+        model: model,
+        base_system_prompt: "Test agent",
+        replace_default_middleware: true,
+        middleware: [],
+        mode: mode
+      })
+
+    {:ok, _sup} =
+      AgentSupervisor.start_link_sync(
+        name: AgentSupervisor.get_name(agent_id),
+        agent: agent,
+        pubsub: {Phoenix.PubSub, :test_pubsub},
+        conversation_id: "conv-#{agent_id}",
+        display_message_persistence: TestDisplayMessagePersistenceForwarding
+      )
+
+    # The supervisor is linked to the test process, so it goes down with it.
+    AgentServer.subscribe(agent_id)
+    agent_id
+  end
+
+  test "the partial reaches the transcript marked as having stopped early" do
+    agent_id = start_agent(DeadStreamMode)
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+    assert_receive {:saved_message, %Message{role: :user}, _items}, 500
+
+    assert_receive {:saved_message, %Message{role: :assistant, content: "Partial answ"}, items},
+                   500
+
+    # The mark rides in the last item's content, so a host reads it from the same
+    # JSONB column it already stores.
+    assert [%{type: :text, content: content}] = items
+    assert content["text"] == "Partial answ"
+    assert content["stop_reason"] == "stream_error"
+  end
+
+  test "no fabricated error row is written alongside the partial" do
+    agent_id = start_agent(DeadStreamMode)
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+    assert_receive {:saved_message, %Message{role: :assistant, content: "Partial answ"}, _}, 500
+
+    # The error row is persisted before the status broadcast, so by the time this
+    # arrives any second row would already be in the mailbox.
+    assert_receive {:agent, {:status_changed, :error, %LangChainError{type: "overloaded"}}}, 500
+    refute_received {:saved_message, %Message{role: :assistant}, _items}
+    refute_received {:saved_synthetic_message, _scope, _attrs, _context}
+  end
+
+  test "the rolling state carries the partial the chain produced" do
+    agent_id = start_agent(DeadStreamMode)
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+    assert_receive {:agent, {:status_changed, :error, _reason}}, 500
+
+    state = AgentServer.get_state(agent_id)
+
+    assert %Message{content: "Partial answ", status: :stream_error} = List.last(state.messages)
+  end
+
+  test "an error that produced no partial still writes the error row" do
+    # A request rejected before the stream opened leaves the reader nothing
+    # otherwise.
+    stub(ChatAnthropic, :call, fn _model, _messages, _tools ->
+      {:error, LangChainError.exception(type: "invalid_request_error", message: "bad request")}
+    end)
+
+    agent_id = start_agent(nil)
+
+    :ok = AgentServer.add_message(agent_id, Message.new_user!("Hello"))
+
+    assert_receive {:saved_message, %Message{role: :user}, _}, 500
+
+    assert_receive {:saved_synthetic_message, _scope, attrs, _context}, 500
+    assert attrs.content_type == "error"
+    assert attrs.content["text"] =~ "Sorry, I encountered an error"
+  end
+end

--- a/test/sagents/agent_test.exs
+++ b/test/sagents/agent_test.exs
@@ -10,6 +10,8 @@ defmodule Sagents.AgentTest do
   alias LangChain.Message.ToolCall
   alias LangChain.Message.ToolResult
   alias Sagents.MiddlewareEntry
+  alias Sagents.Message.DisplayHelpers
+  alias LangChain.Chains.LLMChain
   alias LangChain.LangChainError
 
   # Test middleware for composition testing
@@ -716,6 +718,98 @@ defmodule Sagents.AgentTest do
 
       assert {:ok, %State{} = result_state} = Agent.execute(agent, initial_state)
       assert %Message{status: :length} = List.last(result_state.messages)
+    end
+
+    # The partial is announced through :on_message_processed so it reaches the
+    # host's transcript and an AgentServer's rolling state. Converting the run to
+    # {:error, _} discards the chain, so this is the only chance to surface it.
+    #
+    # These drive a mode that appends via LLMChain.add_message/2, which is what
+    # cancel_delta/3 does and which fires no callbacks. A model stub cannot show
+    # the behaviour: messages returned from the model go through process_message/2,
+    # which announces them anyway.
+
+    test "announces the partial message so it can reach the transcript" do
+      test_pid = self()
+
+      {:ok, agent} =
+        Agent.new(
+          %{model: mock_model(), mode: __MODULE__.DeadStreamAddMessageMode},
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      callbacks = [
+        %{
+          on_message_processed: fn chain, message ->
+            send(test_pid, {:processed, chain, message})
+          end
+        }
+      ]
+
+      assert {:error, %LangChainError{type: "overloaded"}} =
+               Agent.execute(agent, initial_state, callbacks: callbacks)
+
+      assert_received {:processed, %LLMChain{}, %Message{content: "Partial answ"} = announced}
+      assert DisplayHelpers.stop_reason(announced) == :stream_error
+
+      # Announced once. add_message/2 announces nothing, so nothing else can.
+      refute_received {:processed, _chain, _message}
+    end
+
+    test "announces the partial when the run carried a result alongside the chain" do
+      test_pid = self()
+
+      {:ok, agent} =
+        Agent.new(
+          %{model: mock_model(), mode: __MODULE__.DeadStreamThreeTupleMode},
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      callbacks = [
+        %{
+          on_message_processed: fn chain, message ->
+            send(test_pid, {:processed, chain, message})
+          end
+        }
+      ]
+
+      assert {:error, %LangChainError{type: "overloaded"}} =
+               Agent.execute(agent, initial_state, callbacks: callbacks)
+
+      assert_received {:processed, %LLMChain{}, %Message{content: "Partial answ"}}
+    end
+
+    test "a partial carrying nothing displayable is not announced" do
+      # A stream that died before producing content yields a message with no
+      # display items. Announcing it would put an empty assistant message in the
+      # transcript and in persisted agent state, and would suppress the error row
+      # that is then the only thing left to show.
+      test_pid = self()
+
+      {:ok, agent} =
+        Agent.new(
+          %{model: mock_model(), mode: __MODULE__.DeadStreamEmptyPartialMode},
+          replace_default_middleware: true
+        )
+
+      initial_state = State.new!(%{messages: [Message.new_user!("Hello")]})
+
+      callbacks = [
+        %{
+          on_message_processed: fn chain, message ->
+            send(test_pid, {:processed, chain, message})
+          end
+        }
+      ]
+
+      assert {:error, %LangChainError{type: "overloaded"}} =
+               Agent.execute(agent, initial_state, callbacks: callbacks)
+
+      refute_received {:processed, _chain, _message}
     end
   end
 
@@ -1956,6 +2050,40 @@ defmodule Sagents.AgentTest do
   # Returns the {:ok, chain, extra} shape that until_tool and friends produce,
   # with a chain whose last message is a stream that died. Driving this through
   # a mode is the only way to reach that arm without a full tool round trip.
+  # Reproduces LLMChain.cancel_delta/3: the partial is appended with
+  # add_message/2, which announces nothing, and the run still reports success.
+  defmodule DeadStreamAddMessageMode do
+    @behaviour LangChain.Chains.LLMChain.Mode
+
+    @impl true
+    def run(chain, _opts) do
+      {:ok, LangChain.Chains.LLMChain.add_message(chain, DeadStreamAddMessageMode.partial())}
+    end
+
+    def partial(content \\ "Partial answ") do
+      %LangChain.Message{
+        role: :assistant,
+        content: content,
+        status: :stream_error,
+        metadata: %{
+          streaming_error: LangChain.LangChainError.exception(type: "overloaded", message: "busy")
+        }
+      }
+    end
+  end
+
+  # The stream died before any content arrived, so the partial yields no display
+  # items.
+  defmodule DeadStreamEmptyPartialMode do
+    @behaviour LangChain.Chains.LLMChain.Mode
+
+    @impl true
+    def run(chain, _opts) do
+      partial = DeadStreamAddMessageMode.partial("")
+      {:ok, LangChain.Chains.LLMChain.add_message(chain, partial)}
+    end
+  end
+
   defmodule DeadStreamThreeTupleMode do
     @behaviour LangChain.Chains.LLMChain.Mode
 

--- a/test/sagents/message/display_helpers_test.exs
+++ b/test/sagents/message/display_helpers_test.exs
@@ -222,18 +222,18 @@ defmodule Sagents.Message.DisplayHelpersTest do
       assert :content_filtered == DisplayHelpers.stop_reason(message)
     end
 
-    test "a metadata-discriminated stream error is not durable across a state round trip" do
-      # StateSerializer carries role, content, status, tool_calls and tool_results.
-      # metadata does not survive the round trip, so where metadata is the only
-      # discriminator a restored message reports :cancelled. Where the status
-      # itself says :stream_error, the classification survives.
-      restored = Message.new_assistant!(%{content: "Partial", status: :cancelled, metadata: %{}})
+    test "a :cancelled message carrying no error is a caller-initiated stop" do
+      # `:cancelled` and a dead stream are told apart by the presence of the
+      # error in metadata, for the LangChain releases that record both as
+      # `:cancelled`. Absence has to mean the caller stopped the run, or every
+      # cancellation would report as a connection failure.
+      #
+      # Durability of that discrimination across an agent-state round trip is
+      # covered in `Sagents.Persistence.StateSerializerTest`, which is where the
+      # projection that carries it lives.
+      message = Message.new_assistant!(%{content: "Partial", status: :cancelled, metadata: %{}})
 
-      assert :cancelled == DisplayHelpers.stop_reason(restored)
-
-      restored_with_status = %Message{role: :assistant, content: "Partial", status: :stream_error}
-
-      assert :stream_error == DisplayHelpers.stop_reason(restored_with_status)
+      assert :cancelled == DisplayHelpers.stop_reason(message)
     end
   end
 

--- a/test/sagents/persistence/state_serializer_test.exs
+++ b/test/sagents/persistence/state_serializer_test.exs
@@ -3,6 +3,8 @@ defmodule Sagents.Persistence.StateSerializerTest do
 
   alias Sagents.Persistence.StateSerializer
   alias Sagents.{Agent, State, Todo}
+  alias Sagents.Message.DisplayHelpers
+  alias LangChain.LangChainError
   alias LangChain.Message
   alias LangChain.Message.{ToolCall, ToolResult}
   alias LangChain.ChatModels.ChatOpenAI
@@ -518,6 +520,135 @@ defmodule Sagents.Persistence.StateSerializerTest do
       assert restored_call.name == "calculator"
       # metadata can be nil or empty map
       assert restored_call.metadata == nil or restored_call.metadata == %{}
+    end
+  end
+
+  describe "message metadata projection" do
+    # `Message.metadata` holds arbitrary terms, so only the two keys the
+    # framework reads from restored history cross the boundary. Everything here
+    # is about a message read back from persisted agent state answering the same
+    # way it did in the turn that produced it.
+
+    defp round_trip_message(%Message{} = message) do
+      {:ok, model} = ChatOpenAI.new(%{model: "gpt-4", api_key: "test-key"})
+      {:ok, agent} = Agent.new(%{agent_id: "agent-meta", model: model})
+
+      serialized =
+        StateSerializer.serialize_server_state(agent, State.new!(%{messages: [message]}))
+
+      {:ok, restored} = StateSerializer.deserialize_server_state("agent-meta", serialized)
+
+      {List.last(restored.messages), serialized}
+    end
+
+    test "a dead stream still classifies as :stream_error after a restore" do
+      error = LangChainError.exception(type: "overloaded", message: "busy")
+
+      {restored, _serialized} =
+        round_trip_message(%Message{
+          role: :assistant,
+          content: "Partial answ",
+          status: :stream_error,
+          metadata: %{streaming_error: error}
+        })
+
+      assert DisplayHelpers.stop_reason(restored) == :stream_error
+
+      assert %LangChainError{type: "overloaded", message: "busy"} =
+               restored.metadata.streaming_error
+    end
+
+    test "the :cancelled shape classifies as :stream_error after a restore" do
+      # LangChain releases below 0.10.0 record a dead stream as :cancelled
+      # carrying the error, so metadata is the only discriminator. Without the
+      # projection a restored message of this shape reports a caller-initiated
+      # stop, which is a different thing.
+      error = LangChainError.exception(type: "overloaded", message: "busy")
+
+      {restored, _serialized} =
+        round_trip_message(%Message{
+          role: :assistant,
+          content: "Partial answ",
+          status: :cancelled,
+          metadata: %{streaming_error: error}
+        })
+
+      assert DisplayHelpers.stop_reason(restored) == :stream_error
+    end
+
+    test "the error's :original does not cross the boundary" do
+      error =
+        LangChainError.exception(
+          type: "overloaded",
+          message: "busy",
+          original: %{secret: self()}
+        )
+
+      {restored, serialized} =
+        round_trip_message(%Message{
+          role: :assistant,
+          content: "Partial answ",
+          status: :stream_error,
+          metadata: %{streaming_error: error}
+        })
+
+      assert restored.metadata.streaming_error.original == nil
+
+      [message_data] = serialized["state"]["messages"]
+
+      assert message_data["metadata"]["streaming_error"] == %{
+               "type" => "overloaded",
+               "message" => "busy"
+             }
+    end
+
+    test "stop_details survives verbatim" do
+      details = %{"type" => "refusal", "category" => "cyber", "explanation" => "no"}
+
+      {restored, _serialized} =
+        round_trip_message(%Message{
+          role: :assistant,
+          content: "",
+          status: :content_filtered,
+          metadata: %{stop_details: details}
+        })
+
+      assert DisplayHelpers.stop_details(restored) == details
+      assert DisplayHelpers.stop_reason(restored) == :content_filtered
+    end
+
+    test "metadata outside the projection is dropped and writes no key" do
+      # Token usage and anything else a caller stashed lives for the turn that
+      # set it. A message whose metadata projects to nothing serializes exactly
+      # as it did before the projection existed.
+      {restored, serialized} =
+        round_trip_message(%Message{
+          role: :assistant,
+          content: "All done",
+          metadata: %{usage: %{"input" => 10}, whatever: make_ref()}
+        })
+
+      assert restored.metadata == nil
+
+      [message_data] = serialized["state"]["messages"]
+      refute Map.has_key?(message_data, "metadata")
+    end
+
+    test "history written without the key restores unchanged" do
+      {:ok, model} = ChatOpenAI.new(%{model: "gpt-4", api_key: "test-key"})
+      {:ok, agent} = Agent.new(%{agent_id: "agent-meta", model: model})
+
+      serialized =
+        StateSerializer.serialize_server_state(
+          agent,
+          State.new!(%{messages: [Message.new_assistant!("Hi")]})
+        )
+
+      # Stand in for a payload written before the projection existed.
+      refute Map.has_key?(List.first(serialized["state"]["messages"]), "metadata")
+
+      {:ok, restored} = StateSerializer.deserialize_server_state("agent-meta", serialized)
+      assert %Message{content: [_part], metadata: nil} = List.last(restored.messages)
     end
   end
 

--- a/test/support/test_display_message_persistence.ex
+++ b/test/support/test_display_message_persistence.ex
@@ -37,6 +37,37 @@ defmodule Sagents.TestDisplayMessagePersistenceRaising do
   end
 end
 
+defmodule Sagents.TestDisplayMessagePersistenceNoSynthetic do
+  @moduledoc """
+  Forwards messages to a registered process and does **not** implement the
+  optional `save_synthetic_message/3`.
+
+  Stands in for a host generated before that callback existed, which is the case
+  the framework's cancel and error rows have to keep working for.
+
+  Register a test process with `register_test_process/1` before use.
+  """
+
+  @behaviour Sagents.DisplayMessagePersistence
+
+  def register_test_process(pid) do
+    :persistent_term.put({__MODULE__, :test_pid}, pid)
+  end
+
+  @impl true
+  def save_message(_scope, %LangChain.Message{} = message, _context) do
+    display_items = Sagents.Message.DisplayHelpers.extract_display_items(message)
+    pid = :persistent_term.get({__MODULE__, :test_pid})
+    send(pid, {:saved_message, message, display_items})
+    {:ok, []}
+  end
+
+  @impl true
+  def update_tool_status(_scope, _status, _tool_info, _context) do
+    {:error, :not_found}
+  end
+end
+
 defmodule Sagents.TestDisplayMessagePersistenceForwarding do
   @moduledoc """
   Test implementation that forwards messages and display items to a registered process.


### PR DESCRIPTION
## Problem

Three conditions end a turn without the model finishing — the output cap
(`:length`), a content filter, and a stream that dies mid-flight — and a reader
experiences all three identically: "it stopped early." The framework surfaced
them through three unrelated mechanisms, and two of them lost information.

**A dead stream discarded the text the model had already produced.**
`LLMChain.cancel_delta/3` keeps the partial message and appends it with
`add_message/2`, which deliberately fires no callbacks. Nothing downstream ever
saw it: it never reached the host's transcript, and `Agent.handle_chain_result/2`
returned `{:error, reason}` while discarding the state that held it, so
`AgentServer`'s rolling state never got it either. The reader saw
"Sorry, I encountered an error" in place of text that actually existed.

**Cancellations and errors were written as fabricated assistant prose.** Both
paths built a `Message.new_assistant!/1` carrying hardcoded English and persisted
it as an ordinary `content_type: "text"`, `message_type: "assistant"` row. A host
could not style it, could not translate it, and anything consuming the transcript
as a record — search indexing, export, `to_text/1`, conversation summarisation —
treated framework chrome as model output. One of the strings ("Partial response
discarded") overstated what happens.

**The classification did not fully survive a restore.** `Message.metadata` was
not serialized, so `streaming_error/1` and `stop_details/1` returned `nil` for
restored history. Worse, LangChain releases below v0.10.0 record a dead stream as
`:cancelled` plus `metadata[:streaming_error]`, where metadata is the *only*
discriminator — so a restored message of that shape reported `:cancelled`, a
caller-initiated stop, which is a different event with different wording. sagents
keeps a `>= 0.8.11` floor, so that shape is live code, not legacy.

## Solution

The framework classifies; the host renders.

**Announce the partial instead of dropping it.** `execute_model/4` now keeps the
chain result alongside the converted state so `reject_streaming_error/3` can fire
`:on_message_processed` for the partial before turning the run into
`{:error, _}`. That one call puts it on the path every other message takes: the
host persists a display row (already marked `content["stop_reason"] =
"stream_error"` by `extract_display_items/1`), subscribers receive
`{:llm_message, _}` and `{:display_message_saved, _}`, and the
`{:turn_state_update, ...}` cast brings `AgentServer`'s rolling state back in
line with the chain. No LangChain change, and `Agent.execute/3`'s public contract
is untouched.

A partial carrying nothing displayable is deliberately not announced — it would
put an empty assistant message into both the transcript and persisted agent
state, and would suppress the error row that is then the only thing left to say.

**Drop the now-redundant error row for that path.** `AgentServer` writes the
fabricated row only when the partial did *not* reach the transcript. It knows
which by reading its own rolling state: the `:on_message_processed` handler both
persists the row and casts the state update, and the cast and the task's result
are sent by the same process, so Erlang's per-pair message ordering guarantees
the cast lands first. No flag threaded through the return value.

**Classify the two rows the framework writes itself.** `persist_framework_row/3`
routes them through the existing `save_synthetic_message/3` channel:

| | `content_type` | machine-readable key | `message_type` |
|---|---|---|---|
| Cancel | `notification` | `content["stop_reason"] = "cancelled"` | `system` |
| Error | `error` | `content["error_type"]` | `system` |

The cancel row reuses the exact key and value `DisplayHelpers` writes for a model
message the caller stopped, so a host renders both from one branch. The error row
deliberately does *not* borrow that vocabulary: `stop_reason` describes a message
the model began and did not finish, and once the dead-stream partial is persisted
no such case reaches this row — what is left are turns that failed. Overloading
the key would make a host's stop-reason branch mean two unrelated things.

`save_synthetic_message/3` is optional, so this is conditional, not a swap.
A host generated before that callback existed keeps the prose message; routing
unconditionally would have deleted these rows outright for them.

**Make the classification durable.** `StateSerializer` projects two
`Message.metadata` keys through the round trip. `:streaming_error` becomes
`%{"type", "message"}` — `LangChainError.original` holds whatever caused the
failure (an exception, an HTTP response, a raw socket term), none of it JSON-safe
and none of it what a restored transcript needs. `:stop_details` crosses verbatim,
being provider JSON already in the shape the store wants. Everything else in
`metadata` is dropped and lives only for the turn that set it.

## Changes

- `lib/sagents/agent.ex` — `reject_streaming_error/3` announces the dead-stream
  partial via `notify_partial_message/3` before converting the run to an error;
  `execute_model/4` threads the chain result down so handlers get the chain
- `lib/sagents/agent_server.ex` — `persist_framework_row/3` with the
  `save_synthetic_message/3` fallback; `stream_error_partial_shown?/1` suppresses
  the redundant error row; `put_error_type/2`
- `lib/sagents/persistence/state_serializer.ex` — narrow `metadata` projection on
  both serialize and deserialize; moduledoc section stating what crosses and what
  does not
- `lib/sagents/message/display_helpers.ex` (docs) — durability notes on
  `stop_reason/1`, `streaming_error/1` and `stop_details/1` rewritten; they
  previously documented a limitation that no longer exists
- `lib/sagents/agent_server.ex` (@moduledoc) — the event list now states that
  framework-originated rows broadcast `{:display_message_saved, _}` only
- `priv/templates/sagents.gen.persistence/display_message.ex.eex` (moduledoc) —
  documents `"error_type"`, what Sagents writes into `"notification"` and
  `"error"` rows, and that they take the synthetic path
- `test/sagents/agent_test.exs`, `test/sagents/agent_server_stream_error_test.exs`,
  `test/sagents/agent_server_framework_rows_test.exs`,
  `test/sagents/persistence/state_serializer_test.exs` — new coverage (below)
- `test/sagents/message/display_helpers_test.exs` — the round-trip case asserted
  a limitation that is now fixed; rewritten to pin what tells `:cancelled` and a
  dead stream apart
- `test/support/test_display_message_persistence.ex` — adds
  `TestDisplayMessagePersistenceNoSynthetic`, which deliberately does not
  implement the optional callback

No schema or migration work: `"notification"` and `"error"` were already in the
generated `@content_types`, both `validate_content/2` heads are pattern-matched
on `%{"text" => _}` so extra keys pass, and both already had `to_text/1` clauses.
The metadata projection is additive and unversioned — `@current_version` stays
at 2, and a message whose metadata projects to nothing serializes identically to
before.

## Host impact

Two things worth calling out in the changelog:

1. Hosts implementing `save_synthetic_message/3` stop receiving
   `{:llm_message, _}` for the cancel and error rows and receive only
   `{:display_message_saved, _}`. There is no `%Message{}` to carry, and
   fabricating one is the misattribution these rows exist to stop making. Per the
   design review no new PubSub event was added. Exposure is narrow: a host
   exporting the callback already renders synthetic rows from that event for
   `Middleware.TodoList` and `Middleware.AskUserQuestion`.
2. The cancel text drops "Partial response discarded." It overstated even on this
   path — `cancel_execution` gives the chain two seconds to flush the in-progress
   turn through callbacks, so completed turns are persisted and only the in-flight
   delta is lost. Hosts on the fallback path see the wording change.

Hosts that already render `content["stop_reason"]` get the dead-stream partial
marked correctly with no code change.

## Testing

`mix precommit` green: 1832 passed, 1 skipped, credo clean, no vulnerabilities.

Every new behaviour was verified by reverting the change and watching the
relevant tests fail, not just by watching them pass:

- Removing the `:on_message_processed` fire fails both announce cases
- Forcing `persist_framework_row/3` onto the prose path fails the three
  classification cases; forcing it onto the synthetic path fails the two fallback
  cases, which is the "optional callback silently drops rows" regression exactly
- Removing the metadata projection fails four of the six serializer cases

One fixture note worth flagging for review: the `Agent`-level tests drive a
custom `LLMChain.Mode` that appends with `add_message/2` rather than using a
model stub. A stubbed model's messages go through `process_message/2`, which
announces them anyway — so a stub-based test would pass whether or not the fire
existed. Cancellation is likewise driven by a mode that reports the moment it is
in flight and then blocks, so no test sleeps.

Downstream verification: the reference host (`agents_demo`, separate repo)
exercises both classified rows. It needed two renderer changes — an `"error"`
branch, and suppressing the stop-reason annotation on rows that are themselves
the annotation — which are not part of this PR.