### PR TITLE
Clear the TODO list when items are cancelled, not only completed

### DIFF
--- a/lib/sagents/middleware/todo_list.ex
+++ b/lib/sagents/middleware/todo_list.ex
@@ -261,13 +261,13 @@ defmodule Sagents.Middleware.TodoList do
     case parse_todos(todos_data) do
       {:ok, parsed_todos} ->
         # Compute the post-update state, then apply the auto-clear that
-        # collapses a fully-completed list. We hold both: the inline-mode
+        # collapses a fully-resolved list. We hold both: the inline-mode
         # snapshot uses the pre-clear state (so the chat preserves the
-        # final celebratory checked list), while the actual state delta
-        # and sidebar broadcast use the post-clear state (so the agent
-        # and sidebar see the list as resolved).
+        # final checked list), while the actual state delta and sidebar
+        # broadcast use the post-clear state (so the agent and sidebar
+        # see the list as resolved).
         state_after_update = update_todos(context.state, parsed_todos, merge)
-        updated_state = clear_if_all_completed(state_after_update)
+        updated_state = clear_if_all_resolved(state_after_update)
 
         # Broadcast todos immediately for real-time UI updates
         # This is the point where todos are actually committed to state
@@ -396,12 +396,14 @@ defmodule Sagents.Middleware.TodoList do
     %{state | todos: todos_list}
   end
 
-  defp clear_if_all_completed(%State{todos: []} = state), do: state
+  defp clear_if_all_resolved(%State{todos: []} = state), do: state
 
-  defp clear_if_all_completed(%State{todos: todos} = state) do
-    all_completed? = Enum.all?(todos, fn todo -> todo.status == :completed end)
-
-    if all_completed? do
+  defp clear_if_all_resolved(%State{todos: todos} = state) do
+    # Cancelling is a normal outcome, not an abandoned item: a step can turn
+    # out not to apply once an earlier step reports its findings. A list that
+    # ends in a mix of completed and cancelled items is finished, so it clears
+    # the same way an all-completed list does.
+    if Enum.all?(todos, &Todo.resolved?/1) do
       %{state | todos: []}
     else
       state
@@ -420,7 +422,7 @@ defmodule Sagents.Middleware.TodoList do
   defp format_response(todos, merge) do
     case todos do
       [] ->
-        "TODO list cleared - all tasks completed"
+        "TODO list cleared - all tasks resolved"
 
       _other ->
         mode = if merge, do: "merged", else: "replaced"

--- a/lib/sagents/todo.ex
+++ b/lib/sagents/todo.ex
@@ -20,6 +20,13 @@ defmodule Sagents.Todo do
   - `:completed` - Task finished successfully
   - `:cancelled` - Task no longer needed
 
+  The statuses split into two groups. `:pending` and `:in_progress` are *open* —
+  the item still needs work. `:completed` and `:cancelled` are *resolved* — the
+  item has been dealt with, whether by doing it or by establishing that it no
+  longer applies. Use `resolved?/1` and `open?/1` rather than comparing against
+  individual statuses, so a list that ends in a mix of completed and cancelled
+  items is recognized as finished.
+
   ## Usage
 
       # Create a single TODO (id is required)
@@ -37,13 +44,16 @@ defmodule Sagents.Todo do
   import Ecto.Changeset
   alias __MODULE__
 
+  @statuses [:pending, :in_progress, :completed, :cancelled]
+  @resolved_statuses [:completed, :cancelled]
+
   @primary_key false
   embedded_schema do
     field :id, :integer
     field :content, :string
 
     field :status, Ecto.Enum,
-      values: [:pending, :in_progress, :completed, :cancelled],
+      values: @statuses,
       default: :pending
   end
 
@@ -104,6 +114,34 @@ defmodule Sagents.Todo do
       "status" => Atom.to_string(todo.status)
     }
   end
