### PR TITLE
Accept a bare status in Todo.resolved?/1 and Todo.open?/1

### DIFF
--- a/lib/sagents/todo.ex
+++ b/lib/sagents/todo.ex
@@ -27,6 +27,10 @@ defmodule Sagents.Todo do
   individual statuses, so a list that ends in a mix of completed and cancelled
   items is recognized as finished.
 
+  Both predicates accept a bare status as well as a `Todo` struct, so code
+  holding serialized todo data can ask about a `"status"` value without
+  rebuilding a struct for the comparison.
+
   ## Usage
 
       # Create a single TODO (id is required)
@@ -46,6 +50,7 @@ defmodule Sagents.Todo do
 
   @statuses [:pending, :in_progress, :completed, :cancelled]
   @resolved_statuses [:completed, :cancelled]
+  @resolved_status_strings Enum.map(@resolved_statuses, &Atom.to_string/1)
 
   @primary_key false
   embedded_schema do
@@ -57,10 +62,12 @@ defmodule Sagents.Todo do
       default: :pending
   end
 
+  @type status :: :pending | :in_progress | :completed | :cancelled
+
   @type t :: %Todo{
           id: integer(),
           content: String.t(),
-          status: :pending | :in_progress | :completed | :cancelled
+          status: status()
         }
 
   @doc """
@@ -122,26 +129,54 @@ defmodule Sagents.Todo do
   legitimate outcome: a step can turn out not to apply once earlier steps
   report their findings.
 
+  Takes a `Todo` struct or a bare status, as an atom or a string. Code holding
+  serialized todo data can ask about a `"status"` value directly instead of
+  rebuilding a struct for the comparison. A status outside the four known
+  values reads as not resolved, matching how `from_map/1` treats an
+  unrecognized status.
+
   ## Examples
 
       Todo.resolved?(Todo.new!(%{id: 1, content: "Task", status: :cancelled}))
       # => true
+
+      Todo.resolved?(:completed)
+      # => true
+
+      Todo.resolved?("cancelled")
+      # => true
+
+      Todo.resolved?("in_progress")
+      # => false
   """
-  @spec resolved?(t()) :: boolean()
-  def resolved?(%Todo{status: status}), do: status in @resolved_statuses
+  @spec resolved?(t() | status() | String.t()) :: boolean()
+  def resolved?(%Todo{status: status}), do: resolved?(status)
+  def resolved?(status) when is_atom(status), do: status in @resolved_statuses
+  def resolved?(status) when is_binary(status), do: status in @resolved_status_strings
 
   @doc """
   Whether the TODO still needs work.
 
-  The complement of `resolved?/1` — true for `:pending` and `:in_progress`.
+  The complement of `resolved?/1`: true for `:pending` and `:in_progress`, and
+  for any status outside the four known values.
+
+  Takes the same arguments as `resolved?/1`: a `Todo` struct, a status atom, or
+  a status string.
 
   ## Examples
 
       Todo.open?(Todo.new!(%{id: 1, content: "Task", status: :in_progress}))
       # => true
+
+      Todo.open?(:pending)
+      # => true
+
+      Todo.open?("completed")
+      # => false
   """