+
+  @doc """
+  Whether the TODO has been dealt with.
+
+  A TODO is resolved when it is `:completed` or `:cancelled`. Cancelling is a
+  legitimate outcome: a step can turn out not to apply once earlier steps
+  report their findings.
+
+  ## Examples
+
+      Todo.resolved?(Todo.new!(%{id: 1, content: "Task", status: :cancelled}))
+      # => true
+  """
+  @spec resolved?(t()) :: boolean()
+  def resolved?(%Todo{status: status}), do: status in @resolved_statuses
+
+  @doc """
+  Whether the TODO still needs work.
+
+  The complement of `resolved?/1` — true for `:pending` and `:in_progress`.
+
+  ## Examples
+
+      Todo.open?(Todo.new!(%{id: 1, content: "Task", status: :in_progress}))
+      # => true
+  """
+  @spec open?(t()) :: boolean()
+  def open?(%Todo{} = todo), do: not resolved?(todo)
 
   @doc """
   Create a single TODO from a map (for deserialization).
@@ -214,7 +252,7 @@ defmodule Sagents.Todo do
     |> validate_required([:id, :content, :status])
     |> validate_number(:id, greater_than: 0)
     |> validate_length(:content, min: 1, max: 1000)
-    |> validate_inclusion(:status, [:pending, :in_progress, :completed, :cancelled])
+    |> validate_inclusion(:status, @statuses)
     |> apply_action(:insert)
   end
 

--- a/test/sagents/middleware/todo_list_test.exs
+++ b/test/sagents/middleware/todo_list_test.exs
@@ -548,7 +548,7 @@ defmodule Sagents.Middleware.TodoListTest do
       {:ok, msg, updated_state} = tool.function.(params, %{state: state})
 
       assert updated_state.todos == []
-      assert msg == "TODO list cleared - all tasks completed"
+      assert msg == "TODO list cleared - all tasks resolved"
     end
 
     test "clears todo list when all todos marked as completed in merge mode" do
@@ -564,7 +564,7 @@ defmodule Sagents.Middleware.TodoListTest do
       {:ok, msg, updated_state} = tool.function.(params, %{state: state})
 
       assert updated_state.todos == []
-      assert msg == "TODO list cleared - all tasks completed"
+      assert msg == "TODO list cleared - all tasks resolved"
     end
 
     test "keeps todo list when not all todos are completed" do
@@ -615,7 +615,78 @@ defmodule Sagents.Middleware.TodoListTest do
       {:ok, msg, updated_state} = tool.function.(params, %{state: state})
 
       assert updated_state.todos == []
-      assert msg == "TODO list cleared - all tasks completed"
+      assert msg == "TODO list cleared - all tasks resolved"
+    end
+
+    test "clears todo list when every todo is cancelled" do
+      state = State.new!()
+      [tool] = TodoList.tools(nil)
+
+      params = %{
+        merge: false,
+        todos: [
+          %{"id" => 1, "content" => "Task 1", "status" => "cancelled"},
+          %{"id" => 2, "content" => "Task 2", "status" => "cancelled"}
+        ]
+      }
+
+      {:ok, msg, updated_state} = tool.function.(params, %{state: state})
+
+      assert updated_state.todos == []
+      assert msg == "TODO list cleared - all tasks resolved"
+    end
+
+    test "clears todo list when todos are a mix of completed and cancelled" do
+      state = State.new!()
+      [tool] = TodoList.tools(nil)
+
+      params = %{
+        merge: false,
+        todos: [
+          %{"id" => 1, "content" => "Task 1", "status" => "completed"},
+          %{"id" => 2, "content" => "Task 2", "status" => "cancelled"},
+          %{"id" => 3, "content" => "Task 3", "status" => "completed"}
+        ]
+      }
+
+      {:ok, msg, updated_state} = tool.function.(params, %{state: state})
+
+      assert updated_state.todos == []
+      assert msg == "TODO list cleared - all tasks resolved"
+    end
+
+    test "clears list when the final open todo is cancelled via merge" do
+      todo1 = Todo.new!(%{id: 1, content: "Task 1", status: :completed})
+      todo2 = Todo.new!(%{id: 2, content: "Task 2", status: :pending})
+      state = State.new!(%{todos: [todo1, todo2]})
+      [tool] = TodoList.tools(nil)
+
+      params = %{
+        merge: true,
+        todos: [%{"id" => 2, "content" => "No longer applies", "status" => "cancelled"}]
+      }
+
+      {:ok, msg, updated_state} = tool.function.(params, %{state: state})
+
+      assert updated_state.todos == []
+      assert msg == "TODO list cleared - all tasks resolved"
+    end
+
+    test "keeps todo list when a cancelled todo sits alongside a pending one" do
+      state = State.new!()
+      [tool] = TodoList.tools(nil)
+
+      params = %{
+        merge: false,
+        todos: [
+          %{"id" => 1, "content" => "Task 1", "status" => "cancelled"},
+          %{"id" => 2, "content" => "Task 2", "status" => "pending"}
+        ]
+      }
+
+      {:ok, _msg, updated_state} = tool.function.(params, %{state: state})
+
+      assert length(updated_state.todos) == 2
     end
   end
 end


### PR DESCRIPTION
## Problem

The TodoList middleware auto-clears the list once the agent has dealt with every item, which keeps a finished plan from lingering in state, in the `{:todos_updated, _}` broadcast, and in whatever sidebar renders it.

That clearing only recognized `:completed`. A single `:cancelled` item made the list permanently un-clearable: it survived every subsequent `write_todos` call and stayed in `state.todos` for the rest of the conversation, getting re-serialized and re-broadcast each turn.

Cancelling is ordinary work, not an abandoned task. A step can legitimately stop applying once an earlier step reports its findings. The middleware's own system prompt already teaches exactly that contract to the model:

> you MUST work through ALL items until they are marked as completed **or cancelled**
>
> If you cannot complete a todo, mark it as cancelled and explain why in the todo content

So the prompt instructed the model into precisely the state the clearing code refused to recognize.

## Solution

The underlying gap was that the concept "this item has been dealt with" had no name, so the check re-derived it inline and got it wrong.

`Sagents.Todo` now owns the partition. `:pending` and `:in_progress` are *open*; `:completed` and `:cancelled` are *resolved*. Two predicates, `Todo.resolved?/1` and `Todo.open?/1`, expose that grouping, backed by `@statuses` and `@resolved_statuses` module attributes that the `Ecto.Enum` field and the changeset's `validate_inclusion` both now read from. Adding a fifth status means classifying it in one place.

`clear_if_all_completed/1` becomes `clear_if_all_resolved/1` and delegates to `Todo.resolved?/1`. The fix lands only on the post-clear branch, so inline mode still snapshots the pre-clear state and the transcript keeps its final checked list rather than rendering an empty card.

The tool's own return value is corrected alongside it. It previously reported "all tasks completed" to the model, which is inaccurate for a list that ended in cancellations; it now reports "all tasks resolved".

## Changes

- `lib/sagents/todo.ex` - Added `resolved?/1` and `open?/1` with specs and docs; introduced `@statuses` / `@resolved_statuses` and pointed the enum field and changeset validation at them; documented the open/resolved split in the `@moduledoc` status section.
- `lib/sagents/middleware/todo_list.ex` - Renamed `clear_if_all_completed/1` to `clear_if_all_resolved/1` and switched it to `Todo.resolved?/1`; changed the cleared-list response text to "TODO list cleared - all tasks resolved"; refreshed the surrounding comments to match.
- `test/sagents/middleware/todo_list_test.exs` - Four new cases in the auto-cleanup block, plus updated message assertions on the three existing clearing tests.

## Testing

`mix precommit` is green: 1836 tests pass, 1 skipped, credo reports no issues, sobelow finds no vulnerabilities.

Each new test was confirmed to fail against the old predicate before the fix, with the mixed-status case reporting `left: [3 todos] right: []`.

New coverage:

- Every todo cancelled, replace mode, clears the list
- A mix of completed and cancelled clears the list
- Cancelling the last open item via merge mode clears the list. This is the realistic path, where findings from an early step invalidate a later one
- A cancelled item beside a pending one does not clear, guarding against the fix over-reaching

The existing negative cases (open items present, `in_progress` present) still hold, and the wider suite covers that the inline-mode snapshot keeps rendering the pre-clear list.