-  @spec open?(t()) :: boolean()
-  def open?(%Todo{} = todo), do: not resolved?(todo)
+  @spec open?(t() | status() | String.t()) :: boolean()
+  def open?(%Todo{status: status}), do: not resolved?(status)
+  def open?(status) when is_atom(status) or is_binary(status), do: not resolved?(status)
 
   @doc """
   Create a single TODO from a map (for deserialization).

--- a/test/sagents/todo_test.exs
+++ b/test/sagents/todo_test.exs
@@ -221,6 +221,89 @@ defmodule Sagents.TodoTest do
     end
   end
 
+  describe "resolved?/1 and open?/1" do
+    test "classifies a Todo struct by its status" do
+      for {status, resolved} <- [
+            pending: false,
+            in_progress: false,
+            completed: true,
+            cancelled: true
+          ] do
+        todo = Todo.new!(%{id: 1, content: "Task", status: status})
+
+        assert Todo.resolved?(todo) == resolved
+        assert Todo.open?(todo) == not resolved
+      end
+    end
+
+    test "classifies a bare status atom" do
+      assert Todo.resolved?(:completed)
+      assert Todo.resolved?(:cancelled)
+      refute Todo.resolved?(:pending)
+      refute Todo.resolved?(:in_progress)
+
+      assert Todo.open?(:pending)
+      assert Todo.open?(:in_progress)
+      refute Todo.open?(:completed)
+      refute Todo.open?(:cancelled)
+    end
+
+    test "classifies a bare status string" do
+      assert Todo.resolved?("completed")
+      assert Todo.resolved?("cancelled")
+      refute Todo.resolved?("pending")
+      refute Todo.resolved?("in_progress")
+
+      assert Todo.open?("pending")
+      assert Todo.open?("in_progress")
+      refute Todo.open?("completed")
+      refute Todo.open?("cancelled")
+    end
+
+    test "treats an unrecognized status as still needing work" do
+      for status <- ["done", "COMPLETED", "", :done, nil] do
+        refute Todo.resolved?(status)
+        assert Todo.open?(status)
+      end
+    end
+
+    test "raises for a value that is not a struct, atom, or string" do
+      # Called through apply/3 so the compiler's type checker doesn't flag the
+      # deliberately invalid arguments before the test gets to run them.
+      for value <- [42, %{"status" => "completed"}] do
+        assert_raise FunctionClauseError, fn -> apply(Todo, :resolved?, [value]) end
+        assert_raise FunctionClauseError, fn -> apply(Todo, :open?, [value]) end
+      end
+    end
+
+    test "a serialized status agrees with the struct it came from" do
+      for status <- [:pending, :in_progress, :completed, :cancelled] do
+        todo = Todo.new!(%{id: 1, content: "Task", status: status})
+        serialized = Todo.to_map(todo)["status"]
+
+        assert Todo.resolved?(serialized) == Todo.resolved?(todo)
+        assert Todo.open?(serialized) == Todo.open?(todo)
+      end
+    end
+
+    test "open? is the exact complement of resolved? across every accepted input" do
+      structs =
+        Enum.map([:pending, :in_progress, :completed, :cancelled], fn status ->
+          Todo.new!(%{id: 1, content: "Task", status: status})
+        end)
+
+      inputs =
+        structs ++
+          [:pending, :in_progress, :completed, :cancelled] ++
+          ["pending", "in_progress", "completed", "cancelled"] ++
+          ["done", :done, nil]
+
+      for input <- inputs do
+        assert Todo.open?(input) == not Todo.resolved?(input)
+      end
+    end
+  end
+
   defp errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, _opts} -> message end)
   end


### PR DESCRIPTION
## Problem

`Sagents.Todo.resolved?/1` and `open?/1` only match a `%Todo{}` struct, so the
resolved/open grouping held in `@resolved_statuses` is reachable only through a
struct.

Consuming code often holds todos as restored serialized maps
(`%{"id" => 1, "content" => "...", "status" => "completed"}`). To answer "is
this one done?" while keeping the grouping in one place, it has to rebuild a
full struct through `from_map/1` purely to make the comparison. That runs id
coercion, casting, and the whole changeset validation pipeline to read a single
field, and it fails outright on a map whose id is missing or in the legacy
base64 form. The alternative is duplicating `[:completed, :cancelled]`
downstream, which is exactly what these predicates exist to prevent.

## Solution

Both predicates now take a `Todo` struct, a status atom, or a status string.

`@resolved_status_strings` is derived from `@resolved_statuses` with
`Enum.map/2` at compile time, so the string form stays generated from the one
list and costs nothing at runtime. It also means an incoming string is matched
by membership rather than converted, avoiding `String.to_atom/1` on external
input.

The struct clause delegates to the status clause rather than repeating the
membership test, so `@resolved_statuses` is consulted in exactly one place per
input type. The `%Todo{}` head is ordered first, since a struct is a map and
would otherwise fall past the atom/binary guards.

A status outside the four known values reads as not resolved and therefore
open. That matches `from_map/1`, which already defaults an unrecognized status
to `:pending`, and it fails in the safe direction: a list is never wrongly
reported as finished, which is what `clear_if_all_resolved/1` in the TodoList
middleware depends on. Anything that is not a struct, atom, or string raises
`FunctionClauseError`, and in practice the compiler's type checker now catches
that at the call site.

Downstream, the workaround collapses to `Todo.resolved?(map["status"])`, which
also works on maps that `from_map/1` would reject.

This is purely additive to the function head set. No existing caller changes.

## Changes

- [`lib/sagents/todo.ex`](https://github.com/sagents-ai/sagents/blob/me-todo-status-check-functions/lib/sagents/todo.ex) - `resolved?/1` and `open?/1` accept a status atom or string alongside a `%Todo{}`; added the compile-time `@resolved_status_strings` derived from `@resolved_statuses`
- [`lib/sagents/todo.ex`](https://github.com/sagents-ai/sagents/blob/me-todo-status-check-functions/lib/sagents/todo.ex) - extracted `@type status` and reused it in `@type t`, so the widened specs name the same thing the schema does
- [`lib/sagents/todo.ex`](https://github.com/sagents-ai/sagents/blob/me-todo-status-check-functions/lib/sagents/todo.ex) (`@moduledoc` and both `@doc`s) - document the accepted inputs, the serialized-data use case, and the unknown-status behavior, with examples for the atom and string forms
- [`test/sagents/todo_test.exs`](https://github.com/sagents-ai/sagents/blob/me-todo-status-check-functions/test/sagents/todo_test.exs) - new `describe "resolved?/1 and open?/1"` block, 7 tests

## Testing

Neither predicate had any test coverage before this branch, so the new block
pins the existing struct behavior as well as the new arities:

- every status in all three input forms (struct, atom, string)
- the serialized round trip the change exists for: `to_map/1` output fed
  straight into `resolved?/1` agrees with the struct it came from, for all four
  statuses
- unrecognized statuses (`"done"`, `"COMPLETED"`, `""`, `:done`, `nil`) read as
  open, not resolved
- non-status terms raise `FunctionClauseError`
- `open?/1` is an exact complement of `resolved?/1` across every accepted input

The invalid-input test calls through `apply/3`. Written with literal arguments,
the type checker flags them at compile time now that the guards give it a
domain, and `mix precommit` runs with warnings as errors.

`mix precommit` passes: 1882 tests pass, 1 skipped, credo clean, no compile or
format warnings. `test/sagents/middleware/todo_list_test.exs` passes unchanged,
covering the existing `&Todo.resolved?/1` capture in `clear_if_all_resolved/1`.